### PR TITLE
Al3mart/fix create on add

### DIFF
--- a/src/commands/add/mod.rs
+++ b/src/commands/add/mod.rs
@@ -1,9 +1,10 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use crate::engines::pallet_engine;
+use crate::{engines::pallet_engine, helpers::workspace_dir};
 use clap::{Args, Subcommand};
 use cliclack::{intro, outro};
 use console::style;
+use std::fs::create_dir_all;
 
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
@@ -72,6 +73,17 @@ impl AddPallet {
 				// format!("FRAME pallet-{name}")
 			},
 		};
+
+		// Check if pallet folder exists, create it otherwise
+		match workspace_dir() {
+			None => create_dir_all(Path::new("pallets").join(pallet.clone()))
+				.expect("Err: Couldn't create pallet folder."),
+			Some(dir) => {
+				create_dir_all(dir.join("pallets").join(pallet.clone()).as_path())
+					.expect("Err: Couldn't create pallet folder.");
+			},
+		}
+
 		intro(format!(
 			"{}: Adding pallet \"{}\"!",
 			style(" Pop CLI ").black().on_magenta(),

--- a/src/commands/add/mod.rs
+++ b/src/commands/add/mod.rs
@@ -75,9 +75,18 @@ impl AddPallet {
 		};
 
 		// Check if pallet folder exists, create it otherwise
-		match workspace_dir() {
-			None => create_dir_all(Path::new("pallets").join(pallet.clone()))
-				.expect("Err: Couldn't create pallet folder."),
+		match workspace_dir(None) {
+			None => match workspace_dir(Some(runtime_path.parent().unwrap().to_path_buf())) {
+				Some(dir) => {
+					// Init pallet in runtime's workspace directory.
+					create_dir_all(dir.join("pallets").join(pallet.clone()).as_path())
+						.expect("Err: Couldn't create pallet folder.");
+				},
+				None => {
+					create_dir_all(Path::new("pallets").join(pallet.clone()))
+						.expect("Err: Couldn't create pallet folder.");
+				},
+			},
 			Some(dir) => {
 				create_dir_all(dir.join("pallets").join(pallet.clone()).as_path())
 					.expect("Err: Couldn't create pallet folder.");

--- a/src/engines/pallet_engine/parser.rs
+++ b/src/engines/pallet_engine/parser.rs
@@ -300,9 +300,9 @@ impl ToTokens for PalletDeclaration {
 			let idx = format!(" = {},", idx);
 			// This means no help from rustfmt
 			tokens.extend(TokenStream::from_str(&idx));
-			// If we want rustfmt we would have to handroll our own solution or forgo indices
-			// (which is bad and probably not what the developer wants which is to delete code)
-			// tokens.extend(quote!(,));
+		// If we want rustfmt we would have to handroll our own solution or forgo indices
+		// (which is bad and probably not what the developer wants which is to delete code)
+		// tokens.extend(quote!(,));
 		} else {
 			tokens.append(Punct::new(',', Spacing::Alone));
 		}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -59,7 +59,7 @@ pub(crate) fn resolve_pallet_path(path: Option<String>) -> PathBuf {
 	}
 	// Check if inside a project
 	let cwd = current_dir().expect("current dir is inaccessible");
-	match workspace_dir() {
+	match workspace_dir(None) {
 		// No workspace available, return cwd.
 		None => cwd,
 		Some(dir) => {
@@ -73,17 +73,32 @@ pub(crate) fn resolve_pallet_path(path: Option<String>) -> PathBuf {
 }
 
 // Locate the workspace directory if any
-pub(crate) fn workspace_dir() -> Option<PathBuf> {
+pub(crate) fn workspace_dir(path: Option<PathBuf>) -> Option<PathBuf> {
 	use std::process;
 
 	let mut locate_project = process::Command::new(env!("CARGO"));
-	let output = locate_project
-		.arg("locate-project")
-		.arg("--workspace")
-		.arg("--message-format=plain")
-		.output()
-		.unwrap()
-		.stdout;
+	let output = match path {
+		Some(dir) => {
+			// Execute command at the given path
+			locate_project
+				.current_dir(dir)
+				.arg("locate-project")
+				.arg("--workspace")
+				.arg("--message-format=plain")
+				.output()
+				.unwrap()
+				.stdout
+		},
+		None => {
+			locate_project
+				.arg("locate-project")
+				.arg("--workspace")
+				.arg("--message-format=plain")
+				.output()
+				.unwrap()
+				.stdout
+		},
+	};
 
 	let maybe_workspace_path = Path::new(std::str::from_utf8(&output).unwrap().trim());
 


### PR DESCRIPTION
This PR adds the following fix:

When using `pop add pallet template -r <runtime/path>` the structure `pallets/<name-of-pallet>` will be created within the workspace of the runtime, if the runtime is specified, if it doesn't exist. Meaning it will also create the right folders even if the runtime is run from other directory not part of the targeted workspace.

Before this change the command will add the pallet and inject in the runtime a local dependency that didn't exist in the project tree.

Unfortunately, the current state of `pop add pallet` introduces some breaking modifications on the Cargo files of the projects, so this can only be run once successfully.  Afterwards `cargo locate-project --workspace` will return errors that are not handled right now, leading to pallet folders being created in the directory from where the command was run.