### PR TITLE
test: ensure errors propagated

### DIFF
--- a/crates/pop-cli/src/commands/new/contract.rs
+++ b/crates/pop-cli/src/commands/new/contract.rs
@@ -68,9 +68,7 @@ mod tests {
 			name: "test_contract".to_string(),
 			path: Some(PathBuf::from(temp_contract_dir.path())),
 		};
-		let result = command.execute().await;
-		assert!(result.is_ok());
-
+		command.execute().await?;
 		Ok(())
 	}
 }

--- a/crates/pop-cli/src/commands/new/parachain.rs
+++ b/crates/pop-cli/src/commands/new/parachain.rs
@@ -346,32 +346,32 @@ mod tests {
 	}
 
 	#[test]
-	fn test_is_template_supported() {
-		assert!(is_template_supported(&Provider::Pop, &Template::Base).is_ok());
+	fn test_is_template_supported() -> Result<()> {
+		is_template_supported(&Provider::Pop, &Template::Base)?;
 		assert!(is_template_supported(&Provider::Pop, &Template::ParityContracts).is_err());
 		assert!(is_template_supported(&Provider::Pop, &Template::ParityFPT).is_err());
 
 		assert!(is_template_supported(&Provider::Parity, &Template::Base).is_err());
-		assert!(is_template_supported(&Provider::Parity, &Template::ParityContracts).is_ok());
-		assert!(is_template_supported(&Provider::Parity, &Template::ParityFPT).is_ok());
+		is_template_supported(&Provider::Parity, &Template::ParityContracts)?;
+		is_template_supported(&Provider::Parity, &Template::ParityFPT)
 	}
 
 	#[test]
-	fn test_get_customization_values() {
+	fn test_get_customization_values() -> Result<()> {
 		let config = get_customization_value(
 			&Template::Base,
 			Some("DOT".to_string()),
 			Some(6),
 			Some("10000".to_string()),
-		);
-		assert!(config.is_ok());
+		)?;
 		assert_eq!(
-			config.unwrap(),
+			config,
 			Config {
 				symbol: "DOT".to_string(),
 				decimals: 6,
 				initial_endowment: "10000".to_string()
 			}
 		);
+		Ok(())
 	}
 }

--- a/crates/pop-contracts/src/build.rs
+++ b/crates/pop-contracts/src/build.rs
@@ -27,9 +27,7 @@ mod tests {
 		let temp_dir = tempfile::tempdir().expect("Could not create temp dir");
 		let temp_contract_dir = temp_dir.path().join("test_contract");
 		fs::create_dir(&temp_contract_dir)?;
-		let result = crate::create_smart_contract("test_contract", temp_contract_dir.as_path());
-		assert!(result.is_ok(), "Contract test environment setup failed");
-
+		crate::create_smart_contract("test_contract", temp_contract_dir.as_path())?;
 		Ok(temp_dir)
 	}
 
