### PR TITLE
build(deps): use git2 vendored-openssl feature

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,0 +1,27 @@
+name: pop install
+
+on:
+  push:
+    branches: [ "main", "frank/fix-deps" ]
+  pull_request:
+    branches: [ "main" ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    container: ubuntu
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install prerequisites
+        run: apt-get update && apt-get -y install build-essential cmake curl git
+      - name: Install Rust
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - name: Install Pop
+        run: |
+          . "$HOME/.cargo/env"
+          cargo install --locked --path ./crates/pop-cli
+          pop

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -2,7 +2,7 @@ name: pop install
 
 on:
   push:
-    branches: [ "main", "frank/fix-deps" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -24,4 +24,4 @@ jobs:
         run: |
           . "$HOME/.cargo/env"
           cargo install --locked --path ./crates/pop-cli
-          pop
+          pop --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         run: rustup target add ${{ matrix.platform.target }}
 
       - name: Build pop-cli
-        run: cargo build --profile=production -p pop-cli --target ${{ matrix.platform.target }} --features static-ssl
+        run: cargo build --profile=production -p pop-cli --target ${{ matrix.platform.target }}
 
       - name: Package binary (Linux)
         if: contains(matrix.platform.target, 'linux')

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -30,7 +30,7 @@ sp-weights = { workspace = true, optional = true }
 # parachains
 pop-parachains = { path = "../pop-parachains", optional = true }
 dirs = { version = "5.0", optional = true }
-git2.workspace = true
+git2 = { workspace = true, features = ["vendored-openssl"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.14"
@@ -38,7 +38,6 @@ predicates = "3.1.0"
 
 [features]
 default = ["contract", "parachain"]
-static-ssl = ["git2/vendored-openssl"]
 contract = [
     "dep:pop-contracts",
     "dep:sp-core",


### PR DESCRIPTION
Also adds a workflow for checking install of the current branch using a standard ubuntu container, which can be replicated for other flavours of Linux. The final command can then simply become `pop install` once that feature is ready.