### PR TITLE
docs: add missing documentation comments for `pop_contracts` and `pop_parachain` crates

### DIFF
--- a/crates/pop-contracts/README.md
+++ b/crates/pop-contracts/README.md
@@ -1,8 +1,6 @@
 # pop-contracts
 
-A crate for generating, building, deploying and calling [`ink!`](https://github.com/paritytech/ink) Smart Contracts. 
-
-> :information_source: A [crates.io](https://crates.io/crates/pop-contracts) version will be available soon!
+A crate for generating, building, deploying and calling [`ink!`](https://github.com/paritytech/ink) Smart Contracts. Used by [`pop-cli`](https://github.com/r0gue-io/pop-cli).
 
 ## Usage
 

--- a/crates/pop-contracts/src/build.rs
+++ b/crates/pop-contracts/src/build.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use crate::utils::helpers::get_manifest_path;
 
+/// Build the smart contract located in the specified `path`
 pub fn build_smart_contract(path: &Option<PathBuf>) -> anyhow::Result<String> {
 	let manifest_path = get_manifest_path(path)?;
 	// Default values

--- a/crates/pop-contracts/src/call.rs
+++ b/crates/pop-contracts/src/call.rs
@@ -16,6 +16,8 @@ use crate::utils::{
 	helpers::{get_manifest_path, parse_account, parse_balance},
 	signer::create_signer,
 };
+
+/// Attributes for the call command
 pub struct CallOpts {
 	/// Path to the contract build folder.
 	pub path: Option<PathBuf>,
@@ -39,6 +41,12 @@ pub struct CallOpts {
 	pub execute: bool,
 }
 
+/// Prepare the struct for the call to be executed.
+///
+/// # Arguments
+///
+/// * `call_opts` - attributes for the call command.
+///
 pub async fn set_up_call(
 	call_opts: CallOpts,
 ) -> anyhow::Result<CallExec<DefaultConfig, DefaultEnvironment, Keypair>> {
@@ -67,6 +75,12 @@ pub async fn set_up_call(
 	return Ok(call_exec);
 }
 
+/// Simulates a smart contract call without modifying the blockchain.
+///
+/// # Arguments
+///
+/// * `call_exec` - struct with the call to be executed.
+///
 pub async fn dry_run_call(
 	call_exec: &CallExec<DefaultConfig, DefaultEnvironment, Keypair>,
 ) -> anyhow::Result<String> {
@@ -93,6 +107,12 @@ pub async fn dry_run_call(
     }
 }
 
+/// Estimates the gas required for a contract call without modifying the blockchain.
+///
+/// # Arguments
+///
+/// * `call_exec` - struct with the call to be executed.
+///
 pub async fn dry_run_gas_estimate_call(
 	call_exec: &CallExec<DefaultConfig, DefaultEnvironment, Keypair>,
 ) -> anyhow::Result<Weight> {
@@ -116,6 +136,14 @@ pub async fn dry_run_gas_estimate_call(
     }
 }
 
+/// Calls a smart contract on the blockchain
+///
+/// # Arguments
+///
+/// * `call_exec` - struct with the call to be executed.
+/// * `gas_limit` - maximum amount of gas to be used for this call.
+/// * `url` - endpoint of the node where the smart contract is running.
+///
 pub async fn call_smart_contract(
 	call_exec: CallExec<DefaultConfig, DefaultEnvironment, Keypair>,
 	gas_limit: Weight,

--- a/crates/pop-contracts/src/lib.rs
+++ b/crates/pop-contracts/src/lib.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0
+#![doc = include_str!("../README.md")]
 mod build;
 mod call;
 mod errors;
 mod new;
 mod test;
 mod up;
-pub mod utils;
+mod utils;
 
 pub use build::build_smart_contract;
 pub use call::{

--- a/crates/pop-contracts/src/new.rs
+++ b/crates/pop-contracts/src/new.rs
@@ -3,6 +3,12 @@ use crate::errors::Error;
 use contract_build::new_contract_project;
 use std::path::Path;
 
+/// Creates a new smart contract.
+///
+/// # Arguments
+///
+/// * `name` - name for the smart contract to be generated.
+/// * `target` - location where the smart contract will be generated.
 pub fn create_smart_contract(name: &str, target: &Path) -> Result<(), Error> {
 	// Canonicalize the target path to ensure consistency and resolve any symbolic links.
 	let canonicalized_path = target

--- a/crates/pop-contracts/src/test.rs
+++ b/crates/pop-contracts/src/test.rs
@@ -3,6 +3,11 @@ use crate::errors::Error;
 use duct::cmd;
 use std::path::PathBuf;
 
+/// Run unit tests of a smart contract.
+///
+/// # Arguments
+///
+/// * `path` - location of the smart contract.
 pub fn test_smart_contract(path: &Option<PathBuf>) -> Result<(), Error> {
 	// Execute `cargo test` command in the specified directory.
 	cmd("cargo", vec!["test"])
@@ -12,6 +17,11 @@ pub fn test_smart_contract(path: &Option<PathBuf>) -> Result<(), Error> {
 	Ok(())
 }
 
+/// Run e2e tests of a smart contract.
+///
+/// # Arguments
+///
+/// * `path` - location of the smart contract.
 pub fn test_e2e_smart_contract(path: &Option<PathBuf>) -> Result<(), Error> {
 	// Execute `cargo test --features=e2e-tests` command in the specified directory.
 	cmd("cargo", vec!["test", "--features=e2e-tests"])

--- a/crates/pop-contracts/src/up.rs
+++ b/crates/pop-contracts/src/up.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 use subxt::PolkadotConfig as DefaultConfig;
 use subxt_signer::sr25519::Keypair;
 
+/// Attributes for the up command
 pub struct UpOpts {
 	/// Path to the contract build folder.
 	pub path: Option<PathBuf>,
@@ -35,6 +36,13 @@ pub struct UpOpts {
 	/// Secret key URI for the account deploying the contract.
 	pub suri: String,
 }
+
+/// Prepare the struct for the deployment and instantiation to be executed.
+///
+/// # Arguments
+///
+/// * `up_opts` - attributes for the up command.
+///
 pub async fn set_up_deployment(
 	up_opts: UpOpts,
 ) -> anyhow::Result<InstantiateExec<DefaultConfig, DefaultEnvironment, Keypair>> {
@@ -64,6 +72,12 @@ pub async fn set_up_deployment(
 	return Ok(instantiate_exec);
 }
 
+/// Estimates the gas required for the contract instantiation process without modifying the blockchain..
+///
+/// # Arguments
+///
+/// * `instantiate_exec` - struct with the instantiation to be executed.
+///
 pub async fn dry_run_gas_estimate_instantiate(
 	instantiate_exec: &InstantiateExec<DefaultConfig, DefaultEnvironment, Keypair>,
 ) -> anyhow::Result<Weight> {
@@ -89,6 +103,13 @@ pub async fn dry_run_gas_estimate_instantiate(
 	}
 }
 
+/// Initiates the deployment of a smart contract on the blockchain.
+///
+/// # Arguments
+///
+/// * `instantiate_exec` - struct with the instantiation to be executed.
+/// * `gas_limit` - maximum amount of gas to be used for this call.
+///
 pub async fn instantiate_smart_contract(
 	instantiate_exec: InstantiateExec<DefaultConfig, DefaultEnvironment, Keypair>,
 	gas_limit: Weight,

--- a/crates/pop-parachains/README.md
+++ b/crates/pop-parachains/README.md
@@ -1,6 +1,6 @@
 # pop-parachains
 
-A crate for generating, building and running Parachains and Pallets.  Used by
+A crate for generating, building and running Parachains and Pallets. Used by
 [`pop-cli`](https://github.com/r0gue-io/pop-cli).
 
 ## Usage

--- a/crates/pop-parachains/README.md
+++ b/crates/pop-parachains/README.md
@@ -1,8 +1,8 @@
 # pop-parachains
 
-A crate for generating, building and running Parachains and Pallets. 
+A crate for generating, building and running Parachains and Pallets.  Used by
+[`pop-cli`](https://github.com/r0gue-io/pop-cli).
 
-> :information_source: A [crates.io](https://crates.io/crates/pop-parachains) version will be available soon!
 ## Usage
 
 Generate a new Parachain:

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -2,6 +2,7 @@
 use duct::cmd;
 use std::path::PathBuf;
 
+/// Build the parachain located in the specified `path`
 pub fn build_parachain(path: &Option<PathBuf>) -> anyhow::Result<()> {
 	cmd("cargo", vec!["build", "--release"])
 		.dir(path.clone().unwrap_or("./".into()))

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
+#![doc = include_str!("../README.md")]
 mod build;
 mod errors;
 mod generator;
@@ -16,5 +17,5 @@ pub use up::{Source, Status, Zombienet};
 pub use utils::git::{Git, GitHub, Release};
 pub use utils::helpers::is_initial_endowment_valid;
 pub use utils::pallet_helpers::resolve_pallet_path;
-// External exports
+/// Information about the Node. External export from Zombienet-SDK.
 pub use zombienet_sdk::NetworkNode;

--- a/crates/pop-parachains/src/new_pallet.rs
+++ b/crates/pop-parachains/src/new_pallet.rs
@@ -10,12 +10,18 @@ use crate::{
 	utils::helpers::sanitize,
 };
 
+/// Metadata for the Template Pallet.
 pub struct TemplatePalletConfig {
 	pub name: String,
 	pub authors: String,
 	pub description: String,
 }
-
+/// Creates a new pallet from a template .
+///
+/// # Arguments
+///
+/// * `path` - location where the pallet will be generated.
+/// * `config` - customization values to include in the new pallet.
 pub fn create_pallet_template(
 	path: Option<String>,
 	config: TemplatePalletConfig,

--- a/crates/pop-parachains/src/new_parachain.rs
+++ b/crates/pop-parachains/src/new_parachain.rs
@@ -12,7 +12,14 @@ use anyhow::Result;
 use std::{fs, path::Path};
 use walkdir::WalkDir;
 
-/// Creates a new template at `target` dir
+/// Creates a new parachain.
+///
+/// # Arguments
+///
+/// * `template` - template to generate the parachain from.
+/// * `target` - location where the parachain will be generated
+/// * `tag_version` - version to use (none to use the latest one)
+/// * `config` - customization values to include in the new parachain.
 pub fn instantiate_template_dir(
 	template: &Template,
 	target: &Path,

--- a/crates/pop-parachains/src/templates.rs
+++ b/crates/pop-parachains/src/templates.rs
@@ -5,6 +5,7 @@ use strum::{
 use strum_macros::{AsRefStr, Display, EnumMessage, EnumProperty, EnumString, VariantArray};
 use thiserror::Error;
 
+/// Template providers supported.
 #[derive(
 	AsRefStr, Clone, Default, Debug, Display, EnumMessage, EnumString, Eq, PartialEq, VariantArray,
 )]
@@ -27,14 +28,17 @@ pub enum Provider {
 }
 
 impl Provider {
+	/// Get the list of providers supported.
 	pub fn providers() -> &'static [Provider] {
 		Provider::VARIANTS
 	}
 
+	/// Get provider's name.
 	pub fn name(&self) -> &str {
 		self.get_message().unwrap_or_default()
 	}
 
+	/// Get the default template of the provider.
 	pub fn default_template(&self) -> Template {
 		match &self {
 			Provider::Pop => Template::Standard,
@@ -42,10 +46,12 @@ impl Provider {
 		}
 	}
 
+	/// Get the providers detailed description message.
 	pub fn description(&self) -> &str {
 		self.get_detailed_message().unwrap_or_default()
 	}
 
+	/// Get the list of templates of the provider.
 	pub fn templates(&self) -> Vec<&Template> {
 		Template::VARIANTS
 			.iter()
@@ -54,6 +60,7 @@ impl Provider {
 	}
 }
 
+/// Configurable settings for parachain generation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Config {
 	pub symbol: String,
@@ -61,6 +68,7 @@ pub struct Config {
 	pub initial_endowment: String,
 }
 
+/// Templates supported.
 #[derive(
 	AsRefStr,
 	Clone,
@@ -75,7 +83,7 @@ pub struct Config {
 	VariantArray,
 )]
 pub enum Template {
-	// Pop
+	/// Minimalist parachain template.
 	#[default]
 	#[strum(
 		serialize = "standard",
@@ -84,6 +92,7 @@ pub enum Template {
 		props(Provider = "Pop", Repository = "https://github.com/r0gue-io/base-parachain")
 	)]
 	Standard,
+	/// Parachain configured with fungible and non-fungilble asset functionalities.
 	#[strum(
 		serialize = "assets",
 		message = "Assets",
@@ -91,6 +100,7 @@ pub enum Template {
 		props(Provider = "Pop", Repository = "https://github.com/r0gue-io/assets-parachain")
 	)]
 	Assets,
+	/// Parachain configured to support WebAssembly smart contracts.
 	#[strum(
 		serialize = "contracts",
 		message = "Contracts",
@@ -98,6 +108,7 @@ pub enum Template {
 		props(Provider = "Pop", Repository = "https://github.com/r0gue-io/contracts-parachain")
 	)]
 	Contracts,
+	/// Parachain configured with Frontier, enabling compatibility with the Ethereum Virtual Machine (EVM).
 	#[strum(
 		serialize = "evm",
 		message = "EVM",
@@ -105,7 +116,7 @@ pub enum Template {
 		props(Provider = "Pop", Repository = "https://github.com/r0gue-io/evm-parachain")
 	)]
 	EVM,
-	// Parity
+	/// Minimal Substrate node configured for smart contracts via pallet-contracts.
 	#[strum(
 		serialize = "cpt",
 		message = "Contracts",
@@ -116,6 +127,7 @@ pub enum Template {
 		)
 	)]
 	ParityContracts,
+	/// Template node for a Frontier (EVM) based parachain.
 	#[strum(
 		serialize = "fpt",
 		message = "EVM",
@@ -129,22 +141,28 @@ pub enum Template {
 }
 
 impl Template {
+	/// Get the template's name.
 	pub fn name(&self) -> &str {
 		self.get_message().unwrap_or_default()
 	}
+
+	/// Get the detailed message of the template.
 	pub fn description(&self) -> &str {
 		self.get_detailed_message().unwrap_or_default()
 	}
 
+	/// Check the template belongs to a `provider`.
 	pub fn matches(&self, provider: &Provider) -> bool {
 		// Match explicitly on provider name (message)
 		self.get_str("Provider") == Some(provider.name())
 	}
 
+	/// Get the template's repository url.
 	pub fn repository_url(&self) -> Result<&str, Error> {
 		self.get_str("Repository").ok_or(Error::RepositoryMissing)
 	}
 
+	/// Get the provider of the template.
 	pub fn provider(&self) -> Result<&str, Error> {
 		self.get_str("Provider").ok_or(Error::ProviderMissing)
 	}

--- a/crates/pop-parachains/src/up.rs
+++ b/crates/pop-parachains/src/up.rs
@@ -20,6 +20,7 @@ use zombienet_support::fs::local::LocalFileSystem;
 const POLKADOT_SDK: &str = "https://github.com/paritytech/polkadot-sdk";
 const POLKADOT_DEFAULT_VERSION: &str = "v1.11.0";
 
+/// Spawn your network.
 pub struct Zombienet {
 	/// The cache location, used for caching binaries.
 	cache: PathBuf,
@@ -32,6 +33,15 @@ pub struct Zombienet {
 }
 
 impl Zombienet {
+	/// Creates a new Zombienet struct.
+	///
+	/// # Arguments
+	///
+	/// * `cache` - location, used for caching binaries
+	/// * `network_config` - config file to be used to launch a network.
+	/// * `relay_chain_version` - the specific version used for the relay chain (none will fetch the last one).
+	/// * `system_parachain_version` - the specific version used for the system chain (none will fetch the last one).
+	/// * `parachains` - list of parachains url.
 	pub async fn new(
 		cache: PathBuf,
 		network_config: &str,
@@ -115,6 +125,7 @@ impl Zombienet {
 		})
 	}
 
+	/// Keep a list of the missing binaries to be downloaded.
 	pub fn missing_binaries(&self) -> Vec<&Binary> {
 		let mut missing = Vec::new();
 		if !self.relay_chain.path.exists() {
@@ -126,6 +137,7 @@ impl Zombienet {
 		missing
 	}
 
+	/// Launch the networks specified in the Zombienet struct.
 	pub async fn spawn(&mut self) -> Result<Network<LocalFileSystem>, Error> {
 		// Symlink polkadot-related binaries
 		for file in ["polkadot-execute-worker", "polkadot-prepare-worker"] {

--- a/crates/pop-parachains/src/utils/git.rs
+++ b/crates/pop-parachains/src/utils/git.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::{env, fs};
 use url::Url;
 
+/// A struct that handles Git operations.
 pub struct Git;
 impl Git {
 	pub(crate) fn clone(url: &Url, working_dir: &Path, branch: Option<&str>) -> Result<()> {
@@ -43,7 +44,13 @@ impl Git {
 		}
 		Ok(())
 	}
-	/// Clone `url` into `target` and degit it
+	/// Clones a Git repository and degit it
+	///
+	/// # Arguments
+	///
+	/// * `url` - the URL of the repository to clone.
+	/// * `target` - location where the repository will be cloned.
+	/// * `tag_version` - the specific tag or version of the repository to use
 	pub fn clone_and_degit(
 		url: &str,
 		target: &Path,
@@ -123,7 +130,12 @@ impl Git {
 		None
 	}
 
-	/// Init a new git repo on creation of a parachain
+	/// Init a new git repository.
+	///
+	/// # Arguments
+	///
+	/// * `target` - location where the parachain will be generated.
+	/// * `message` - message for first commit.
 	pub fn git_init(target: &Path, message: &str) -> Result<(), git2::Error> {
 		let repo = Repository::init(target)?;
 		let signature = repo.signature()?;
@@ -142,6 +154,7 @@ impl Git {
 	}
 }
 
+/// A struct that handles GitHub operations.
 pub struct GitHub {
 	pub org: String,
 	pub name: String,
@@ -151,6 +164,11 @@ pub struct GitHub {
 impl GitHub {
 	const GITHUB: &'static str = "github.com";
 
+	/// Parse url of a github repository to creat a GitHub struct
+	///
+	/// # Arguments
+	///
+	/// * `url` - the URL of the repository to clone.
 	pub fn parse(url: &str) -> Result<Self> {
 		let url = Url::parse(url)?;
 		Ok(Self {
@@ -167,6 +185,7 @@ impl GitHub {
 		self
 	}
 
+	/// Fetch the latest releases of the Github repository
 	pub async fn get_latest_releases(&self) -> Result<Vec<Release>> {
 		static APP_USER_AGENT: &str =
 			concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
@@ -176,6 +195,7 @@ impl GitHub {
 		Ok(response.json::<Vec<Release>>().await?)
 	}
 
+	/// Retrieves the commit hash associated with a specified tag in a GitHub repository.
 	pub async fn get_commit_sha_from_release(&self, tag_name: &str) -> Result<String> {
 		static APP_USER_AGENT: &str =
 			concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
@@ -229,6 +249,7 @@ impl GitHub {
 	}
 }
 
+/// Represents the data of a GitHub release.
 #[derive(Debug, PartialEq, serde::Deserialize)]
 pub struct Release {
 	pub tag_name: String,

--- a/crates/pop-parachains/src/utils/helpers.rs
+++ b/crates/pop-parachains/src/utils/helpers.rs
@@ -24,6 +24,11 @@ pub(crate) fn sanitize(target: &Path) -> Result<(), Error> {
 	Ok(())
 }
 
+/// Check if the initial endowment input by the user is a valid balance.
+///
+/// # Arguments
+///
+/// * `initial_endowment` - initial endowment amount to be checked for validity.
 pub fn is_initial_endowment_valid(initial_endowment: &str) -> bool {
 	initial_endowment.parse::<u128>().is_ok()
 		|| is_valid_bitwise_left_shift(initial_endowment).is_ok()


### PR DESCRIPTION
Added the missing documentation for the 2 crates we are providing to external developers: `pop_contracts` and `pop_parachain`. Documentation comments use three slashes `///`.

To test it move to the crate: 
```
cd crates/pop_contracts
cd crates/pop_parachain
``` 
And run:
```
cargo doc --open
```

And example of a documented crate for `cargo-contract`: https://docs.rs/contract-build/latest/contract_build/index.html