### PR TITLE
feat(new-parachain): add network config

### DIFF
--- a/src/engines/generator.rs
+++ b/src/engines/generator.rs
@@ -36,6 +36,12 @@ pub(crate) struct PalletTests {
 	pub(crate) module: String,
 }
 
+#[derive(Template)]
+#[template(path = "base/network.templ", escape = "none")]
+pub(crate) struct Network {
+	pub(crate) node: String,
+}
+
 // todo : generate directory structure
 // todo : This is only for development
 #[allow(unused)]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -28,7 +28,7 @@ pub(crate) fn sanitize(target: &Path) -> Result<()> {
 pub(crate) fn write_to_file<'a>(path: &Path, contents: &'a str) {
 	log::info(format!("Writing to {}", path.display())).ok();
 	use std::io::Write;
-	let mut file = OpenOptions::new().write(true).truncate(true).open(path).unwrap();
+	let mut file = OpenOptions::new().write(true).truncate(true).create(true).open(path).unwrap();
 	file.write_all(contents.as_bytes()).unwrap();
 	if path.extension().map_or(false, |ext| ext == "rs") {
 		let output = std::process::Command::new("rustfmt")

--- a/templates/base/network.templ
+++ b/templates/base/network.templ
@@ -1,0 +1,13 @@
+[relaychain]
+chain = "rococo-local"
+
+[[relaychain.nodes]]
+name = "alice"
+validator = true
+
+[[parachains]]
+id = 1000
+default_command = "./target/release/^^node^^"
+
+[[parachains.collators]]
+name = "collator-01"


### PR DESCRIPTION
Adds simple network config file, so that parachain can easily be launched with the following after build:

```shell
pop up parachain -f ./network.toml
```

closes #39 