### PR TITLE
build: enable vendored-openssl via feature to ease cross compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,6 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-22.04
-            target: x86_64-unknown-linux-gnu
-            cpu: skylake
           # macOS
           - os: macos-14
             target: aarch64-apple-darwin
@@ -33,7 +30,7 @@ jobs:
     env:
       RUSTFLAGS: "${{ matrix.platform.cpu != '' && format('-C target-cpu={0}', matrix.platform.cpu) || '' }} ${{ matrix.platform.target == 'aarch64-unknown-linux-gnu' && '-C linker=aarch64-linux-gnu-gcc' || '' }}"
       path: "target/${{ matrix.platform.target }}/production"
-      package: "pop-cli-${{ matrix.platform.target }}${{ matrix.platform.cpu != '' && format('-{0}', matrix.platform.cpu) || '' }}.tar.gz"
+      package: "pop-${{ matrix.platform.target }}${{ matrix.platform.cpu != '' && format('-{0}', matrix.platform.cpu) || '' }}.tar.gz"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,20 +54,21 @@ jobs:
         run: rustup target add ${{ matrix.platform.target }}
 
       - name: Build pop-cli
-        run: cargo build --profile=production -p pop-cli --target ${{ matrix.platform.target }}
+        run: cargo build --profile=production -p pop-cli --target ${{ matrix.platform.target }} --features static-ssl
+
       - name: Package binary (Linux)
         if: contains(matrix.platform.target, 'linux')
         run: |
           cd ${{ env.path }}
-          sha256sum pop-cli > pop-cli.sha256
-          tar -czf ${{ env.package }} pop-cli pop-cli.sha256
+          sha256sum pop > pop.sha256
+          tar -czf ${{ env.package }} pop pop.sha256
 
       - name: Package binary (macOS)
         if: contains(matrix.platform.target, 'apple')
         run: |
           cd ${{ env.path }}
-          shasum -a 256 pop-cli > pop-cli.sha256
-          tar -czf ${{ env.package }} pop-cli pop-cli.sha256
+          shasum -a 256 pop > pop.sha256
+          tar -czf ${{ env.package }} pop pop.sha256
 
       - name: Upload binary
         uses: actions/upload-artifact@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4927,6 +4927,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.2.3+3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4934,6 +4943,7 @@ checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -23,14 +23,14 @@ strum.workspace = true
 strum_macros.workspace = true
 
 # contracts
-pop-contracts = { path = "../pop-contracts", optional = true}
+pop-contracts = { path = "../pop-contracts", optional = true }
 sp-core = { workspace = true, optional = true }
 sp-weights = { workspace = true, optional = true }
 
 # parachains
 pop-parachains = { path = "../pop-parachains", optional = true }
-dirs = { version = "5.0", optional = true}
-git2.workspace  = true
+dirs = { version = "5.0", optional = true }
+git2.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2.0.14"
@@ -38,6 +38,7 @@ predicates = "3.1.0"
 
 [features]
 default = ["contract", "parachain"]
+static-ssl = ["git2/vendored-openssl"]
 contract = [
     "dep:pop-contracts",
     "dep:sp-core",


### PR DESCRIPTION
Fixes the cross compilation issues. Results of a run at https://github.com/r0gue-io/pop-cli/actions/runs/8853101362, tested briefly on all platforms via Docker/Linux/Rosetta using Mac.

Also removed skylake as dont think we need to make that available.