### PR TITLE
fix(up-parachain): improve command handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+**/target/
+**/*.txt
+**/*.md
+/docker/
+
+# dotfiles in the repo root
+/.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10171,7 +10171,7 @@ dependencies = [
 [[package]]
 name = "zombienet-configuration"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/paritytech/zombienet-sdk#81f5aabaddd1b5dd93c5dd2ae79adab4c7df8a63"
+source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#183f49156dc9d0f55fb2ea8632e87b522c69bcd5"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -10187,7 +10187,7 @@ dependencies = [
 [[package]]
 name = "zombienet-orchestrator"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/paritytech/zombienet-sdk#81f5aabaddd1b5dd93c5dd2ae79adab4c7df8a63"
+source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#183f49156dc9d0f55fb2ea8632e87b522c69bcd5"
 dependencies = [
  "anyhow",
  "futures",
@@ -10215,7 +10215,7 @@ dependencies = [
 [[package]]
 name = "zombienet-prom-metrics-parser"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/paritytech/zombienet-sdk#81f5aabaddd1b5dd93c5dd2ae79adab4c7df8a63"
+source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#183f49156dc9d0f55fb2ea8632e87b522c69bcd5"
 dependencies = [
  "pest",
  "pest_derive",
@@ -10225,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "zombienet-provider"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/paritytech/zombienet-sdk#81f5aabaddd1b5dd93c5dd2ae79adab4c7df8a63"
+source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#183f49156dc9d0f55fb2ea8632e87b522c69bcd5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10255,7 +10255,7 @@ dependencies = [
 [[package]]
 name = "zombienet-sdk"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/paritytech/zombienet-sdk#81f5aabaddd1b5dd93c5dd2ae79adab4c7df8a63"
+source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#183f49156dc9d0f55fb2ea8632e87b522c69bcd5"
 dependencies = [
  "async-trait",
  "futures",
@@ -10271,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "zombienet-support"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/paritytech/zombienet-sdk#81f5aabaddd1b5dd93c5dd2ae79adab4c7df8a63"
+source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#183f49156dc9d0f55fb2ea8632e87b522c69bcd5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,8 @@ symlink = { version = "0.1", optional = true }
 toml_edit = { version = "0.22", optional = true }
 tracing-subscriber = { version = "0.3", optional = true }
 url = { version = "2.5", optional = true }
-zombienet-sdk = { git = "https://github.com/paritytech/zombienet-sdk", optional = true }
-zombienet-support = { git = "https://github.com/paritytech/zombienet-sdk", optional = true }
-
+zombienet-sdk = { git = "https://github.com/r0gue-io/zombienet-sdk", branch = "pop", optional = true }
+zombienet-support = { git = "https://github.com/r0gue-io/zombienet-sdk", branch = "pop", optional = true }
 
 [features]
 default = ["contract", "parachain"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM rust as builder
+RUN apt-get update && apt-get -y install cmake
+WORKDIR /pop
+COPY . /pop
+RUN cargo build --release
+
+# Build image
+FROM rust:slim
+RUN apt-get update && apt install -y openssl ca-certificates protobuf-compiler
+COPY --from=builder /pop/target/release/pop /usr/bin/pop
+CMD ["/usr/bin/pop"]

--- a/src/commands/up/parachain.rs
+++ b/src/commands/up/parachain.rs
@@ -50,12 +50,13 @@ impl ZombienetCommand {
 			}
 			log::info(format!("They will be cached at {}", &cache.to_str().unwrap()))?;
 			// Source binaries
+			let mut spinner = cliclack::spinner();
 			for binary in missing {
-				let mut spinner = cliclack::spinner();
 				spinner.start(format!("Sourcing {}...", binary.name));
 				binary.source(&cache).await?;
-				spinner.stop(format!("Sourcing {} complete.", binary.name));
+				spinner.start(format!("Sourcing {} complete.", binary.name));
 			}
+			spinner.stop("Sourcing complete.");
 		}
 		// Finally spawn network and wait for signal to terminate
 		let mut spinner = cliclack::spinner();

--- a/src/parachains/zombienet.rs
+++ b/src/parachains/zombienet.rs
@@ -297,7 +297,7 @@ impl Zombienet {
 					sources.push(Source::Url {
 						name: b.to_string(),
 						version: version.clone(),
-						url: GitHub::release(&repo, &version, b),
+						url: GitHub::release(&repo, &format!("polkadot-{version}"), b),
 					})
 				}
 			};
@@ -325,7 +325,7 @@ impl Zombienet {
 				sources.push(Source::Url {
 					name: BINARY.into(),
 					version: version.into(),
-					url: GitHub::release(&repo, version, BINARY),
+					url: GitHub::release(&repo, &format!("polkadot-{version}"), BINARY),
 				})
 			};
 		}

--- a/src/parachains/zombienet.rs
+++ b/src/parachains/zombienet.rs
@@ -14,8 +14,8 @@ use std::{
 	path::{Path, PathBuf},
 };
 use symlink::{remove_symlink_file, symlink_file};
-use tempfile::Builder;
-use toml_edit::{value, Document, Value};
+use tempfile::{Builder, NamedTempFile};
+use toml_edit::{value, Document, Formatted, Item, Table, Value};
 use url::Url;
 use zombienet_sdk::{Network, NetworkConfig, NetworkConfigExt};
 use zombienet_support::fs::local::LocalFileSystem;
@@ -55,13 +55,35 @@ impl Zombienet {
 					.ok_or(anyhow!("expected `parachain` to have `id`"))? as u32;
 				let default_command = table
 					.get("default_command")
-					.ok_or(anyhow!("expected `parachain` to have `default_command`"))?;
+					.cloned()
+					.or_else(|| {
+						// Check if any collators define command
+						if let Some(collators) =
+							table.get("collators").and_then(|p| p.as_array_of_tables())
+						{
+							for collator in collators.iter() {
+								if let Some(command) =
+									collator.get("command").and_then(|i| i.as_str())
+								{
+									return Some(Item::Value(Value::String(Formatted::new(
+										command.into(),
+									))));
+								}
+							}
+						}
+
+						// Otherwise default to polkadot-parachain
+						Some(Item::Value(Value::String(Formatted::new(
+							"polkadot-parachain".into(),
+						))))
+					})
+					.expect("missing default_command set above");
 				let Some(Value::String(command)) = default_command.as_value() else {
 					continue;
 				};
 
 				let command = command.value().to_lowercase();
-				if command.contains("polkadot-parachain") {
+				if command == "polkadot-parachain" {
 					parachain_binaries.insert(
 						id,
 						Self::system_parachain(
@@ -73,7 +95,7 @@ impl Zombienet {
 					for parachain in parachains {
 						let url = Url::parse(parachain)?;
 						let name = GitHub::name(&url)?;
-						if command.contains(name) {
+						if command == name {
 							parachain_binaries.insert(id, Self::parachain(url, &cache)?);
 						}
 					}
@@ -101,19 +123,53 @@ impl Zombienet {
 	}
 
 	pub async fn spawn(&mut self) -> Result<Network<LocalFileSystem>> {
+		// Symlink polkadot-related binaries
+		for file in ["polkadot-execute-worker", "polkadot-prepare-worker"] {
+			let dest = self.cache.join(file);
+			if dest.exists() {
+				remove_symlink_file(&dest)?;
+			}
+			symlink_file(self.cache.join(format!("{file}-{}", self.relay_chain.version)), dest)?;
+		}
+
+		// Load from config and spawn network
+		let config = self.configure()?;
+		let path = config.path().to_str().expect("temp config file should have a path").into();
+		info!("spawning network...");
+		let network_config = NetworkConfig::load_from_toml(path)?;
+		Ok(network_config.spawn_native().await?)
+	}
+
+	// Adapts provided config file to one that is compatible with current zombienet-sdk requirements
+	fn configure(&mut self) -> Result<NamedTempFile> {
+		let (network_config_path, network_config) = &mut self.network_config;
+
+		// Add zombienet-sdk specific settings if missing
+		let Item::Table(settings) =
+			network_config.entry("settings").or_insert(Item::Table(Table::new()))
+		else {
+			return Err(anyhow!("expected `settings` to be table"));
+		};
+		settings
+			.entry("timeout")
+			.or_insert(Item::Value(Value::Integer(Formatted::new(1_000))));
+		settings
+			.entry("node_spawn_timeout")
+			.or_insert(Item::Value(Value::Integer(Formatted::new(300))));
+
 		// Update relay chain config
 		let relay_path = self
 			.relay_chain
 			.path
 			.to_str()
 			.ok_or(anyhow!("the relay chain path is invalid"))?;
-		let (network_config_path, network_config) = &mut self.network_config;
-		let relay_chain_config =
-			network_config.get_mut("relaychain").ok_or(anyhow!("expected `relaychain`"))?;
-		match relay_chain_config.get_mut("default_command") {
-			None => relay_chain_config["default_command"] = value(relay_path),
-			Some(command) => *command = value(relay_path),
-		}
+		let Item::Table(relay_chain) =
+			network_config.entry("relaychain").or_insert(Item::Table(Table::new()))
+		else {
+			return Err(anyhow!("expected `relaychain` to be table"));
+		};
+		*relay_chain.entry("default_command").or_insert(value(relay_path)) = value(relay_path);
+
 		// Update parachain config
 		if let Some(tables) =
 			network_config.get_mut("parachains").and_then(|p| p.as_array_of_tables_mut())
@@ -123,51 +179,54 @@ impl Zombienet {
 					.get("id")
 					.and_then(|i| i.as_integer())
 					.ok_or(anyhow!("expected `parachain` to have `id`"))? as u32;
-				if let Some(para) = self.parachains.get(&id) {
-					let para_path =
-						para.path.to_str().ok_or(anyhow!("the parachain path is invalid"))?;
-					match table.get_mut("default_command") {
-						None => table["default_command"] = value(para_path),
-						Some(command) => *command = value(para_path),
+
+				// Resolve default_command to binary
+				{
+					// Check if provided via args, therefore cached
+					if let Some(para) = self.parachains.get(&id) {
+						let para_path =
+							para.path.to_str().ok_or(anyhow!("the parachain path is invalid"))?;
+						table.insert("default_command", value(para_path));
+					} else if let Some(default_command) = table.get_mut("default_command") {
+						// Otherwise assume local binary, fix path accordingly
+						let command_path = default_command
+							.as_str()
+							.ok_or(anyhow!("expected `default_command` value to be a string"))?;
+						let path = Self::resolve_path(network_config_path, command_path)?;
+						*default_command = value(path.to_str().ok_or(anyhow!(
+							"the parachain binary was not found: {0}",
+							command_path
+						))?);
 					}
-				} else {
-					// Assume local binary, fix path accordingly
-					match table.get_mut("default_command") {
-						None => {
-							return Err(anyhow!("expected `default_command` value to be a string"));
-						},
-						Some(command) => {
-							let command_path = command.as_str().ok_or(anyhow!(
-								"expected `default_command` value to be a string"
-							))?;
-							let path = {
-								network_config_path
-									.join(command_path)
-									.canonicalize()
-									.or_else(|_| {
-										current_dir().unwrap().join(command_path).canonicalize()
-									})
-									.map_err(|_| {
-										anyhow!("unable to find canonical local path to specified command: {}", command_path)
-									})?
-							};
-							*command = value(path.to_str().ok_or(anyhow!(
-								"the parachain binary was not found: {0}",
-								command_path
-							))?)
-						},
+				}
+
+				// Resolve individual collator command to binary
+				if let Some(collators) =
+					table.get_mut("collators").and_then(|p| p.as_array_of_tables_mut())
+				{
+					for collator in collators.iter_mut() {
+						if let Some(command) = collator.get_mut("command") {
+							// Check if provided via args, therefore cached
+							if let Some(para) = self.parachains.get(&id) {
+								let para_path = para
+									.path
+									.to_str()
+									.ok_or(anyhow!("the parachain path is invalid"))?;
+								*command = value(para_path);
+							} else {
+								let command_path = command
+									.as_str()
+									.ok_or(anyhow!("expected `command` value to be a string"))?;
+								let path = Self::resolve_path(network_config_path, command_path)?;
+								*command = value(path.to_str().ok_or(anyhow!(
+									"the parachain binary was not found: {0}",
+									command_path
+								))?);
+							}
+						}
 					}
 				}
 			}
-		}
-
-		// Symlink polkadot-related binaries
-		for file in ["polkadot-execute-worker", "polkadot-prepare-worker"] {
-			let dest = self.cache.join(file);
-			if dest.exists() {
-				remove_symlink_file(&dest)?;
-			}
-			symlink_file(self.cache.join(format!("{file}-{}", self.relay_chain.version)), dest)?;
 		}
 
 		// Write adapted zombienet config to temp file
@@ -178,14 +237,22 @@ impl Zombienet {
 		let path = network_config_file
 			.path()
 			.to_str()
-			.expect("temp config file should have a path")
-			.into();
+			.expect("temp config file should have a path");
 		write(path, network_config.to_string())?;
+		Ok(network_config_file)
+	}
 
-		// Load from config and spawn network
-		info!("spawning network...");
-		let network_config = NetworkConfig::load_from_toml(path)?;
-		Ok(network_config.spawn_native().await?)
+	fn resolve_path(network_config_path: &mut PathBuf, command_path: &str) -> Result<PathBuf> {
+		network_config_path
+			.join(command_path)
+			.canonicalize()
+			.or_else(|_| current_dir().unwrap().join(command_path).canonicalize())
+			.map_err(|_| {
+				anyhow!(
+					"unable to find canonical local path to specified command: `{}` are you missing an argument?",
+					command_path
+				)
+			})
 	}
 
 	async fn relay_chain(

--- a/tests/zombienet.toml
+++ b/tests/zombienet.toml
@@ -17,7 +17,7 @@ chain = "asset-hub-rococo-local"
 name = "asset-hub"
 
 [[parachains]]
-id = 909
+id = 9090
 default_command = "pop-node"
 
 [[parachains.collators]]

--- a/tests/zombienet.toml
+++ b/tests/zombienet.toml
@@ -1,10 +1,5 @@
-[settings]
-timeout = 1000
-node_spawn_timeout = 300
-
 [relaychain]
 chain = "rococo-local"
-default_command = "./polkadot"
 
 [[relaychain.nodes]]
 name = "alice"
@@ -17,14 +12,13 @@ validator = true
 [[parachains]]
 id = 1000
 chain = "asset-hub-rococo-local"
-default_command = "./polkadot-parachain"
 
 [[parachains.collators]]
 name = "asset-hub"
 
 [[parachains]]
 id = 909
-default_command = "./pop-node"
+default_command = "pop-node"
 
 [[parachains.collators]]
 name = "pop"


### PR DESCRIPTION
Improves command handling and legacy zombienet flle support by:
- automatically adding zombinetnet-sdk `settings` to temp config when not specified
- defaulting to `polkadot` for relay, `polkadot-parachain` for parachain when not specified
- resolves `default_command` and `command` to local binaries when relative paths specified
- simplifies test `zombienet.toml` file

Closes #25 