### PR TITLE
fix(deps): remove deprecated dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2758,12 +2758,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5392,7 +5386,6 @@ dependencies = [
  "subxt 0.34.0",
  "subxt-signer 0.34.0",
  "symlink",
- "tempdir",
  "tempfile",
  "tokio",
  "toml_edit 0.22.6",
@@ -5598,19 +5591,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -5655,21 +5635,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -5693,15 +5658,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -5787,15 +5743,6 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "rend"
@@ -8520,16 +8467,6 @@ name = "target-lexicon"
 version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2021"
 name = "pop"
 path = "src/main.rs"
 
-[dev-dependencies]
-tempdir = "0.3.7"
-
 [dependencies]
 anyhow = "1.0"
 askama = "0.12"

--- a/src/engines/contract_engine.rs
+++ b/src/engines/contract_engine.rs
@@ -171,11 +171,10 @@ pub async fn dry_run_call(
 mod tests {
 	use super::*;
 	use std::fs;
-	use tempdir;
 
 	#[test]
 	fn test_create_smart_contract() -> Result<(), Box<dyn std::error::Error>> {
-		let temp_dir = tempdir::TempDir::new("test_folder")?;
+		let temp_dir = tempfile::tempdir()?;
 		let result: anyhow::Result<()> =
 			create_smart_contract("test".to_string(), &Some(PathBuf::from(temp_dir.path())));
 		assert!(result.is_ok());

--- a/src/engines/parachain_engine.rs
+++ b/src/engines/parachain_engine.rs
@@ -81,11 +81,10 @@ pub fn build_parachain(path: &Option<PathBuf>) -> anyhow::Result<()> {
 mod tests {
 	use super::*;
 	use std::{env::current_dir, fs};
-	use tempdir;
 
 	#[test]
 	fn test_instantiate_template_dir_base() -> Result<(), Box<dyn std::error::Error>> {
-		let temp_dir = tempdir::TempDir::new("base_template")?;
+		let temp_dir = tempfile::tempdir()?;
 		let config = Config {
 			symbol: "DOT".to_string(),
 			decimals: 18,


### PR DESCRIPTION
As per https://crates.io/crates/tempdir, tempdir was deprecated ages ago with functionality moved into tempfile which already exists as a dependency. Primary motivation was a security advisory triggered by dependabot: https://github.com/r0gue-io/pop-cli/security/dependabot/1.