### PR TITLE
fix: retrieve templates of provider

### DIFF
--- a/crates/pop-parachains/src/templates.rs
+++ b/crates/pop-parachains/src/templates.rs
@@ -49,7 +49,7 @@ impl Provider {
 	pub fn templates(&self) -> Vec<&Template> {
 		Template::VARIANTS
 			.iter()
-			.filter(|t| t.get_str("Provider") == Some(self.to_string().as_str()))
+			.filter(|t| t.get_str("Provider") == Some(self.name().to_string().as_str()))
 			.collect()
 	}
 }
@@ -196,11 +196,19 @@ mod tests {
 	}
 
 	#[test]
-	fn test_default_provider() {
+	fn test_default_template_of_provider() {
 		let mut provider = Provider::Pop;
 		assert_eq!(provider.default_template(), Template::Base);
 		provider = Provider::Parity;
 		assert_eq!(provider.default_template(), Template::ParityContracts);
+	}
+
+	#[test]
+	fn test_templates_of_provider() {
+		let mut provider = Provider::Pop;
+		assert_eq!(provider.templates(), [&Template::Base, &Template::Assets]);
+		provider = Provider::Parity;
+		assert_eq!(provider.templates(), [&Template::ParityContracts, &Template::ParityFPT]);
 	}
 
 	#[test]

--- a/crates/pop-parachains/src/templates.rs
+++ b/crates/pop-parachains/src/templates.rs
@@ -49,7 +49,7 @@ impl Provider {
 	pub fn templates(&self) -> Vec<&Template> {
 		Template::VARIANTS
 			.iter()
-			.filter(|t| t.get_str("Provider") == Some(self.name().to_string().as_str()))
+			.filter(|t| t.get_str("Provider") == Some(self.name()))
 			.collect()
 	}
 }


### PR DESCRIPTION
Quick fix for a bug we introduced after a refactor in the Provider enum.

Was not getting the list of templates a provider have: 
```
 Select a template provider: 
│  ● Pop (An all-in-one tool for Polkadot development. 0 available option(s) )
│  ○ Parity
```
And throwing an error when try to generate a parachain using the user guide.

Fixed and unit test added to prevent it for happening again.
