### PR TITLE
build(deps): update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,8 +755,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
  "bitcoin_hashes 0.11.0",
- "rand",
- "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -1315,9 +1313,9 @@ checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
 
 [[package]]
 name = "contract-build"
-version = "4.0.2"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1419d360c4519b3995a7e390f0f6a72a386c2cfb9a187f1114a3e9c719e02c1"
+checksum = "d30f629d8cb26692c4e5f4155e8ab37649f1b2fd0abab64a4c1b3c95c9bcf3df"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1355,13 +1353,12 @@ dependencies = [
 
 [[package]]
 name = "contract-extrinsics"
-version = "4.0.2"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0cd1533705bd07c376992b9dfc31751da41376450da0481f6c89f864d7847a"
+checksum = "c4b1840f7218ce4c7b7ba6e97f23e9e9a814710ff1cfe44e69215b42651539cd"
 dependencies = [
  "anyhow",
  "blake2",
- "clap",
  "colored",
  "contract-build",
  "contract-metadata",
@@ -1378,10 +1375,10 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core 30.0.0",
- "sp-runtime 33.0.0",
- "sp-weights 29.0.0",
- "subxt 0.34.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-weights",
+ "subxt",
  "tokio",
  "tracing",
  "url",
@@ -1389,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "contract-metadata"
-version = "4.0.2"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b31736c09a0d23fec6263686d4bce595634faeed1875520fecf191985f7a2db"
+checksum = "dd54ed69476dc2076d6ebda17351babe1c2f33751170877f66719e8129078d3a"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -1403,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "4.0.2"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e17348a8e977b53dbdc8fde57861726f98fbb89eee36d8884c85b9838769430"
+checksum = "6c7e979c22d15a6b0615b039bf69427bc0f96c6a984943fa4f4e91149ac2712e"
 dependencies = [
  "anyhow",
  "base58",
@@ -1570,16 +1567,6 @@ name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "generic-array",
  "subtle",
@@ -3036,17 +3023,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac 0.11.0",
+ "crypto-mac",
  "digest 0.9.0",
 ]
 
@@ -3712,47 +3689,14 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9579d0ca9fb30da026bac2f0f7d9576ec93489aeb7cd4971dd5b4617d82c79b2"
-dependencies = [
- "jsonrpsee-client-transport 0.21.0",
- "jsonrpsee-core 0.21.0",
- "jsonrpsee-http-client 0.21.0",
- "jsonrpsee-types 0.21.0",
-]
-
-[[package]]
-name = "jsonrpsee"
 version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
 dependencies = [
- "jsonrpsee-client-transport 0.22.5",
- "jsonrpsee-core 0.22.5",
- "jsonrpsee-http-client 0.22.5",
- "jsonrpsee-types 0.22.5",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9f9ed46590a8d5681975f126e22531698211b926129a40a2db47cbca429220"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "jsonrpsee-core 0.21.0",
- "pin-project",
- "rustls-native-certs 0.7.0",
- "rustls-pki-types",
- "soketto",
- "thiserror",
- "tokio",
- "tokio-rustls 0.25.0",
- "tokio-util",
- "tracing",
- "url",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -3763,7 +3707,7 @@ checksum = "4978087a58c3ab02efc5b07c5e5e2803024536106fd5506f558db172c889b3aa"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "jsonrpsee-core 0.22.5",
+ "jsonrpsee-core",
  "pin-project",
  "rustls-native-certs 0.7.0",
  "rustls-pki-types",
@@ -3774,30 +3718,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "776d009e2f591b78c038e0d053a796f94575d66ca4e77dd84bfc5e81419e436c"
-dependencies = [
- "anyhow",
- "async-lock 3.3.0",
- "async-trait",
- "beef",
- "futures-timer",
- "futures-util",
- "hyper 0.14.28",
- "jsonrpsee-types 0.21.0",
- "pin-project",
- "rustc-hash",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
 ]
 
 [[package]]
@@ -3812,7 +3732,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hyper 0.14.28",
- "jsonrpsee-types 0.22.5",
+ "jsonrpsee-types",
  "pin-project",
  "rustc-hash",
  "serde",
@@ -3825,26 +3745,6 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b7de9f3219d95985eb77fd03194d7c1b56c19bce1abfcc9d07462574b15572"
-dependencies = [
- "async-trait",
- "hyper 0.14.28",
- "hyper-rustls",
- "jsonrpsee-core 0.21.0",
- "jsonrpsee-types 0.21.0",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tower",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
 version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ccf93fc4a0bfe05d851d37d7c32b7f370fe94336b52a2f0efc5f1981895c2e5"
@@ -3852,8 +3752,8 @@ dependencies = [
  "async-trait",
  "hyper 0.14.28",
  "hyper-rustls",
- "jsonrpsee-core 0.22.5",
- "jsonrpsee-types 0.22.5",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "serde",
  "serde_json",
  "thiserror",
@@ -3861,19 +3761,6 @@ dependencies = [
  "tower",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3266dfb045c9174b24c77c2dfe0084914bb23a6b2597d70c9dc6018392e1cd1b"
-dependencies = [
- "anyhow",
- "beef",
- "serde",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -4991,15 +4878,6 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pbkdf2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
-dependencies = [
- "crypto-mac 0.11.0",
-]
-
-[[package]]
-name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
@@ -5388,8 +5266,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sp-core 30.0.0",
- "sp-weights 29.0.0",
+ "sp-core",
+ "sp-weights",
  "strum 0.26.2",
  "strum_macros 0.26.2",
  "tempfile",
@@ -5406,10 +5284,10 @@ dependencies = [
  "contract-extrinsics",
  "duct",
  "ink_env",
- "sp-core 30.0.0",
- "sp-weights 29.0.0",
- "subxt 0.34.0",
- "subxt-signer 0.34.0",
+ "sp-core",
+ "sp-weights",
+ "subxt",
+ "subxt-signer",
  "tempfile",
  "thiserror",
  "tokio",
@@ -6195,7 +6073,6 @@ checksum = "036575c29af9b6e4866ffb7fa055dbf623fe7a9cc159b33786de6013a6969d89"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde",
 ]
 
 [[package]]
@@ -6218,7 +6095,6 @@ checksum = "7caaf753f8ed1ab4752c6afb20174f03598c664724e0e32628e161c21000ff76"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
- "primitive-types",
  "scale-bits 0.4.0",
  "scale-decode-derive 0.10.0",
  "scale-info",
@@ -6273,8 +6149,6 @@ checksum = "6d70cb4b29360105483fac1ed567ff95d65224a14dd275b6303ed0a654c78de5"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
- "primitive-types",
- "scale-bits 0.4.0",
  "scale-encode-derive 0.5.0",
  "scale-info",
  "smallvec",
@@ -6360,19 +6234,6 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00860983481ac590ac87972062909bef0d6a658013b592ccc0f2feb272feab11"
-dependencies = [
- "proc-macro2",
- "quote",
- "scale-info",
- "syn 2.0.58",
- "thiserror",
-]
-
-[[package]]
-name = "scale-typegen"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d470fa75e71b12b3244a4113adc4bc49891f3daba2054703cacd06256066397e"
@@ -6382,26 +6243,6 @@ dependencies = [
  "scale-info",
  "syn 2.0.58",
  "thiserror",
-]
-
-[[package]]
-name = "scale-value"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58223c7691bf0bd46b43c9aea6f0472d1067f378d574180232358d7c6e0a8089"
-dependencies = [
- "base58",
- "blake2",
- "derive_more",
- "either",
- "frame-metadata 15.1.0",
- "parity-scale-codec",
- "scale-bits 0.4.0",
- "scale-decode 0.10.0",
- "scale-encode 0.5.0",
- "scale-info",
- "serde",
- "yap",
 ]
 
 [[package]]
@@ -6664,9 +6505,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
@@ -7017,7 +6858,7 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "num-traits",
- "pbkdf2 0.12.2",
+ "pbkdf2",
  "pin-project",
  "poly1305",
  "rand",
@@ -7134,20 +6975,6 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b4b7b12922cb90cf8dff0cab14087ba0ca25c1f04ba060c7294ce42c78d89ab"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 30.0.0",
- "sp-io 32.0.0",
- "sp-std",
-]
-
-[[package]]
-name = "sp-application-crypto"
 version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13ca6121c22c8bd3d1dce1f05c479101fd0d7b159bef2a3e8c834138d839c75c"
@@ -7155,8 +6982,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
+ "sp-core",
+ "sp-io",
  "sp-std",
 ]
 
@@ -7173,52 +7000,6 @@ dependencies = [
  "serde",
  "sp-std",
  "static_assertions",
-]
-
-[[package]]
-name = "sp-core"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "586e0d5185e4545f465fc9a04fb9c4572d3e294137312496db2b67b0bb579e1f"
-dependencies = [
- "array-bytes",
- "bip39",
- "bitflags 1.3.2",
- "blake2",
- "bounded-collections",
- "bs58",
- "dyn-clonable",
- "ed25519-zebra 3.1.0",
- "futures",
- "hash-db",
- "hash256-std-hasher",
- "impl-serde",
- "itertools 0.10.5",
- "libsecp256k1",
- "log",
- "merlin",
- "parity-scale-codec",
- "parking_lot",
- "paste",
- "primitive-types",
- "rand",
- "scale-info",
- "schnorrkel",
- "secp256k1",
- "secrecy",
- "serde",
- "sp-crypto-hashing",
- "sp-debug-derive",
- "sp-externalities",
- "sp-runtime-interface",
- "sp-std",
- "sp-storage",
- "ss58-registry",
- "substrate-bip39 0.4.6",
- "thiserror",
- "tracing",
- "w3f-bls",
- "zeroize",
 ]
 
 [[package]]
@@ -7261,25 +7042,11 @@ dependencies = [
  "sp-std",
  "sp-storage",
  "ss58-registry",
- "substrate-bip39 0.5.0",
+ "substrate-bip39",
  "thiserror",
  "tracing",
  "w3f-bls",
  "zeroize",
-]
-
-[[package]]
-name = "sp-core-hashing"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0f4990add7b2cefdeca883c0efa99bb4d912cb2196120e1500c0cc099553b0"
-dependencies = [
- "blake2b_simd",
- "byteorder",
- "digest 0.10.7",
- "sha2 0.10.8",
- "sha3",
- "twox-hash",
 ]
 
 [[package]]
@@ -7321,32 +7088,6 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca29e042628cb94cbcaefa935e624a9b48f9230dbce6324908e9b4f768317ef"
-dependencies = [
- "bytes",
- "ed25519-dalek",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "rustversion",
- "secp256k1",
- "sp-core 30.0.0",
- "sp-crypto-hashing",
- "sp-externalities",
- "sp-keystore 0.36.0",
- "sp-runtime-interface",
- "sp-state-machine 0.37.0",
- "sp-std",
- "sp-tracing",
- "sp-trie 31.0.0",
- "tracing",
- "tracing-core",
-]
-
-[[package]]
-name = "sp-io"
 version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e09bba780b55bd9e67979cd8f654a31e4a6cf45426ff371394a65953d2177f2"
@@ -7359,29 +7100,17 @@ dependencies = [
  "polkavm-derive 0.9.1",
  "rustversion",
  "secp256k1",
- "sp-core 31.0.0",
+ "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-keystore 0.37.0",
+ "sp-keystore",
  "sp-runtime-interface",
- "sp-state-machine 0.38.0",
+ "sp-state-machine",
  "sp-std",
  "sp-tracing",
- "sp-trie 32.0.0",
+ "sp-trie",
  "tracing",
  "tracing-core",
-]
-
-[[package]]
-name = "sp-keystore"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd4bf9e5fa486416c92c2bb497b7ce2c43eac80cbdc407ffe2d34b365694ac29"
-dependencies = [
- "parity-scale-codec",
- "parking_lot",
- "sp-core 30.0.0",
- "sp-externalities",
 ]
 
 [[package]]
@@ -7392,7 +7121,7 @@ checksum = "bdbab8b61bd61d5f8625a0c75753b5d5a23be55d3445419acd42caf59cf6236b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
- "sp-core 31.0.0",
+ "sp-core",
  "sp-externalities",
 ]
 
@@ -7405,31 +7134,6 @@ dependencies = [
  "backtrace",
  "lazy_static",
  "regex",
-]
-
-[[package]]
-name = "sp-runtime"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28fcf8f53d917e420e783dd27d06fd276f55160301c5bc977cc5898c4130f6f"
-dependencies = [
- "docify",
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "paste",
- "rand",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 32.0.0",
- "sp-arithmetic",
- "sp-core 30.0.0",
- "sp-io 32.0.0",
- "sp-std",
- "sp-weights 29.0.0",
 ]
 
 [[package]]
@@ -7449,12 +7153,12 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 33.0.0",
+ "sp-application-crypto",
  "sp-arithmetic",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
+ "sp-core",
+ "sp-io",
  "sp-std",
- "sp-weights 30.0.0",
+ "sp-weights",
 ]
 
 [[package]]
@@ -7493,28 +7197,6 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ae47765916d342b53d07be012a71efc4c1377d875ade31340cc4fb784b9921"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "parking_lot",
- "rand",
- "smallvec",
- "sp-core 30.0.0",
- "sp-externalities",
- "sp-panic-handler",
- "sp-std",
- "sp-trie 31.0.0",
- "thiserror",
- "tracing",
- "trie-db",
-]
-
-[[package]]
-name = "sp-state-machine"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1eae0eac8034ba14437e772366336f579398a46d101de13dbb781ab1e35e67c5"
@@ -7525,11 +7207,11 @@ dependencies = [
  "parking_lot",
  "rand",
  "smallvec",
- "sp-core 31.0.0",
+ "sp-core",
  "sp-externalities",
  "sp-panic-handler",
  "sp-std",
- "sp-trie 32.0.0",
+ "sp-trie",
  "thiserror",
  "tracing",
  "trie-db",
@@ -7570,31 +7252,6 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5791e2e310cf88abedbd5f60ff3d9c9a09d95b182b4a7510f3648a2170ace593"
-dependencies = [
- "ahash 0.8.11",
- "hash-db",
- "lazy_static",
- "memory-db",
- "nohash-hasher",
- "parity-scale-codec",
- "parking_lot",
- "rand",
- "scale-info",
- "schnellru",
- "sp-core 30.0.0",
- "sp-externalities",
- "sp-std",
- "thiserror",
- "tracing",
- "trie-db",
- "trie-root",
-]
-
-[[package]]
-name = "sp-trie"
 version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1aa91ad26c62b93d73e65f9ce7ebd04459c4bad086599348846a81988d6faa4"
@@ -7609,7 +7266,7 @@ dependencies = [
  "rand",
  "scale-info",
  "schnellru",
- "sp-core 31.0.0",
+ "sp-core",
  "sp-externalities",
  "sp-std",
  "thiserror",
@@ -7630,22 +7287,6 @@ dependencies = [
  "parity-scale-codec",
  "sp-std",
  "wasmtime",
-]
-
-[[package]]
-name = "sp-weights"
-version = "29.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8a9c7a1b64fa7dba38622ad1de26f0b2e595727c0e42c7b109ecb8e7120688"
-dependencies = [
- "bounded-collections",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "smallvec",
- "sp-arithmetic",
- "sp-debug-derive",
- "sp-std",
 ]
 
 [[package]]
@@ -7816,25 +7457,12 @@ dependencies = [
 
 [[package]]
 name = "substrate-bip39"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7590dc041b9bc2825e52ce5af8416c73dbe9d0654402bfd4b4941938b94d8f"
-dependencies = [
- "hmac 0.11.0",
- "pbkdf2 0.8.0",
- "schnorrkel",
- "sha2 0.9.9",
- "zeroize",
-]
-
-[[package]]
-name = "substrate-bip39"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b564c293e6194e8b222e52436bcb99f60de72043c7f845cf6c4406db4df121"
 dependencies = [
  "hmac 0.12.1",
- "pbkdf2 0.12.2",
+ "pbkdf2",
  "schnorrkel",
  "sha2 0.10.8",
  "zeroize",
@@ -7845,42 +7473,6 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
-
-[[package]]
-name = "subxt"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3323d5c27898b139d043dc1ee971f602f937b99354ee33ee933bd90e0009fbd"
-dependencies = [
- "async-trait",
- "base58",
- "blake2",
- "derivative",
- "either",
- "frame-metadata 16.0.0",
- "futures",
- "hex",
- "impl-serde",
- "instant",
- "jsonrpsee 0.21.0",
- "parity-scale-codec",
- "primitive-types",
- "scale-bits 0.4.0",
- "scale-decode 0.10.0",
- "scale-encode 0.5.0",
- "scale-info",
- "scale-value 0.13.0",
- "serde",
- "serde_json",
- "sp-core-hashing",
- "subxt-lightclient 0.34.0",
- "subxt-macro 0.34.0",
- "subxt-metadata 0.34.0",
- "thiserror",
- "tokio-util",
- "tracing",
- "url",
-]
 
 [[package]]
 name = "subxt"
@@ -7898,47 +7490,26 @@ dependencies = [
  "hex",
  "impl-serde",
  "instant",
- "jsonrpsee 0.22.5",
+ "jsonrpsee",
  "parity-scale-codec",
  "primitive-types",
  "scale-bits 0.5.0",
  "scale-decode 0.11.1",
  "scale-encode 0.6.0",
  "scale-info",
- "scale-value 0.14.1",
+ "scale-value",
  "serde",
  "serde_json",
- "sp-core 31.0.0",
+ "sp-core",
  "sp-crypto-hashing",
- "sp-runtime 34.0.0",
- "subxt-lightclient 0.35.3",
- "subxt-macro 0.35.3",
- "subxt-metadata 0.35.3",
+ "sp-runtime",
+ "subxt-lightclient",
+ "subxt-macro",
+ "subxt-metadata",
  "thiserror",
  "tokio-util",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "subxt-codegen"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0e58c3f88651cff26aa52bae0a0a85f806a2e923a20eb438c16474990743ea"
-dependencies = [
- "frame-metadata 16.0.0",
- "heck 0.4.1",
- "hex",
- "jsonrpsee 0.21.0",
- "parity-scale-codec",
- "proc-macro2",
- "quote",
- "scale-info",
- "scale-typegen 0.1.1",
- "subxt-metadata 0.34.0",
- "syn 2.0.58",
- "thiserror",
- "tokio",
 ]
 
 [[package]]
@@ -7950,33 +7521,16 @@ dependencies = [
  "frame-metadata 16.0.0",
  "heck 0.4.1",
  "hex",
- "jsonrpsee 0.22.5",
+ "jsonrpsee",
  "parity-scale-codec",
  "proc-macro2",
  "quote",
  "scale-info",
- "scale-typegen 0.2.1",
- "subxt-metadata 0.35.3",
+ "scale-typegen",
+ "subxt-metadata",
  "syn 2.0.58",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "subxt-lightclient"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecec7066ba7bc0c3608fcd1d0c7d9584390990cd06095b6ae4f114f74c4b8550"
-dependencies = [
- "futures",
- "futures-util",
- "serde",
- "serde_json",
- "smoldot-light",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
 ]
 
 [[package]]
@@ -7998,21 +7552,6 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365251668613323064803427af8c7c7bc366cd8b28e33639640757669dafebd5"
-dependencies = [
- "darling 0.20.8",
- "parity-scale-codec",
- "proc-macro-error",
- "quote",
- "scale-typegen 0.1.1",
- "subxt-codegen 0.34.0",
- "syn 2.0.58",
-]
-
-[[package]]
-name = "subxt-macro"
 version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98dc84d7e6a0abd7ed407cce0bf60d7d58004f699460cffb979640717d1ab506"
@@ -8021,22 +7560,9 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro-error",
  "quote",
- "scale-typegen 0.2.1",
- "subxt-codegen 0.35.3",
+ "scale-typegen",
+ "subxt-codegen",
  "syn 2.0.58",
-]
-
-[[package]]
-name = "subxt-metadata"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02aca8d39a1f6c55fff3a8fd81557d30a610fedc1cef03f889a81bc0f8f0b52"
-dependencies = [
- "frame-metadata 16.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core-hashing",
- "thiserror",
 ]
 
 [[package]]
@@ -8055,28 +7581,6 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88a76a5d114bfae2f6f9cc1491c46173ecc3fb2b9e53948eb3c8d43d4b43ab5"
-dependencies = [
- "bip39",
- "hex",
- "hmac 0.12.1",
- "parity-scale-codec",
- "pbkdf2 0.12.2",
- "regex",
- "schnorrkel",
- "secp256k1",
- "secrecy",
- "sha2 0.10.8",
- "sp-core-hashing",
- "subxt 0.34.0",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "subxt-signer"
 version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ccb59a38fe357fab55247756174435e8626b93929864e8a498635a15e779df8"
@@ -8087,14 +7591,14 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "parity-scale-codec",
- "pbkdf2 0.12.2",
+ "pbkdf2",
  "regex",
  "schnorrkel",
  "secp256k1",
  "secrecy",
  "sha2 0.10.8",
  "sp-crypto-hashing",
- "subxt 0.35.3",
+ "subxt",
  "zeroize",
 ]
 
@@ -9498,9 +9002,9 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-opt"
-version = "0.116.0"
+version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc942673e7684671f0c5708fc18993569d184265fd5223bb51fc8e5b9b6cfd52"
+checksum = "2fd87a4c135535ffed86123b6fb0f0a5a0bc89e50416c942c5f0662c645f679c"
 dependencies = [
  "anyhow",
  "libc",
@@ -10178,9 +9682,9 @@ dependencies = [
  "reqwest",
  "serde_json",
  "sha2 0.10.8",
- "sp-core 31.0.0",
- "subxt 0.35.3",
- "subxt-signer 0.35.3",
+ "sp-core",
+ "subxt",
+ "subxt-signer",
  "thiserror",
  "tokio",
  "tracing",
@@ -10242,7 +9746,7 @@ dependencies = [
  "async-trait",
  "futures",
  "lazy_static",
- "subxt 0.35.3",
+ "subxt",
  "tokio",
  "zombienet-configuration",
  "zombienet-orchestrator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
  "bitcoin_hashes 0.11.0",
  "rand",
- "rand_core 0.6.4",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -1993,7 +1993,7 @@ dependencies = [
  "deno_core",
  "deno_native_certs",
  "once_cell",
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "rustls-webpki 0.101.7",
  "serde",
@@ -3261,7 +3261,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.28",
  "log",
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -3961,7 +3961,7 @@ dependencies = [
  "pem",
  "pin-project",
  "rand",
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "secrecy",
  "serde",
@@ -4899,7 +4899,7 @@ checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes 0.13.0",
  "rand",
- "rand_core 0.6.4",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -5035,9 +5035,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -5046,9 +5046,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5056,9 +5056,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
 dependencies = [
  "pest",
  "pest_meta",
@@ -5069,9 +5069,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",
@@ -5839,7 +5839,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -6032,9 +6032,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.11"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
@@ -6044,9 +6044,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring",
@@ -6113,7 +6113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cae64d5219dfdd7f2d18dda421a2137ebdd63be6d0dc53d7836003f224f3d0"
 dependencies = [
  "futures",
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -8716,7 +8716,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -8726,7 +8726,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.3",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
  "bitcoin_hashes 0.11.0",
  "rand",
- "rand_core 0.5.1",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -4899,7 +4899,7 @@ checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes 0.13.0",
  "rand",
- "rand_core 0.5.1",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10146,8 +10146,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-configuration"
-version = "0.2.1"
-source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#34d07c5d52592cc0eda184f7087e2d2795b4b6c9"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dbe5721cebe0be12db36d5efd8c6f0dd473137dc0e3442b81bc79bd64507f70"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -10163,8 +10164,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-orchestrator"
-version = "0.2.1"
-source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#34d07c5d52592cc0eda184f7087e2d2795b4b6c9"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d936c875d7e5c19751711b9e211408950f114444b0ed7d2155e552a239a2419"
 dependencies = [
  "anyhow",
  "futures",
@@ -10191,8 +10193,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-prom-metrics-parser"
-version = "0.2.1"
-source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#34d07c5d52592cc0eda184f7087e2d2795b4b6c9"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b10ecce0d2ae02fb65d9003e961e18c3337a1e9e9dc431499b7b6d1dab984d0"
 dependencies = [
  "pest",
  "pest_derive",
@@ -10201,8 +10204,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-provider"
-version = "0.2.1"
-source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#34d07c5d52592cc0eda184f7087e2d2795b4b6c9"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b6fedfcadd090def727cd626b26c26d1072c44ea516fe781d7c60baf7f4a16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10231,8 +10235,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-sdk"
-version = "0.2.1"
-source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#34d07c5d52592cc0eda184f7087e2d2795b4b6c9"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76345c48a6ca7694935c8e3af91eea71d8950debfa6e61353dbd3f603522cd09"
 dependencies = [
  "async-trait",
  "futures",
@@ -10247,8 +10252,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-support"
-version = "0.2.1"
-source = "git+https://github.com/r0gue-io/zombienet-sdk?branch=pop#34d07c5d52592cc0eda184f7087e2d2795b4b6c9"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b5dbc58de99a397b096acf8f520f547880017e5bea9dc5e5c1ee7719274373"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,7 +1908,7 @@ dependencies = [
  "deno_tls",
  "dyn-clone",
  "http 0.2.12",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "tokio",
  "tokio-util",
@@ -2046,7 +2046,7 @@ dependencies = [
  "deno_net",
  "deno_tls",
  "fastwebsockets",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "hyper 0.14.28",
  "once_cell",
@@ -2935,6 +2935,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hash-db"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,7 +3199,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -3203,6 +3222,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.4",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
@@ -3267,6 +3287,22 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -3593,7 +3629,7 @@ dependencies = [
  "socket2",
  "widestring",
  "windows-sys 0.48.0",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -5263,7 +5299,7 @@ dependencies = [
  "pop-parachains",
  "pop-telemetry",
  "predicates",
- "reqwest",
+ "reqwest 0.12.4",
  "serde",
  "serde_json",
  "sp-core",
@@ -5306,7 +5342,7 @@ dependencies = [
  "indexmap 2.2.6",
  "mockito",
  "regex",
- "reqwest",
+ "reqwest 0.12.4",
  "serde",
  "serde_json",
  "strum 0.26.2",
@@ -5330,7 +5366,7 @@ dependencies = [
  "env_logger",
  "log",
  "mockito",
- "reqwest",
+ "reqwest 0.12.4",
  "serde",
  "serde_json",
  "tempfile",
@@ -5703,12 +5739,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-rustls",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -5736,7 +5772,49 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.1.2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -9548,6 +9626,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9679,7 +9767,7 @@ dependencies = [
  "multiaddr",
  "pjs-rs",
  "rand",
- "reqwest",
+ "reqwest 0.11.27",
  "serde_json",
  "sha2 0.10.8",
  "sp-core",
@@ -9721,7 +9809,7 @@ dependencies = [
  "kube",
  "nix",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -9766,7 +9854,7 @@ dependencies = [
  "nix",
  "rand",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "thiserror",
  "tokio",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ duct = "0.13"
 git2 = { version = "0.18", features = ["vendored-openssl"] }
 log = "0.4.20"
 mockito = "1.4.0"
-tempfile = "3.8"
+tempfile = "3.10"
 thiserror = "1.0.58"
 
 # networking
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 url = "2.5"
 
@@ -45,8 +45,8 @@ contract-extrinsics = "4.1"
 
 # parachains
 askama = "0.12"
-regex = "1.5.4"
-walkdir = "2.4"
+regex = "1.10"
+walkdir = "2.5"
 indexmap = "2.2"
 toml_edit = { version = "0.22", features = ["serde"] }
 symlink = "0.1"
@@ -57,7 +57,7 @@ zombienet-support = "0.2"
 git2_credentials = "0.13.0"
 
 # pop-cli
-clap = { version = "4.4", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 cliclack = "0.2"
 console = "0.15"
 strum = "0.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,25 +32,25 @@ thiserror = "1.0.58"
 # networking
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-url = { version = "2.5" }
+url = "2.5"
 
 # contracts
 subxt-signer = { version = "0.34.0", features = ["subxt", "sr25519"] }
-subxt = { version = "0.34.0" }
-ink_env = { version = "5.0.0-rc.2" }
-sp-core = { version = "30.0.0" }
-sp-weights = { version = "29.0.0" }
-contract-build = { version = "4.0.2" }
-contract-extrinsics = { version = "4.0.0-rc.3" }
+subxt = "0.34.0"
+ink_env = "5.0.0-rc.2"
+sp-core = "30.0.0"
+sp-weights = "29.0.0"
+contract-build = "4.0.2"
+contract-extrinsics = "4.0.0-rc.3"
 
 # parachains
 askama = "0.12"
 regex = "1.5.4"
 walkdir = "2.4"
-indexmap = { version = "2.2" }
+indexmap = "2.2"
 toml_edit = { version = "0.22", features = ["serde"] }
-symlink = { version = "0.1" }
-serde_json = { version = "1.0" }
+symlink = "0.1"
+serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 zombienet-sdk = "0.2"
 zombienet-support = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,8 @@ toml_edit = { version = "0.22", features = ["serde"] }
 symlink = { version = "0.1" }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
-zombienet-sdk = { git = "https://github.com/r0gue-io/zombienet-sdk", branch = "pop" }
-zombienet-support = { git = "https://github.com/r0gue-io/zombienet-sdk", branch = "pop" }
+zombienet-sdk = "0.2"
+zombienet-support = "0.2"
 git2_credentials = "0.13.0"
 
 # pop-cli

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,13 +35,13 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 url = "2.5"
 
 # contracts
-subxt-signer = { version = "0.34.0", features = ["subxt", "sr25519"] }
-subxt = "0.34.0"
-ink_env = "5.0.0-rc.2"
-sp-core = "30.0.0"
-sp-weights = "29.0.0"
-contract-build = "4.0.2"
-contract-extrinsics = "4.0.0-rc.3"
+subxt-signer = { version = "0.35", features = ["subxt", "sr25519"] }
+subxt = "0.35"
+ink_env = "5.0.0"
+sp-core = "31"
+sp-weights = "30"
+contract-build = "4.1"
+contract-extrinsics = "4.1"
 
 # parachains
 askama = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,16 @@ members = ["crates/*"]
 
 [workspace.package]
 edition = "2021"
-license = "GPL-3"
+license = "GPL-3.0"
 
 [workspace.dependencies]
 anyhow = "1.0"
+assert_cmd = "2.0.14"
+predicates = "3.1.0"
 dirs = "5.0"
 env_logger = "0.11.1"
 duct = "0.13"
-git2 = "0.18"
+git2 = { version = "0.18", features = ["vendored-openssl"] }
 log = "0.4.20"
 mockito = "1.4.0"
 tempfile = "3.8"

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -35,15 +35,15 @@ sp-weights = { workspace = true, optional = true }
 
 # parachains
 pop-parachains = { path = "../pop-parachains", optional = true }
-dirs = { version = "5.0", optional = true }
-git2 = { workspace = true, features = ["vendored-openssl"] }
+dirs = { workspace = true, optional = true }
+git2.workspace = true
 
 # telemetry
 pop-telemetry = { path = "../pop-telemetry", optional = true }
 
 [dev-dependencies]
-assert_cmd = "2.0.14"
-predicates = "3.1.0"
+assert_cmd.workspace = true
+predicates.workspace = true
 
 [features]
 default = ["contract", "parachain", "telemetry"]

--- a/crates/pop-contracts/Cargo.toml
+++ b/crates/pop-contracts/Cargo.toml
@@ -9,16 +9,16 @@ edition.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-thiserror.workspace = true
 duct.workspace = true
-url.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
+url.workspace = true
 
-subxt-signer.workspace = true
-subxt.workspace = true
 ink_env.workspace = true
 sp-core.workspace = true
 sp-weights.workspace = true
+subxt-signer.workspace = true
+subxt.workspace = true
 
 # cargo-contracts
 contract-build.workspace = true

--- a/crates/pop-contracts/tests/contract.rs
+++ b/crates/pop-contracts/tests/contract.rs
@@ -12,7 +12,7 @@ fn setup_test_environment() -> std::result::Result<tempfile::TempDir, Error> {
 	let temp_dir = tempfile::tempdir().expect("Could not create temp dir");
 	let temp_contract_dir = temp_dir.path().join("test_contract");
 	fs::create_dir(&temp_contract_dir)?;
-	crate::create_smart_contract("test_contract", temp_contract_dir.as_path())?;
+	create_smart_contract("test_contract", temp_contract_dir.as_path())?;
 	Ok(temp_dir)
 }
 
@@ -65,7 +65,7 @@ async fn test_set_up_deployment() -> std::result::Result<(), Error> {
 		salt: None,
 	};
 	let result = set_up_deployment(call_opts).await?;
-	assert_eq!(result.url(), "wss://rococo-contracts-rpc.polkadot.io:443/");
+	assert_eq!(result.opts().url(), "wss://rococo-contracts-rpc.polkadot.io:443/");
 	Ok(())
 }
 


### PR DESCRIPTION
Bumps dependencies in order:
- address advisories
- use crates.io version of zombienet-sdk
- update contracts related dependencies to release version

Also ensures all dependencies are defined in workspace manifest. 