### PR TITLE
feat(up-parachain): enable optional verbose output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10171,7 +10171,7 @@ dependencies = [
 [[package]]
 name = "zombienet-configuration"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#183f49156dc9d0f55fb2ea8632e87b522c69bcd5"
+source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#0e7fc0665ec01c6aa7189bfb2aaddd74b11e7e9f"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -10187,7 +10187,7 @@ dependencies = [
 [[package]]
 name = "zombienet-orchestrator"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#183f49156dc9d0f55fb2ea8632e87b522c69bcd5"
+source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#0e7fc0665ec01c6aa7189bfb2aaddd74b11e7e9f"
 dependencies = [
  "anyhow",
  "futures",
@@ -10215,7 +10215,7 @@ dependencies = [
 [[package]]
 name = "zombienet-prom-metrics-parser"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#183f49156dc9d0f55fb2ea8632e87b522c69bcd5"
+source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#0e7fc0665ec01c6aa7189bfb2aaddd74b11e7e9f"
 dependencies = [
  "pest",
  "pest_derive",
@@ -10225,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "zombienet-provider"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#183f49156dc9d0f55fb2ea8632e87b522c69bcd5"
+source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#0e7fc0665ec01c6aa7189bfb2aaddd74b11e7e9f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10255,7 +10255,7 @@ dependencies = [
 [[package]]
 name = "zombienet-sdk"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#183f49156dc9d0f55fb2ea8632e87b522c69bcd5"
+source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#0e7fc0665ec01c6aa7189bfb2aaddd74b11e7e9f"
 dependencies = [
  "async-trait",
  "futures",
@@ -10271,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "zombienet-support"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#183f49156dc9d0f55fb2ea8632e87b522c69bcd5"
+source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#0e7fc0665ec01c6aa7189bfb2aaddd74b11e7e9f"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -133,17 +133,18 @@ Some of the options available are:
 For more information about the options,
 check [cargo-contract documentation](https://github.com/paritytech/cargo-contract/blob/master/crates/extrinsics/README.md#instantiate)
 
-
 Interacting with the Smart Contract:
 
-1. Read-only Operations: For operations that only require reading from the blockchain state. This approach does not require to submit an extrinsic (skip the flag `x/--execute`).
-Example using the get() message:
+1. Read-only Operations: For operations that only require reading from the blockchain state. This approach does not
+   require to submit an extrinsic (skip the flag `x/--execute`).
+   Example using the get() message:
 
 ```sh
 pop call contract -p ./my_contract --contract $INSTANTIATED_CONTRACT_ADDRESS --message get --suri //Alice
 ```
 
-2. State-modifying Operations: For operations that change a storage value, thus altering the blockchain state. Include the `x/--execute`  flag to submit an extrinsic on-chain.
+2. State-modifying Operations: For operations that change a storage value, thus altering the blockchain state. Include
+   the `x/--execute`  flag to submit an extrinsic on-chain.
 
 Example executing the `flip()` message:
 
@@ -204,3 +205,9 @@ pop up parachain -f ./tests/zombienet.toml -p https://github.com/r0gue-io/pop-no
 
 > :information_source: Pop CLI will automatically source the necessary polkadot binaries. Currently, these will be built
 > if on a non-linux system.
+
+## Acknowledgements
+
+Pop CLI would not be possible without these awesome crates!
+
+- `zombienet-sdk`: https://github.com/paritytech/zombienet-sdk

--- a/README.md
+++ b/README.md
@@ -210,4 +210,4 @@ pop up parachain -f ./tests/zombienet.toml -p https://github.com/r0gue-io/pop-no
 
 Pop CLI would not be possible without these awesome crates!
 
-- `zombienet-sdk`: https://github.com/paritytech/zombienet-sdk
+- Local network deployment powered by [zombienet-sdk](https://github.com/paritytech/zombienet-sdk)

--- a/src/commands/up/mod.rs
+++ b/src/commands/up/mod.rs
@@ -15,7 +15,7 @@ pub(crate) struct UpArgs {
 #[derive(Subcommand)]
 pub(crate) enum UpCommands {
 	#[cfg(feature = "parachain")]
-	/// Deploy a parachain to a network.
+	/// Deploy a parachain to a local network, powered by zombienet-sdk <https://github.com/paritytech/zombienet-sdk>.
 	#[clap(alias = "p")]
 	Parachain(parachain::ZombienetCommand),
 	#[cfg(feature = "contract")]

--- a/src/commands/up/mod.rs
+++ b/src/commands/up/mod.rs
@@ -15,7 +15,7 @@ pub(crate) struct UpArgs {
 #[derive(Subcommand)]
 pub(crate) enum UpCommands {
 	#[cfg(feature = "parachain")]
-	/// Deploy a parachain to a local network, powered by zombienet-sdk <https://github.com/paritytech/zombienet-sdk>.
+	/// Deploy a parachain to a local network.
 	#[clap(alias = "p")]
 	Parachain(parachain::ZombienetCommand),
 	#[cfg(feature = "contract")]

--- a/src/commands/up/parachain.rs
+++ b/src/commands/up/parachain.rs
@@ -21,6 +21,9 @@ pub(crate) struct ZombienetCommand {
 	/// The url of the git repository of a parachain to be used, with branch/release tag specified as #fragment (e.g. 'https://github.com/org/repository#tag'). A specific binary name can also be optionally specified via query string parameter (e.g. 'https://github.com/org/repository?binaryname#tag'), defaulting to the name of the repository when not specified.
 	#[arg(short, long)]
 	parachain: Option<Vec<String>>,
+	/// Whether the output should be verbose.
+	#[arg(short, long, action)]
+	verbose: bool,
 }
 impl ZombienetCommand {
 	pub(crate) async fn execute(&self) -> anyhow::Result<()> {
@@ -71,12 +74,20 @@ impl ZombienetCommand {
 
 				let output = |node: &NetworkNode| -> String {
 					let name = node.name();
-					format!(
+					let mut output = format!(
 						"\n{bar}       {name}:
 {bar}         portal: https://polkadot.js.org/apps/?rpc={}#/explorer
 {bar}         logs: tail -f {base_dir}/{name}/{name}.log",
 						node.ws_uri(),
-					)
+					);
+					if self.verbose {
+						output += &format!(
+							"\n{bar}         command: {} {}",
+							node.spec().command(),
+							node.args().join(" ")
+						);
+					}
+					output
 				};
 				// Add relay info
 				let mut validators = network.relaychain().nodes();

--- a/src/commands/up/parachain.rs
+++ b/src/commands/up/parachain.rs
@@ -6,8 +6,7 @@ use zombienet_sdk::NetworkNode;
 
 #[derive(Args)]
 pub(crate) struct ZombienetCommand {
-	/// The configuration file to be used. Only Zombienet configuration files are currently
-	/// supported.
+	/// The Zombienet configuration file to be used.
 	#[arg(short, long)]
 	file: String,
 	/// The version of Polkadot to be used for the relay chain, as per the release tag (e.g.


### PR DESCRIPTION
Adds an optional `--verbose` or `-v` argument to the up parachain command, which includes the command that was used to launch a node in the output which can be useful in advanced scenarios.