### PR TITLE
fix: validate endowment input

### DIFF
--- a/crates/pop-cli/src/commands/new/parachain.rs
+++ b/crates/pop-cli/src/commands/new/parachain.rs
@@ -89,16 +89,16 @@ impl NewParachainCommand {
 				is_template_supported(provider, &template)?;
 				let mut initial_endowment = self.initial_endowment.clone();
 				if initial_endowment.is_some()
-					&& !is_initial_endowment_valid(initial_endowment.unwrap())
+					&& !is_initial_endowment_valid(&initial_endowment.clone().unwrap())
 				{
-					log::warning(format!(
-						"⚠️ The specified initial endowment {} is not valid",
-						initial_endowment.unwrap()
-					))?;
+					log::warning("⚠️ The specified initial endowment is not valid")?;
 					//Prompt the user if want to use the one by default
-					if !confirm("📦 Would you like to use the one by default?")
-						.initial_value(true)
-						.interact()?
+					if !confirm(format!(
+						"📦 Would you like to use the one by default {}?",
+						DEFAULT_INITIAL_ENDOWMENT
+					))
+					.initial_value(true)
+					.interact()?
 					{
 						outro_cancel("🚫 Cannot create a parachain with an incorrect initial endowment value.")?;
 						return Ok(());
@@ -109,7 +109,7 @@ impl NewParachainCommand {
 					&template,
 					self.symbol.clone(),
 					self.decimals,
-					initial_endowment,
+					initial_endowment.clone(),
 				)?;
 
 				generate_parachain_from_template(name, provider, &template, None, config)
@@ -238,7 +238,6 @@ fn get_customization_value(
 	decimals: Option<u8>,
 	initial_endowment: Option<String>,
 ) -> Result<Config> {
-	println!("endowment {:?}", initial_endowment);
 	if !matches!(template, Template::Base)
 		&& (symbol.is_some() || decimals.is_some() || initial_endowment.is_some())
 	{

--- a/crates/pop-parachains/src/errors.rs
+++ b/crates/pop-parachains/src/errors.rs
@@ -51,4 +51,7 @@ pub enum Error {
 
 	#[error("Template error: {0}")]
 	TemplateError(#[from] templates::Error),
+
+	#[error("Failed to parse the endowment value")]
+	EndowmentError,
 }

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -14,6 +14,7 @@ pub use new_parachain::instantiate_template_dir;
 pub use templates::{Config, Provider, Template};
 pub use up::{Status, Zombienet};
 pub use utils::git::{Git, GitHub, Release};
+pub use utils::helpers::is_initial_endowment_valid;
 pub use utils::pallet_helpers::resolve_pallet_path;
 // External exports
 pub use zombienet_sdk::NetworkNode;

--- a/crates/pop-parachains/src/new_parachain.rs
+++ b/crates/pop-parachains/src/new_parachain.rs
@@ -51,6 +51,7 @@ pub fn instantiate_base_template(
 			fs::copy(source_path, &destination_path)?;
 		}
 	}
+
 	let chainspec = ChainSpec {
 		token_symbol: config.symbol,
 		decimals: config.decimals,

--- a/crates/pop-parachains/src/utils/helpers.rs
+++ b/crates/pop-parachains/src/utils/helpers.rs
@@ -24,6 +24,16 @@ pub(crate) fn sanitize(target: &Path) -> Result<(), Error> {
 	Ok(())
 }
 
+pub fn is_initial_endowment_valid(initial_endowment: String) -> bool {
+	match initial_endowment.parse::<i128>() {
+		Ok(_) => return true,
+		Err(error) => {
+			println!("{:?}", error);
+			return false;
+		},
+	}
+}
+
 pub(crate) fn write_to_file(path: &Path, contents: &str) -> Result<(), Error> {
 	let mut file = OpenOptions::new()
 		.write(true)
@@ -49,4 +59,18 @@ pub(crate) fn write_to_file(path: &Path, contents: &str) -> Result<(), Error> {
 	}
 
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_is_initial_endowment_valid() {
+		assert_eq!(is_initial_endowment_valid("100000".to_string()), true);
+		//assert_eq!(is_initial_endowment_valid("1u64 << 60".to_string()), true);
+		assert_eq!(is_initial_endowment_valid("1 << 60".to_string()), true);
+		// assert_eq!(is_initial_endowment_valid("wrong".to_string()), false);
+		// assert_eq!(is_initial_endowment_valid(" ".to_string()), false);
+	}
 }


### PR DESCRIPTION
Close https://github.com/r0gue-io/pop-cli/issues/38

Verify the user-provided endowment value. 
If the value is a wrong value prompt the user if they want to use the default value: `1u64 << 60`