### PR TITLE
feat(up parachain): improve build ux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,9 +1291,9 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "cliclack"
-version = "0.1.13"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be29210ca32b96e4f67fe9a520d2eeacc078d94ff4027100dc6b7262fdfec5c4"
+checksum = "4febf49beeedc40528e4956995631f1bbdb4d8804ef940b44351f393a996c739"
 dependencies = [
  "console",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,34 +19,34 @@ duct = "0.13"
 git2 = "0.18"
 tempfile = "3.8"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-url = { version = "2.5"}
+url = { version = "2.5" }
 
 # contracts
-subxt-signer = { version = "0.34.0", features = ["subxt", "sr25519"]}
+subxt-signer = { version = "0.34.0", features = ["subxt", "sr25519"] }
 subxt = { version = "0.34.0" }
 ink_env = { version = "5.0.0-rc.2" }
-sp-core = { version = "30.0.0"}
+sp-core = { version = "30.0.0" }
 sp-weights = { version = "29.0.0" }
 contract-build = { version = "4.0.2" }
-contract-extrinsics = { version = "4.0.0-rc.3"}
+contract-extrinsics = { version = "4.0.0-rc.3" }
 
 # parachains
 askama = "0.12"
-regex="1.5.4"
+regex = "1.5.4"
 walkdir = "2.4"
-indexmap = { version = "2.2"}
+indexmap = { version = "2.2" }
 toml_edit = { version = "0.22", features = ["serde"] }
 symlink = { version = "0.1" }
 reqwest = { version = "0.11" }
-serde_json = { version = "1.0"}
+serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
-zombienet-sdk = { git = "https://github.com/r0gue-io/zombienet-sdk", branch = "pop", version = "0.1.0-alpha.1"}
+zombienet-sdk = { git = "https://github.com/r0gue-io/zombienet-sdk", branch = "pop", version = "0.1.0-alpha.1" }
 zombienet-support = { git = "https://github.com/r0gue-io/zombienet-sdk", branch = "pop", version = "0.1.0-alpha.1" }
 git2_credentials = "0.13.0"
 
 # pop-cli
 clap = { version = "4.4", features = ["derive"] }
-cliclack = "0.1"
+cliclack = "0.2"
 console = "0.15"
 strum = "0.26"
 strum_macros = "0.26"

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -74,7 +74,7 @@ impl CallContractCommand {
 		.await?;
 
 		if !self.execute {
-			let mut spinner = cliclack::spinner();
+			let spinner = cliclack::spinner();
 			spinner.start("Calling the contract...");
 			let call_dry_run_result = dry_run_call(&call_exec).await?;
 			log::info(format!("Result: {}", call_dry_run_result))?;
@@ -89,7 +89,7 @@ impl CallContractCommand {
 				weight_limit =
 					Weight::from_parts(self.gas_limit.unwrap(), self.proof_size.unwrap());
 			} else {
-				let mut spinner = cliclack::spinner();
+				let spinner = cliclack::spinner();
 				spinner.start("Doing a dry run to estimate the gas...");
 				weight_limit = match dry_run_gas_estimate_call(&call_exec).await {
 					Ok(w) => {
@@ -103,7 +103,7 @@ impl CallContractCommand {
 					},
 				};
 			}
-			let mut spinner = cliclack::spinner();
+			let spinner = cliclack::spinner();
 			spinner.start("Calling the contract...");
 
 			let call_result = call_smart_contract(call_exec, weight_limit, &self.url)

--- a/crates/pop-cli/src/commands/new/contract.rs
+++ b/crates/pop-cli/src/commands/new/contract.rs
@@ -47,7 +47,7 @@ impl NewContractCommand {
 			fs::remove_dir_all(contract_path.as_path())?;
 		}
 		fs::create_dir_all(contract_path.as_path())?;
-		let mut spinner = cliclack::spinner();
+		let spinner = cliclack::spinner();
 		spinner.start("Generating contract...");
 		create_smart_contract(&self.name, contract_path.as_path())?;
 		spinner.stop("Smart contract created!");

--- a/crates/pop-cli/src/commands/new/pallet.rs
+++ b/crates/pop-cli/src/commands/new/pallet.rs
@@ -45,7 +45,7 @@ impl NewPalletCommand {
 			}
 			fs::remove_dir_all(pallet_path)?;
 		}
-		let mut spinner = cliclack::spinner();
+		let spinner = cliclack::spinner();
 		spinner.start("Generating pallet...");
 		create_pallet_template(
 			self.path.clone(),

--- a/crates/pop-cli/src/commands/new/parachain.rs
+++ b/crates/pop-cli/src/commands/new/parachain.rs
@@ -144,7 +144,7 @@ fn generate_parachain_from_template(
 	))?;
 	let destination_path = check_destination_path(name_template)?;
 
-	let mut spinner = cliclack::spinner();
+	let spinner = cliclack::spinner();
 	spinner.start("Generating parachain...");
 	let tag = instantiate_template_dir(template, destination_path, tag_version, config)?;
 	if let Err(err) = Git::git_init(destination_path, "initialized parachain") {

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -72,7 +72,7 @@ impl UpContractCommand {
 		if self.gas_limit.is_some() && self.proof_size.is_some() {
 			weight_limit = Weight::from_parts(self.gas_limit.unwrap(), self.proof_size.unwrap());
 		} else {
-			let mut spinner = cliclack::spinner();
+			let spinner = cliclack::spinner();
 			spinner.start("Doing a dry run to estimate the gas...");
 			weight_limit = match dry_run_gas_estimate_instantiate(&instantiate_exec).await {
 				Ok(w) => {
@@ -86,7 +86,7 @@ impl UpContractCommand {
 				},
 			};
 		}
-		let mut spinner = cliclack::spinner();
+		let spinner = cliclack::spinner();
 		spinner.start("Uploading and instantiating the contract...");
 		let contract_address = instantiate_smart_contract(instantiate_exec, weight_limit)
 			.await

--- a/crates/pop-cli/src/commands/up/parachain.rs
+++ b/crates/pop-cli/src/commands/up/parachain.rs
@@ -64,7 +64,7 @@ impl ZombienetCommand {
 				let spinner = multi.add(cliclack::spinner());
 				for attempt in (0..=1).rev() {
 					if let Err(e) =
-						binary.source(&cache, &mut |status| spinner.start(format(status))).await
+						binary.source(&cache, &|status| spinner.start(format(status))).await
 					{
 						match attempt {
 							0 => {

--- a/crates/pop-cli/src/commands/up/parachain.rs
+++ b/crates/pop-cli/src/commands/up/parachain.rs
@@ -84,7 +84,7 @@ impl ZombienetCommand {
 			}
 		}
 		// Finally spawn network and wait for signal to terminate
-		let mut spinner = cliclack::spinner();
+		let spinner = cliclack::spinner();
 		spinner.start("🚀 Launching local network...");
 		//tracing_subscriber::fmt().init();
 		match zombienet.spawn().await {

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -12,7 +12,7 @@ pub use build::build_parachain;
 pub use new_pallet::{create_pallet_template, TemplatePalletConfig};
 pub use new_parachain::instantiate_template_dir;
 pub use templates::{Config, Provider, Template};
-pub use up::Zombienet;
+pub use up::{Status, Zombienet};
 pub use utils::git::{Git, GitHub, Release};
 pub use utils::pallet_helpers::resolve_pallet_path;
 // External exports


### PR DESCRIPTION
Improves the ux when building binaries for `pop up parachain`, by updating `cliclack` and by using a callback to pass underlying `cargo build` status updates back up to cli ui for output.

Also adds a retry attempt should the first attempt fail. This is primarily due to an interrupted process, but could potentially be due to a connectivity issue.