### PR TITLE
fix: cargo test takes too long to test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,4 +65,4 @@ jobs:
       run: cargo build
 
     - name: Run unit tests
-      run: cargo test --bins
+      run: cargo test --all-features -- --include-ignored

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,4 +65,4 @@ jobs:
       run: cargo build
 
     - name: Run tests
-      run: cargo test --all-features -- --include-ignored
+      run: cargo test --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,5 +64,5 @@ jobs:
     - name: Build default features
       run: cargo build
 
-    - name: Run unit tests
+    - name: Run tests
       run: cargo test --all-features -- --include-ignored

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,5 +64,5 @@ jobs:
     - name: Build default features
       run: cargo build
 
-    - name: Run tests
-      run: cargo test --verbose
+    - name: Run unit tests
+      run: cargo test --bins

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ contract = [
     "dep:sp-weights",
     "dep:url",
 ]
+e2e_contract = []
 parachain = [
     "dep:dirs",
     "dep:indexmap",
@@ -75,3 +76,5 @@ parachain = [
     "dep:zombienet-sdk",
     "dep:zombienet-support"
 ]
+e2e_parachain = []
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ contract = [
     "dep:url",
 ]
 e2e_contract = []
+unit_contract = []
 parachain = [
     "dep:dirs",
     "dep:indexmap",

--- a/README.md
+++ b/README.md
@@ -204,3 +204,32 @@ pop up parachain -f ./tests/zombienet.toml -p https://github.com/r0gue-io/pop-no
 
 > :information_source: Pop CLI will automatically source the necessary polkadot binaries. Currently, these will be built
 > if on a non-linux system.
+
+
+## Testing Pop CLI 
+
+To test the tool locally.
+
+Run the unit tests:
+
+```sh
+cargo test
+```
+
+Run the contracts e2e tests:
+
+```sh
+cargo test --features e2e_contract
+```
+
+Run the parachain e2e tests:
+
+```sh
+cargo test --features e2e_parachain
+```
+
+Run all tests, including the ignored ones:
+
+```sh
+cargo test --all-features -- --include-ignored
+```

--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ Run the unit tests:
 cargo test
 ```
 
+Run only contracts unit tests:
+
+```sh
+cargo test --features unit_contract
+```
+
 Run the contracts e2e tests:
 
 ```sh
@@ -228,8 +234,8 @@ Run the parachain e2e tests:
 cargo test --features e2e_parachain
 ```
 
-Run all tests, including the ignored ones:
+Run all tests:
 
 ```sh
-cargo test --all-features -- --include-ignored
+cargo test --all-features
 ```

--- a/src/engines/contract_engine.rs
+++ b/src/engines/contract_engine.rs
@@ -203,8 +203,8 @@ mod tests {
 		Ok(())
 	}
 
+	#[cfg(feature = "unit_contract")]
 	#[test]
-	#[ignore = "Build a contract takes long time to build"]
 	fn test_contract_build() -> Result<(), Error> {
 		let temp_contract_dir = setup_test_environment()?;
 
@@ -229,9 +229,9 @@ mod tests {
 
 		Ok(())
 	}
-
+	
+	#[cfg(feature = "unit_contract")]
 	#[test]
-	#[ignore = "Build a contract to test it takes long time to build"]
 	fn test_contract_test() -> Result<(), Error> {
 		let temp_contract_dir = setup_test_environment()?;
 

--- a/src/engines/contract_engine.rs
+++ b/src/engines/contract_engine.rs
@@ -204,7 +204,7 @@ mod tests {
 	}
 
 	#[test]
-	#[ignore] // It takes long time to build
+	#[ignore = "Build a contract takes long time to build"]
 	fn test_contract_build() -> Result<(), Error> {
 		let temp_contract_dir = setup_test_environment()?;
 
@@ -231,7 +231,7 @@ mod tests {
 	}
 
 	#[test]
-	#[ignore] // It takes long time to build
+	#[ignore = "Build a contract to test it takes long time to build"]
 	fn test_contract_test() -> Result<(), Error> {
 		let temp_contract_dir = setup_test_environment()?;
 

--- a/src/engines/contract_engine.rs
+++ b/src/engines/contract_engine.rs
@@ -204,6 +204,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore] // It takes long time to build
 	fn test_contract_build() -> Result<(), Error> {
 		let temp_contract_dir = setup_test_environment()?;
 
@@ -230,6 +231,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore] // It takes long time to build
 	fn test_contract_test() -> Result<(), Error> {
 		let temp_contract_dir = setup_test_environment()?;
 

--- a/src/engines/contract_engine.rs
+++ b/src/engines/contract_engine.rs
@@ -230,7 +230,7 @@ mod tests {
 
 		Ok(())
 	}
-	
+
 	#[cfg(feature = "unit_contract")]
 	#[test]
 	fn test_contract_test() -> Result<(), Error> {

--- a/src/engines/parachain_engine.rs
+++ b/src/engines/parachain_engine.rs
@@ -125,7 +125,7 @@ mod tests {
 	}
 
 	#[test]
-	#[ignore] // It takes long time to build
+	#[ignore = "Build parachain takes long time to build"]
 	fn test_parachain_build_after_instantiating_template() -> Result<()> {
 		let temp_dir =
 			setup_template_and_instantiate().expect("Failed to setup template and instantiate");

--- a/src/engines/parachain_engine.rs
+++ b/src/engines/parachain_engine.rs
@@ -123,14 +123,4 @@ mod tests {
 
 		Ok(())
 	}
-
-	#[test]
-	#[ignore = "Build parachain takes long time to build"]
-	fn test_parachain_build_after_instantiating_template() -> Result<()> {
-		let temp_dir =
-			setup_template_and_instantiate().expect("Failed to setup template and instantiate");
-		let build = build_parachain(&Some(temp_dir.path().to_path_buf()));
-		assert!(build.is_ok(), "Result should be Ok");
-		Ok(())
-	}
 }

--- a/src/engines/parachain_engine.rs
+++ b/src/engines/parachain_engine.rs
@@ -125,6 +125,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore] // It takes long time to build
 	fn test_parachain_build_after_instantiating_template() -> Result<()> {
 		let temp_dir =
 			setup_template_and_instantiate().expect("Failed to setup template and instantiate");

--- a/tests/build_contract.rs
+++ b/tests/build_contract.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "e2e_contract")]
 use anyhow::{Error, Result};
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -16,7 +17,6 @@ fn setup_test_environment() -> Result<tempfile::TempDir, Error> {
 }
 
 #[test]
-#[cfg_attr(not(feature = "e2e_contract"), ignore)]
 fn test_contract_build_success() -> Result<(), Error> {
 	let temp_contract_dir = setup_test_environment()?;
 
@@ -48,7 +48,6 @@ fn test_contract_build_success() -> Result<(), Error> {
 }
 
 #[test]
-#[cfg_attr(not(feature = "e2e_contract"), ignore)]
 fn test_contract_build_specify_path() -> Result<(), Error> {
 	let temp_contract_dir = setup_test_environment()?;
 
@@ -80,7 +79,6 @@ fn test_contract_build_specify_path() -> Result<(), Error> {
 }
 
 #[test]
-#[cfg_attr(not(feature = "e2e_contract"), ignore)]
 fn test_contract_build_fails_if_no_contract_exists() -> Result<(), Error> {
 	// pop build contract
 	Command::cargo_bin("pop")

--- a/tests/build_contract.rs
+++ b/tests/build_contract.rs
@@ -17,7 +17,7 @@ fn setup_test_environment() -> Result<tempfile::TempDir, Error> {
 
 #[test]
 #[cfg_attr(not(feature = "e2e_contract"), ignore)]
-fn test_contract_build() -> Result<(), Error> {
+fn test_contract_build_success() -> Result<(), Error> {
 	let temp_contract_dir = setup_test_environment()?;
 
 	// pop build contract

--- a/tests/build_contract.rs
+++ b/tests/build_contract.rs
@@ -16,6 +16,7 @@ fn setup_test_environment() -> Result<tempfile::TempDir, Error> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "e2e_contract"), ignore)]
 fn test_contract_build() -> Result<(), Error> {
 	let temp_contract_dir = setup_test_environment()?;
 
@@ -47,6 +48,7 @@ fn test_contract_build() -> Result<(), Error> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "e2e_contract"), ignore)]
 fn test_contract_build_specify_path() -> Result<(), Error> {
 	let temp_contract_dir = setup_test_environment()?;
 
@@ -78,6 +80,7 @@ fn test_contract_build_specify_path() -> Result<(), Error> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "e2e_contract"), ignore)]
 fn test_contract_build_fails_if_no_contract_exists() -> Result<(), Error> {
 	// pop build contract
 	Command::cargo_bin("pop")

--- a/tests/build_parachain.rs
+++ b/tests/build_parachain.rs
@@ -1,0 +1,32 @@
+#![cfg(feature = "e2e_parachain")]
+use anyhow::{Error, Result};
+use assert_cmd::Command;
+
+fn setup_test_environment() -> Result<tempfile::TempDir, Error> {
+	let temp_dir = tempfile::tempdir().unwrap();
+	// pop new parachain test_parachain
+	Command::cargo_bin("pop")
+		.unwrap()
+		.current_dir(&temp_dir)
+		.args(&["new", "parachain", "test_parachain"])
+		.assert()
+		.success();
+
+	Ok(temp_dir)
+}
+
+#[test]
+fn test_parachain_build_after_instantiating_template() -> Result<()> {
+    let temp_dir = setup_test_environment()?;
+
+    // pop build contract -p "./test_parachain"
+	Command::cargo_bin("pop")
+        .unwrap()
+        .current_dir(&temp_dir)
+        .args(&["build", "parachain", "-p", "./test_parachain"])
+        .assert()
+        .success();
+
+    assert!(temp_dir.path().join("test_parachain/target").exists());
+    Ok(())
+}

--- a/tests/build_parachain.rs
+++ b/tests/build_parachain.rs
@@ -17,16 +17,16 @@ fn setup_test_environment() -> Result<tempfile::TempDir, Error> {
 
 #[test]
 fn test_parachain_build_after_instantiating_template() -> Result<()> {
-    let temp_dir = setup_test_environment()?;
+	let temp_dir = setup_test_environment()?;
 
-    // pop build contract -p "./test_parachain"
+	// pop build contract -p "./test_parachain"
 	Command::cargo_bin("pop")
-        .unwrap()
-        .current_dir(&temp_dir)
-        .args(&["build", "parachain", "-p", "./test_parachain"])
-        .assert()
-        .success();
+		.unwrap()
+		.current_dir(&temp_dir)
+		.args(&["build", "parachain", "-p", "./test_parachain"])
+		.assert()
+		.success();
 
-    assert!(temp_dir.path().join("test_parachain/target").exists());
-    Ok(())
+	assert!(temp_dir.path().join("test_parachain/target").exists());
+	Ok(())
 }


### PR DESCRIPTION
Fixing Issue https://github.com/r0gue-io/pop-cli/issues/88

- Run only unit tests when `cargo test`
- unit tests that are a bit slower, build a contract move it into feature `unit_contract`. To run `cargo test --features unit_contract `
- Run e2e tests using a feature flag `cargo test --features e2e_contract` for contracts and `cargo test --features e2e_parachain` for parachains
- Moved the test that builds a parachain to e2e test

- In the CI run everything `cargo test --all-features -- --include-ignored`