### PR TITLE
update rust dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An all-in-one tool for Polkadot development.
 You can install Pop CLI as follows:
 
 ```shell
+rustup update
 cargo install --git https://github.com/r0gue-io/pop-cli
 ```
 


### PR DESCRIPTION
If there are certain version dependencies then these should be taken care of

```
error: failed to compile `pop-cli v0.1.0 (https://github.com/r0gue-io/pop-cli#7dc2e5dd)`, intermediate artifacts can be found at `/var/folders/_0/x9pp72wj13551p5tqynmrmpr0000gn/T/cargo-installf10s9A`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  package `subxt-metadata v0.34.0` cannot be built because it requires rustc 1.74.0 or newer, while the currently active rustc version is 1.72.0
  Either upgrade to rustc 1.74.0 or newer, or use
  cargo update -p subxt-metadata@0.34.0 --precise ver
  where `ver` is the latest version of `subxt-metadata` supporting rustc 1.72.0
```