@@ -37,8 +35,7 @@ mod tests {
 	fn test_contract_build() -> Result<(), Error> {
 		let temp_contract_dir = setup_test_environment()?;
 
-		let build = build_smart_contract(&Some(temp_contract_dir.path().join("test_contract")));
-		assert!(build.is_ok(), "Result should be Ok");
+		build_smart_contract(&Some(temp_contract_dir.path().join("test_contract")))?;
 
 		// Verify that the folder target has been created
 		assert!(temp_contract_dir.path().join("test_contract/target").exists());

--- a/crates/pop-contracts/src/call.rs
+++ b/crates/pop-contracts/src/call.rs
@@ -147,9 +147,7 @@ mod tests {
 		let temp_dir = tempfile::tempdir().expect("Could not create temp dir");
 		let temp_contract_dir = temp_dir.path().join("test_contract");
 		fs::create_dir(&temp_contract_dir)?;
-		let result = create_smart_contract("test_contract", temp_contract_dir.as_path());
-		assert!(result.is_ok(), "Contract test environment setup failed");
-
+		create_smart_contract("test_contract", temp_contract_dir.as_path())?;
 		Ok(temp_dir)
 	}
 	fn build_smart_contract_test_environment(temp_dir: &TempDir) -> Result<(), Error> {
@@ -174,10 +172,8 @@ mod tests {
 			suri: "//Alice".to_string(),
 			execute: false,
 		};
-		let call = set_up_call(call_opts).await;
-		assert!(call.is_ok());
-		assert_eq!(call.unwrap().message(), "get");
-
+		let call = set_up_call(call_opts).await?;
+		assert_eq!(call.message(), "get");
 		Ok(())
 	}
 

--- a/crates/pop-contracts/src/test.rs
+++ b/crates/pop-contracts/src/test.rs
@@ -27,27 +27,12 @@ mod tests {
 	use super::*;
 	use std::fs;
 	use tempfile;
-	use thiserror::Error;
-
-	#[derive(Error, Debug)]
-	pub enum Error {
-		#[error("Error in test: {0}")]
-		TestEnvironmentError(String),
-	}
 
 	fn setup_test_environment() -> Result<tempfile::TempDir, Error> {
-		let temp_dir = tempfile::tempdir().map_err(|e| {
-			Error::TestEnvironmentError(format!("Failed to create temp dir: {}", e))
-		})?;
+		let temp_dir = tempfile::tempdir()?;
 		let temp_contract_dir = temp_dir.path().join("test_contract");
-		fs::create_dir(&temp_contract_dir).map_err(|e| {
-			Error::TestEnvironmentError(format!("Failed to create test contract directory: {}", e))
-		})?;
-		let result = crate::create_smart_contract("test_contract", temp_contract_dir.as_path())
-			.map_err(|e| {
-				Error::TestEnvironmentError(format!("Failed to create smart contract: {}", e))
-			});
-		assert!(result.is_ok(), "Contract test environment setup failed");
+		fs::create_dir(&temp_contract_dir)?;
+		crate::create_smart_contract("test_contract", temp_contract_dir.as_path())?;
 		Ok(temp_dir)
 	}
 
@@ -55,8 +40,7 @@ mod tests {
 	fn test_contract_test() -> Result<(), Error> {
 		let temp_contract_dir = setup_test_environment()?;
 		// Run unit tests for the smart contract in the temporary contract directory.
-		let result = test_smart_contract(&Some(temp_contract_dir.path().join("test_contract")));
-		assert!(result.is_ok(), "Result should be Ok");
+		test_smart_contract(&Some(temp_contract_dir.path().join("test_contract")))?;
 		Ok(())
 	}
 }

--- a/crates/pop-contracts/src/up.rs
+++ b/crates/pop-contracts/src/up.rs
@@ -113,9 +113,7 @@ mod tests {
 		let temp_dir = tempfile::tempdir().expect("Could not create temp dir");
 		let temp_contract_dir = temp_dir.path().join("test_contract");
 		fs::create_dir(&temp_contract_dir)?;
-		let result = create_smart_contract("test_contract", temp_contract_dir.as_path());
-		assert!(result.is_ok(), "Contract test environment setup failed");
-
+		create_smart_contract("test_contract", temp_contract_dir.as_path())?;
 		Ok(temp_dir)
 	}
 	fn build_smart_contract_test_environment(temp_dir: &TempDir) -> Result<(), Error> {
@@ -139,9 +137,8 @@ mod tests {
 			suri: "//Alice".to_string(),
 			salt: None,
 		};
-		let result = set_up_deployment(call_opts).await;
-		assert!(result.is_ok());
-		assert_eq!(result.unwrap().url(), "wss://rococo-contracts-rpc.polkadot.io:443/");
+		let result = set_up_deployment(call_opts).await?;
+		assert_eq!(result.url(), "wss://rococo-contracts-rpc.polkadot.io:443/");
 		Ok(())
 	}
 
@@ -163,9 +160,7 @@ mod tests {
 		};
 		let instantiate_exec = set_up_deployment(call_opts).await;
 
-		let result = dry_run_gas_estimate_instantiate(&instantiate_exec.unwrap()).await;
-		assert!(result.is_ok());
-		let weight = result.unwrap();
+		let weight = dry_run_gas_estimate_instantiate(&instantiate_exec.unwrap()).await?;
 		assert!(weight.clone().ref_time() > 0);
 		assert!(weight.proof_size() > 0);
 

--- a/crates/pop-contracts/src/utils/helpers.rs
+++ b/crates/pop-contracts/src/utils/helpers.rs
@@ -38,18 +38,14 @@ mod tests {
 		let temp_dir = tempfile::tempdir().expect("Could not create temp dir");
 		let temp_contract_dir = temp_dir.path().join("test_contract");
 		fs::create_dir(&temp_contract_dir)?;
-		let result = crate::create_smart_contract("test_contract", temp_contract_dir.as_path());
-		assert!(result.is_ok(), "Contract test environment setup failed");
-
+		crate::create_smart_contract("test_contract", temp_contract_dir.as_path())?;
 		Ok(temp_dir)
 	}
 
 	#[test]
 	fn test_get_manifest_path() -> Result<(), Error> {
 		let temp_dir = setup_test_environment()?;
-		let manifest_path =
-			get_manifest_path(&Some(PathBuf::from(temp_dir.path().join("test_contract"))));
-		assert!(manifest_path.is_ok());
+		get_manifest_path(&Some(PathBuf::from(temp_dir.path().join("test_contract"))))?;
 		Ok(())
 	}
 }

--- a/crates/pop-parachains/src/new_pallet.rs
+++ b/crates/pop-parachains/src/new_pallet.rs
@@ -73,7 +73,7 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn test_pallet_create_template() {
+	fn test_pallet_create_template() -> Result<(), Error> {
 		let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
 		let pallet_name = "MyPallet";
 		let config = TemplatePalletConfig {
@@ -83,11 +83,7 @@ mod tests {
 		};
 
 		// Call the function being tested
-		let result =
-			create_pallet_template(Some(temp_dir.path().to_str().unwrap().to_string()), config);
-
-		// Assert that the result is Ok
-		assert!(result.is_ok(), "Result should be Ok");
+		create_pallet_template(Some(temp_dir.path().to_str().unwrap().to_string()), config)?;
 
 		// Assert that the pallet structure is generated
 		let pallet_path = temp_dir.path().join(pallet_name);
@@ -105,6 +101,7 @@ mod tests {
 		let lib_rs_content = fs::read_to_string(pallet_path.join("src").join("lib.rs"))
 			.expect("Failed to read lib.rs");
 		assert!(lib_rs_content.contains("pub mod pallet"), "lib.rs should contain pub mod pallet");
+		Ok(())
 	}
 
 	#[test]

--- a/crates/pop-parachains/src/new_parachain.rs
+++ b/crates/pop-parachains/src/new_parachain.rs
@@ -80,9 +80,7 @@ mod tests {
 			decimals: 18,
 			initial_endowment: "1000000".to_string(),
 		};
-		let result: anyhow::Result<Option<String>> =
-			instantiate_base_template(temp_dir.path(), config, None);
-		assert!(result.is_ok());
+		instantiate_base_template(temp_dir.path(), config, None)?;
 		Ok(temp_dir)
 	}
 

--- a/crates/pop-parachains/src/up.rs
+++ b/crates/pop-parachains/src/up.rs
@@ -826,9 +826,7 @@ mod tests {
 		)
 		.await?;
 
-		let config = zombienet.configure();
-		assert!(config.is_ok());
-
+		zombienet.configure()?;
 		Ok(())
 	}
 
@@ -851,9 +849,7 @@ mod tests {
 			binary.source(&cache, ()).await?;
 		}
 
-		let spawn = zombienet.spawn().await;
-		assert!(spawn.is_ok());
-
+		zombienet.spawn().await?;
 		Ok(())
 	}
 
@@ -887,8 +883,7 @@ mod tests {
 			version: TESTING_POLKADOT_VERSION.to_string(),
 			url: "https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.7.0/polkadot".to_string()
 		};
-		let result = source.process(&cache, ()).await;
-		assert!(result.is_ok());
+		source.process(&cache, ()).await?;
 		assert!(temp_dir.path().join(POLKADOT_BINARY).exists());
 
 		Ok(())
@@ -913,8 +908,7 @@ mod tests {
 			version: Some(version),
 		};
 
-		let result = source.process(&cache, ()).await;
-		assert!(result.is_ok());
+		source.process(&cache, ()).await?;
 		assert!(temp_dir.path().join(POLKADOT_BINARY).exists());
 
 		Ok(())


### PR DESCRIPTION
Existing implementation was not propagating errors encountered whilst running tests, making debugging when running via CI harder. All tests should now fail with the actual error encountered.