### PR TITLE
feat: pop build contract: add build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/target/
 **/node_modules/
 /src/x.rs
+
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5254,6 +5254,7 @@ dependencies = [
 name = "pop-cli"
 version = "0.1.0"
 dependencies = [
+ "ansi_term",
  "anyhow",
  "askama",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ subxt-signer = { version = "0.34.0", features = ["subxt", "sr25519"], optional =
 subxt = { version = "0.34.0", optional = true  }
 ink_env = { version = "5.0.0-rc.2", optional = true  }
 sp-weights = { version ="27.0.0", optional = true  }
+ansi_term = "0.12.1"
 
 # parachains
 dirs = { version = "5.0", optional = true }

--- a/src/commands/build/contract.rs
+++ b/src/commands/build/contract.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::Args;
-use cliclack::{clear_screen, intro, log, outro, set_theme};
+use cliclack::{clear_screen, intro, outro, set_theme};
 use console::style;
 
 use crate::{engines::contract_engine::build_smart_contract, style::Theme};
@@ -19,8 +19,7 @@ impl BuildContractCommand {
 		set_theme(Theme);
 
 		build_smart_contract(&self.path)?;
-		log::info("The smart contract has been successfully built.")?;
-		outro("Build Completed Successfully!")?;
+		outro("Build completed successfully!")?;
 		Ok(())
 	}
 }

--- a/src/engines/contract_engine.rs
+++ b/src/engines/contract_engine.rs
@@ -1,5 +1,6 @@
 use duct::cmd;
 use std::path::PathBuf;
+use cliclack::log;
 
 use contract_build::{
 	execute, new_contract_project, BuildArtifacts, BuildMode, ExecuteArgs, Features, ManifestPath,
@@ -45,7 +46,13 @@ pub fn build_smart_contract(path: &Option<PathBuf>) -> anyhow::Result<()> {
 		max_memory_pages: DEFAULT_MAX_MEMORY_PAGES,
 		image: Default::default(),
 	};
-	execute(args)?;
+
+	// Execute the build and log the output of the build
+	let result = execute(args)?;
+	let formatted_result = result.display();
+	let colored_output = ansi_term::Color::Green.paint(formatted_result).to_string();	
+    log::info(colored_output.to_string())?;
+
 	Ok(())
 }
 

--- a/src/engines/contract_engine.rs
+++ b/src/engines/contract_engine.rs
@@ -50,8 +50,7 @@ pub fn build_smart_contract(path: &Option<PathBuf>) -> anyhow::Result<()> {
 	// Execute the build and log the output of the build
 	let result = execute(args)?;
 	let formatted_result = result.display();
-	let colored_output = ansi_term::Color::Green.paint(formatted_result).to_string();	
-    log::info(colored_output.to_string())?;
+    log::success(formatted_result.to_string())?;
 
 	Ok(())
 }


### PR DESCRIPTION
Closes: https://github.com/r0gue-io/pop-cli/issues/21

With this PR output will be as follows:
```
┌   Pop CLI : Building a contract
│
 [==] Checking clippy linting rules
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
 [==] Building cargo project
    Finished release [optimized] target(s) in 0.08s
◆  
│  The contract was built in RELEASE mode.
│  
│  Your contract artifacts are ready. You can find them in:
│  /Users/bruno/src/pop-cli/my_contract/target/ink
│  
│    - my_contract.contract (code + metadata)
│    - my_contract.wasm (the contract's code)
│    - my_contract.json (the contract's metadata)
│  
└  Build completed successfully!
```