### PR TITLE
feat(new-parachain): increase validators

### DIFF
--- a/templates/base/network.templ
+++ b/templates/base/network.templ
@@ -5,6 +5,10 @@ chain = "rococo-local"
 name = "alice"
 validator = true
 
+[[relaychain.nodes]]
+name = "bob"
+validator = true
+
 [[parachains]]
 id = 1000
 default_command = "./target/release/^^node^^"


### PR DESCRIPTION
Tried to keep config light to be mindful of user's resources, but actually running a local network results in `[Relaychain] failed to calculate erasure root para_id=1000 err=Erasure(NotEnoughValidators)`.

Adding another validator resolves.