### PR TITLE
fix: error parsing polkadot version from github API

### DIFF
--- a/crates/pop-parachains/src/up.rs
+++ b/crates/pop-parachains/src/up.rs
@@ -368,12 +368,10 @@ impl Zombienet {
 
 	async fn latest_polkadot_release() -> Result<String, Error> {
 		let repo = Url::parse(POLKADOT_SDK).expect("repository url valid");
-		println!("{:?}", repo);
 		match GitHub::get_latest_releases(&repo).await {
 			Ok(releases) => {
 				// Fetching latest releases
 				for release in releases {
-					println!("{:?}", release.tag_name);
 					if !release.prerelease && release.tag_name.starts_with("polkadot-v") {
 						return Ok(release
 							.tag_name

--- a/crates/pop-parachains/src/up.rs
+++ b/crates/pop-parachains/src/up.rs
@@ -368,8 +368,10 @@ impl Zombienet {
 
 	async fn latest_polkadot_release() -> Result<String, Error> {
 		let repo = Url::parse(POLKADOT_SDK).expect("repository url valid");
+		println!("{:?}", repo);
 		// Fetching latest releases
 		for release in GitHub::get_latest_releases(&repo).await? {
+			println!("{:?}", release.tag_name);
 			if !release.prerelease && release.tag_name.starts_with("polkadot-v") {
 				return Ok(release
 					.tag_name

--- a/crates/pop-parachains/src/up.rs
+++ b/crates/pop-parachains/src/up.rs
@@ -369,18 +369,24 @@ impl Zombienet {
 	async fn latest_polkadot_release() -> Result<String, Error> {
 		let repo = Url::parse(POLKADOT_SDK).expect("repository url valid");
 		println!("{:?}", repo);
-		// Fetching latest releases
-		for release in GitHub::get_latest_releases(&repo).await? {
-			println!("{:?}", release.tag_name);
-			if !release.prerelease && release.tag_name.starts_with("polkadot-v") {
-				return Ok(release
-					.tag_name
-					.strip_prefix("polkadot-")
-					.map_or_else(|| release.tag_name.clone(), |v| v.to_string()));
-			}
+		match GitHub::get_latest_releases(&repo).await {
+			Ok(releases) => {
+				// Fetching latest releases
+				for release in releases {
+					println!("{:?}", release.tag_name);
+					if !release.prerelease && release.tag_name.starts_with("polkadot-v") {
+						return Ok(release
+							.tag_name
+							.strip_prefix("polkadot-")
+							.map_or_else(|| release.tag_name.clone(), |v| v.to_string()));
+					}
+				}
+				// It should never reach this point, but in case we download a default version of polkadot
+				Ok(POLKADOT_DEFAULT_VERSION.to_string())
+			},
+			// If an error with Github API return the POLKADOT DEFAULT VERSION
+			Err(_) => Ok(POLKADOT_DEFAULT_VERSION.to_string()),
 		}
-		// It should never reach this point, but in case we download a default version of polkadot
-		Ok(POLKADOT_DEFAULT_VERSION.to_string())
 	}
 }
 

--- a/crates/pop-parachains/src/utils/git.rs
+++ b/crates/pop-parachains/src/utils/git.rs
@@ -150,8 +150,6 @@ impl GitHub {
 			concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
 		let client = reqwest::ClientBuilder::new().user_agent(APP_USER_AGENT).build()?;
-		println!("https://api.github.com/repos/{}/{}/releases", Self::org(repo)?,
-		Self::name(repo)?);
 		let response = client
 			.get(format!(
 				"https://api.github.com/repos/{}/{}/releases",
@@ -160,7 +158,6 @@ impl GitHub {
 			))
 			.send()
 			.await?;
-		println!("Response");
 		Ok(response.json::<Vec<Release>>().await?)
 	}
 

--- a/crates/pop-parachains/src/utils/git.rs
+++ b/crates/pop-parachains/src/utils/git.rs
@@ -150,6 +150,8 @@ impl GitHub {
 			concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
 		let client = reqwest::ClientBuilder::new().user_agent(APP_USER_AGENT).build()?;
+		println!("https://api.github.com/repos/{}/{}/releases", Self::org(repo)?,
+		Self::name(repo)?);
 		let response = client
 			.get(format!(
 				"https://api.github.com/repos/{}/{}/releases",
@@ -158,6 +160,7 @@ impl GitHub {
 			))
 			.send()
 			.await?;
+		println!("Response");
 		Ok(response.json::<Vec<Release>>().await?)
 	}
 


### PR DESCRIPTION
Close: https://github.com/r0gue-io/pop-cli/issues/138

In `pop up parachain` we are getting the last Polkadot release from the GitHub API. If there is something wrong with this call (for example:  IP blocked by Github due to rate limit), return at least a default version