### PR TITLE
refactor: maximise use of enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5508,6 +5508,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
  "symlink",
  "tempfile",
  "thiserror",

--- a/crates/pop-cli/src/commands/new/contract.rs
+++ b/crates/pop-cli/src/commands/new/contract.rs
@@ -49,7 +49,7 @@ impl NewContractCommand {
 		fs::create_dir_all(contract_path.as_path())?;
 		let mut spinner = cliclack::spinner();
 		spinner.start("Generating contract...");
-		create_smart_contract(self.name.clone(), contract_path.as_path())?;
+		create_smart_contract(&self.name, contract_path.as_path())?;
 		spinner.stop("Smart contract created!");
 		outro(format!("cd into \"{}\" and enjoy hacking! 🚀", contract_path.display()))?;
 		Ok(())

--- a/crates/pop-contracts/src/new.rs
+++ b/crates/pop-contracts/src/new.rs
@@ -3,7 +3,7 @@ use crate::errors::Error;
 use contract_build::new_contract_project;
 use std::path::Path;
 
-pub fn create_smart_contract(name: String, target: &Path) -> Result<(), Error> {
+pub fn create_smart_contract(name: &str, target: &Path) -> Result<(), Error> {
 	// Canonicalize the target path to ensure consistency and resolve any symbolic links.
 	let canonicalized_path = target
 		.canonicalize()
@@ -35,7 +35,7 @@ mod tests {
 		let temp_dir = tempfile::tempdir()?;
 		let temp_contract_dir = temp_dir.path().join("test_contract");
 		fs::create_dir(&temp_contract_dir)?;
-		create_smart_contract("test_contract".to_string(), temp_contract_dir.as_path())?;
+		create_smart_contract("test_contract", temp_contract_dir.as_path())?;
 		Ok(temp_dir)
 	}
 

--- a/crates/pop-contracts/src/utils/helpers.rs
+++ b/crates/pop-contracts/src/utils/helpers.rs
@@ -38,8 +38,7 @@ mod tests {
 		let temp_dir = tempfile::tempdir().expect("Could not create temp dir");
 		let temp_contract_dir = temp_dir.path().join("test_contract");
 		fs::create_dir(&temp_contract_dir)?;
-		let result =
-			crate::create_smart_contract("test_contract".to_string(), temp_contract_dir.as_path());
+		let result = crate::create_smart_contract("test_contract", temp_contract_dir.as_path());
 		assert!(result.is_ok(), "Contract test environment setup failed");
 
 		Ok(temp_dir)

--- a/crates/pop-parachains/Cargo.toml
+++ b/crates/pop-parachains/Cargo.toml
@@ -5,27 +5,27 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow.workspace = true
-thiserror.workspace = true
 duct.workspace = true
 git2.workspace = true
 git2_credentials.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
 tempfile.workspace = true
-url.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
+url.workspace = true
 
 askama.workspace = true
-regex.workspace = true
-walkdir.workspace = true
 indexmap.workspace = true
-toml_edit.workspace = true
-symlink.workspace = true
+regex.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
 serde.workspace = true
+symlink.workspace = true
+toml_edit.workspace = true
+walkdir.workspace = true
 # Zombienet
 zombienet-sdk.workspace = true
 zombienet-support.workspace = true

--- a/crates/pop-parachains/src/errors.rs
+++ b/crates/pop-parachains/src/errors.rs
@@ -1,3 +1,4 @@
+use crate::templates;
 use thiserror::Error;
 use zombienet_sdk::OrchestratorError;
 
@@ -47,4 +48,7 @@ pub enum Error {
 
 	#[error("Failed to execute rustfmt")]
 	RustfmtError(std::io::Error),
+
+	#[error("Template error: {0}")]
+	TemplateError(#[from] templates::Error),
 }

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -13,7 +13,7 @@ pub use new_pallet::{create_pallet_template, TemplatePalletConfig};
 pub use new_parachain::instantiate_template_dir;
 pub use templates::{Config, Provider, Template};
 pub use up::Zombienet;
-pub use utils::git::{Git, GitHub, TagInfo};
+pub use utils::git::{Git, GitHub, Release};
 pub use utils::pallet_helpers::resolve_pallet_path;
 // External exports
 pub use zombienet_sdk::NetworkNode;

--- a/crates/pop-parachains/src/new_parachain.rs
+++ b/crates/pop-parachains/src/new_parachain.rs
@@ -24,7 +24,7 @@ pub fn instantiate_template_dir(
 	if matches!(template, &Template::Base) {
 		return instantiate_base_template(target, config, tag_version);
 	}
-	let tag = Git::clone_and_degit(template.repository_url(), target, tag_version)?;
+	let tag = Git::clone_and_degit(template.repository_url()?, target, tag_version)?;
 	Ok(tag)
 }
 
@@ -37,7 +37,7 @@ pub fn instantiate_base_template(
 	let source = temp_dir.path();
 	let template = crate::templates::Template::Base;
 
-	let tag = Git::clone_and_degit(template.repository_url(), source, tag_version)?;
+	let tag = Git::clone_and_degit(template.repository_url()?, source, tag_version)?;
 
 	for entry in WalkDir::new(&source) {
 		let entry = entry?;


### PR DESCRIPTION
Maximises the use of the `Provider` and `Template` enums so that new templates can be added easily and in a single place.

Note: I think the Parity templates should be marked as deprecated owing to how old the available releases are. We could also look to provide the default branch as an additional option to the available releases, perhaps via an opt-in flag/property by provider or template.