### PR TITLE
fix: fetch latest polkadot releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tempfile = "3.8"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 url = { version = "2.5", optional = true }
 walkdir = "2.4"
-regex="1.5.4"
+regex = "1.5.4"
 
 # contracts
 contract-build = { version = "4.0.2", optional = true }
@@ -70,6 +70,7 @@ parachain = [
     "dep:dirs",
     "dep:indexmap",
     "dep:reqwest",
+    "dep:serde",
     "dep:serde_json",
     "dep:symlink",
     "dep:toml_edit",


### PR DESCRIPTION
We are fetching the latest polkadot version from https://github.com/paritytech/polkadot-sdk/releases,
Latest release there is a [Polkadot Parachain](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-parachain-v1.10.1) release, and this was making the tool fail because we are trying to get a version of Polkadot that doesn't exist:
```
Error: error sending request for url (https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-parachain-v1.10.1/polkadot): error trying to connect: unexpected EOF
```

The workaround suggested in this PR: fetch the latest n (5 in this case) versions and iterate to find the Polkadot version.
