### PR TITLE
refactor: improve latest release filtering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tempfile = "3.8"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 url = { version = "2.5", optional = true }
 walkdir = "2.4"
-regex="1.5.4"
+regex = "1.5.4"
 
 # contracts
 contract-build = { version = "4.0.2", optional = true }
@@ -70,6 +70,7 @@ parachain = [
     "dep:dirs",
     "dep:indexmap",
     "dep:reqwest",
+    "dep:serde",
     "dep:serde_json",
     "dep:symlink",
     "dep:toml_edit",


### PR DESCRIPTION
Simply uses serde to deserialise releases to improve filtering, allowing the exclusion of prereleases and filtering by tag. Adding additonal fields will be much easier in the future. Currently returns all releases to let the caller apply the filtering, as the full list is downloaded in any case. Can be further optimised in the future.

Note: will currently download `polkadot` and `polkadot-parachain` at v1.10.  `-s v1.10.1` can be specified to explictly use the latest `polkadot-parachain` version currently available.