### PR TITLE
feat: init git repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  GITHUB_ACTOR: pop-cli
 
 jobs:
   build:
@@ -27,6 +28,11 @@ jobs:
       with:
         cache-on-failure: true
         cache-all-crates: true
+    
+    - name: Setup git config
+      run: |
+        git config --global user.name "${GITHUB_ACTOR}"
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
     - uses: actions/checkout@v3
     - name: Check Feature Contracts Excl.

--- a/src/commands/new/parachain.rs
+++ b/src/commands/new/parachain.rs
@@ -1,5 +1,7 @@
 use crate::{
-	engines::parachain_engine::{instantiate_template_dir, Config}, helpers::git_init, style::{style, Theme}
+	engines::parachain_engine::{instantiate_template_dir, Config},
+	helpers::git_init,
+	style::{style, Theme},
 };
 use clap::{Args, Parser};
 use std::{fs, path::Path};
@@ -76,7 +78,11 @@ impl NewParachainCommand {
 				initial_endowment: self.initial_endowment.clone().expect("default values"),
 			},
 		)?;
-        git_init(destination_path, "initialized parachain")?;
+		if let Err(err) = git_init(destination_path, "initialized parachain") {
+			if err.class() == git2::ErrorClass::Config && err.code() == git2::ErrorCode::NotFound {
+				outro_cancel("git signature could not be found. Please configure your git config with your name and email")?;
+			}
+		}
 		spinner.stop("Generation complete");
 		outro(format!("cd into \"{}\" and enjoy hacking! 🚀", &self.name))?;
 		Ok(())

--- a/src/commands/new/parachain.rs
+++ b/src/commands/new/parachain.rs
@@ -86,6 +86,8 @@ impl NewParachainCommand {
 #[cfg(test)]
 mod tests {
 
+	use git2::Repository;
+
 	use super::*;
 	use std::fs;
 
@@ -99,14 +101,12 @@ mod tests {
 			initial_endowment: Some("1u64 << 60".to_string()),
 		};
 		let result = command.execute();
-
-		// Check if the Git repository was initialized
-		let destination_path = Path::new(&command.name);
-        let git_dir = destination_path.join(".git");
-        assert!(git_dir.exists(), "Git repository not initialized correctly");
-
 		assert!(result.is_ok());
 
+		// check for git_init
+		let repo = Repository::open(Path::new(&command.name))?;
+		let reflog = repo.reflog("HEAD")?;
+		assert_eq!(reflog.len(), 1);
 
 		// Clean up
 		if let Err(err) = fs::remove_dir_all("test_parachain") {

--- a/src/commands/new/parachain.rs
+++ b/src/commands/new/parachain.rs
@@ -1,6 +1,5 @@
 use crate::{
-	engines::parachain_engine::{instantiate_template_dir, Config},
-	style::{style, Theme},
+	engines::parachain_engine::{instantiate_template_dir, Config}, helpers::git_init, style::{style, Theme}
 };
 use clap::{Args, Parser};
 use std::{fs, path::Path};
@@ -77,6 +76,7 @@ impl NewParachainCommand {
 				initial_endowment: self.initial_endowment.clone().expect("default values"),
 			},
 		)?;
+        git_init(destination_path, "initialized parachain")?;
 		spinner.stop("Generation complete");
 		outro(format!("cd into \"{}\" and enjoy hacking! 🚀", &self.name))?;
 		Ok(())
@@ -85,6 +85,7 @@ impl NewParachainCommand {
 
 #[cfg(test)]
 mod tests {
+
 	use super::*;
 	use std::fs;
 
@@ -98,7 +99,14 @@ mod tests {
 			initial_endowment: Some("1u64 << 60".to_string()),
 		};
 		let result = command.execute();
+
+		// Check if the Git repository was initialized
+		let destination_path = Path::new(&command.name);
+        let git_dir = destination_path.join(".git");
+        assert!(git_dir.exists(), "Git repository not initialized correctly");
+
 		assert!(result.is_ok());
+
 
 		// Clean up
 		if let Err(err) = fs::remove_dir_all("test_parachain") {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use cliclack::{log, outro_cancel};
-use git2::Repository;
+use git2::{IndexAddOption, Repository, ResetType};
 use std::{
 	env::current_dir,
 	fs::{self, OpenOptions},
@@ -47,6 +47,24 @@ pub(crate) fn clone_and_degit(url: &str, target: &Path) -> Result<()> {
 	let repo = Repository::clone(url, target)?;
 	let git_dir = repo.path();
 	fs::remove_dir_all(&git_dir)?;
+	Ok(())
+}
+
+/// Init a new git repo on creation of a parachain
+pub(crate) fn git_init(target: &Path, message: &str) -> Result<(), git2::Error> {
+	let repo = Repository::init(target)?;
+	let signature = repo.signature()?;
+
+	let mut index = repo.index()?;
+	index.add_all(["*"].iter(), IndexAddOption::DEFAULT, None)?;
+	let tree_id = index.write_tree()?;
+
+	let tree = repo.find_tree(tree_id)?;
+	let commit_id = repo.commit(Some("HEAD"), &signature, &signature, message, &tree, &[])?;
+
+	let commit_object = repo.find_object(commit_id, Some(git2::ObjectType::Commit))?;
+	repo.reset(&commit_object, ResetType::Hard, None)?;
+
 	Ok(())
 }
 


### PR DESCRIPTION
This PR solves for #61. It initializes a new git repo with `initialized parachain` as the commit message. It takes the default global user config from git and uses it as the signature. 

Currently the test passes even if there is no `.git` dir in the new parachain. I need help with that.