### PR TITLE
ci: add code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build & Test Pop-CLI
+name: ci
 
 on:
   push:
@@ -49,8 +49,31 @@ jobs:
           git-user: ${{ env.GITHUB_ACTOR }}
 
       - name: Run unit tests
-        run: cargo test --lib
+        run: cargo test --lib --bins
 
+  coverage:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: "./.github/actions/init"
+        with:
+          git-user: ${{ env.GITHUB_ACTOR }}
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lib --bins --codecov --output-path codecov.json
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov.json
+          fail_ci_if_error: true
+  
   contract-integration-tests:
     needs: lint
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+# https://docs.codecov.com/docs/common-recipe-list
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+comment:
+  layout: " diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+  hide_project_coverage: false


### PR DESCRIPTION
Adds code coverage checks.

Coverage report from this branch at https://app.codecov.io/gh/r0gue-io/pop-cli/tree/frank%2Fcode-coverage.