### PR TITLE
chore: update para id

### DIFF
--- a/crates/pop-parachains/src/up.rs
+++ b/crates/pop-parachains/src/up.rs
@@ -913,7 +913,7 @@ mod tests {
 				name = "asset-hub"
 				
 				[[parachains]]
-				id = 9090
+				id = 4385
 				default_command = "pop-node"
 				
 				[[parachains.collators]]

--- a/tests/zombienet.toml
+++ b/tests/zombienet.toml
@@ -17,7 +17,7 @@ chain = "asset-hub-rococo-local"
 name = "asset-hub"
 
 [[parachains]]
-id = 9090
+id = 4385
 default_command = "pop-node"
 
 [[parachains.collators]]


### PR DESCRIPTION
Uses rococo para id until we can replace with paseo-local.