### PR TITLE
ci: add dependency and license checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,13 @@ jobs:
       - name: Build default features
         run: cargo build
 
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: EmbarkStudios/cargo-deny-action@v1
+
   unit-tests:
     needs: lint
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = ["crates/*"]
 
 [workspace.package]
 edition = "2021"
-license = "GPL-3"
+license = "GPL-3.0"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/deny.toml
+++ b/deny.toml
@@ -12,10 +12,15 @@ allow = [
     "ISC",
     "GPL-3.0",
     "MIT",
-    "OpenSSL",
-    "Unicode-DFS-2016"
+    "MPL-2.0",
+    "Unicode-DFS-2016",
+    "Unlicense"
 ]
 confidence-threshold = 0.93
+
+[[licenses.exceptions]]
+allow = ["OpenSSL"]
+name = "ring"
 
 [[licenses.clarify]]
 name = "ring"

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,14 @@
 [graph]
 all-features = true
 
+# This section is considered when running `cargo deny check advisories`
+[advisories]
+unmaintained = "warn"
+ignore = [
+    { id = "RUSTSEC-2024-0336", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/173" },
+    { id = "RUSTSEC-2023-0071", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/173" },
+]
+
 [licenses]
 allow = [
     "Apache-2.0",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,25 @@
+[graph]
+all-features = true
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSL-1.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "GPL-3.0",
+    "MIT",
+    "OpenSSL",
+    "Unicode-DFS-2016"
+]
+confidence-threshold = 0.93
+
+[[licenses.clarify]]
+name = "ring"
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]


### PR DESCRIPTION
Adds cargo-deny to CI workflow for dependency and license checks.

Note: the list of allowed licenses have not yet been validated in terms of compliance. This should be completed before this PR is accepted.