### PR TITLE
feat: add command aliases

### DIFF
--- a/src/commands/build/mod.rs
+++ b/src/commands/build/mod.rs
@@ -14,5 +14,6 @@ pub(crate) enum BuildCommands {
     /// Compiles the contract, generates metadata, bundles both together in a
     /// `<name>.contract` file
     #[cfg(feature = "contract")]
+    #[clap(alias = "c")]
     Contract(contract::BuildContractCommand),
 }

--- a/src/commands/new/mod.rs
+++ b/src/commands/new/mod.rs
@@ -1,11 +1,11 @@
 use clap::{Args, Subcommand};
 
+#[cfg(feature = "contract")]
+pub mod contract;
 #[cfg(feature = "parachain")]
 pub mod pallet;
 #[cfg(feature = "parachain")]
 pub mod parachain;
-#[cfg(feature = "contract")]
-pub mod contract;
 
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
@@ -18,11 +18,14 @@ pub struct NewArgs {
 pub enum NewCommands {
     /// Generate a new parachain template
     #[cfg(feature = "parachain")]
+    #[clap(alias = "p")]
     Parachain(parachain::NewParachainCommand),
     /// Generate a new pallet template
     #[cfg(feature = "parachain")]
+    #[clap(alias = "m")] // (m)odule, as p used above
     Pallet(pallet::NewPalletCommand),
     /// Generate a new smart contract template
     #[cfg(feature = "contract")]
+    #[clap(alias = "c")]
     Contract(contract::NewContractCommand),
 }

--- a/src/commands/test/mod.rs
+++ b/src/commands/test/mod.rs
@@ -13,5 +13,6 @@ pub(crate) struct TestArgs {
 pub(crate) enum TestCommands {
     /// Test the contract
     #[cfg(feature = "contract")]
+    #[clap(alias = "c")]
     Contract(contract::TestContractCommand),
 }

--- a/src/commands/up/mod.rs
+++ b/src/commands/up/mod.rs
@@ -14,5 +14,6 @@ pub(crate) struct UpArgs {
 pub(crate) enum UpCommands {
     #[cfg(feature = "parachain")]
     /// Deploy a parachain to a network.
+    #[clap(alias = "p")]
     Parachain(parachain::ZombienetCommand),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ mod helpers;
 #[cfg(feature = "parachain")]
 mod parachains;
 
-
 use anyhow::{anyhow, Result};
 use clap::{Parser, Subcommand};
 use std::{fs::create_dir_all, path::PathBuf};
@@ -28,12 +27,16 @@ pub struct Cli {
 #[command(subcommand_required = true)]
 enum Commands {
     /// Build a parachain, a pallet or smart contract.
+    #[clap(alias = "n")]
     New(commands::new::NewArgs),
     /// Compile a parachain or smart contract.
+    #[clap(alias = "b")]
     Build(commands::build::BuildArgs),
     /// Deploy a parachain or smart contract.
+    #[clap(alias = "u")]
     Up(commands::up::UpArgs),
     /// Test a smart contract.
+    #[clap(alias = "t")]
     Test(commands::test::TestArgs),
 }
 


### PR DESCRIPTION
Adds aliases to (optionally) shorten commands.

For example:
`pop up parachain -f ./tests/zombienet.toml -p https://github.com/r0gue-io/pop-node` 
can now be:
`pop u p -f ./tests/zombienet.toml -p https://github.com/r0gue-io/pop-node`
