### PR TITLE
feat(new): add next steps

### DIFF
--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -18,7 +18,7 @@ pub struct BuildContractCommand {
 impl BuildContractCommand {
 	pub(crate) fn execute(&self) -> anyhow::Result<()> {
 		clear_screen()?;
-		intro(format!("{}: Building a contract", style(" Pop CLI ").black().on_magenta()))?;
+		intro(format!("{}: Building your contract", style(" Pop CLI ").black().on_magenta()))?;
 		set_theme(Theme);
 
 		let result_build = build_smart_contract(&self.path)?;

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -2,7 +2,7 @@
 
 use crate::style::{style, Theme};
 use clap::Args;
-use cliclack::{clear_screen, intro, outro, set_theme};
+use cliclack::{clear_screen, intro, log::warning, outro, set_theme};
 use pop_parachains::build_parachain;
 use std::path::PathBuf;
 
@@ -19,8 +19,10 @@ pub struct BuildParachainCommand {
 impl BuildParachainCommand {
 	pub(crate) fn execute(&self) -> anyhow::Result<()> {
 		clear_screen()?;
-		intro(format!("{}: Building a parachain", style(" Pop CLI ").black().on_magenta()))?;
+		intro(format!("{}: Building your parachain", style(" Pop CLI ").black().on_magenta()))?;
 		set_theme(Theme);
+
+		warning("NOTE: this may take some time...")?;
 		build_parachain(&self.path)?;
 
 		outro("Build Completed Successfully!")?;

--- a/crates/pop-cli/src/commands/new/parachain.rs
+++ b/crates/pop-cli/src/commands/new/parachain.rs
@@ -173,11 +173,11 @@ fn generate_parachain_from_template(
 	config: Config,
 ) -> Result<()> {
 	intro(format!(
-		"{}: Generating \"{}\" using {:?} from {:?}!",
+		"{}: Generating \"{}\" using {} from {}!",
 		style(" Pop CLI ").black().on_magenta(),
 		name_template,
-		template,
-		provider
+		template.name(),
+		provider.name()
 	))?;
 
 	let destination_path = check_destination_path(name_template)?;


### PR DESCRIPTION
Improves post-generation UX by showing next steps for building and launching a parachain (provided a network config file exists for the template).

Also includes a link to docs.