### PR TITLE
feat: add paseo support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ toml_edit = { version = "0.22", features = ["serde"] }
 symlink = "0.1"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-zombienet-sdk = "0.2.2"
-zombienet-support = "0.2.2"
+zombienet-sdk = "0.2.5"
+zombienet-support = "0.2.5"
 git2_credentials = "0.13.0"
 
 # pop-cli

--- a/crates/pop-cli/src/commands/up/parachain.rs
+++ b/crates/pop-cli/src/commands/up/parachain.rs
@@ -16,14 +16,23 @@ pub(crate) struct ZombienetCommand {
 	/// The Zombienet network configuration file to be used.
 	#[arg(short, long)]
 	file: String,
-	/// The version of Polkadot to be used for the relay chain, as per the release tag (e.g.
-	/// "v1.11.0").
+	/// The version of the binary to be used for the relay chain, as per the release tag (e.g. "v1.13.0").
+	/// See https://github.com/paritytech/polkadot-sdk/releases for more details.
 	#[arg(short, long)]
 	relay_chain: Option<String>,
-	/// The version of Polkadot to be used for a system parachain, as per the release tag (e.g.
-	/// "v1.11.0"). Defaults to the relay chain version if not specified.
+	/// The version of the runtime to be used for the relay chain, as per the release tag (e.g. "v1.2.7").
+	/// See https://github.com/polkadot-fellows/runtimes/releases for more details.
+	#[arg(short = 'R', long)]
+	relay_chain_runtime: Option<String>,
+	/// The version of the binary to be used for system parachains, as per the release tag (e.g. "v1.13.0").
+	/// Defaults to the relay chain version if not specified.
+	/// See https://github.com/paritytech/polkadot-sdk/releases for more details.
 	#[arg(short, long)]
 	system_parachain: Option<String>,
+	/// The version of the runtime to be used for system parachains, as per the release tag (e.g. "v1.2.7").
+	/// See https://github.com/polkadot-fellows/runtimes/releases for more details.
+	#[arg(short = 'S', long)]
+	system_parachain_runtime: Option<String>,
 	/// The url of the git repository of a parachain to be used, with branch/release tag/commit specified as #fragment (e.g. 'https://github.com/org/repository#ref').
 	/// A specific binary name can also be optionally specified via query string parameter (e.g. 'https://github.com/org/repository?binaryname#ref'), defaulting to the name of the repository when not specified.
 	#[arg(short, long)]
@@ -46,8 +55,10 @@ impl ZombienetCommand {
 		let mut zombienet = match Zombienet::new(
 			&cache,
 			&self.file,
-			self.relay_chain.as_ref().map(|v| v.as_str()),
-			self.system_parachain.as_ref().map(|v| v.as_str()),
+			self.relay_chain.as_deref(),
+			self.relay_chain_runtime.as_deref(),
+			self.system_parachain.as_deref(),
+			self.system_parachain_runtime.as_deref(),
 			self.parachain.as_ref(),
 		)
 		.await
@@ -164,7 +175,7 @@ impl ZombienetCommand {
 			))
 			.dim()
 			.to_string();
-			log::warning(format!("⚠️ The following binaries specified in the network configuration file cannot be found locally:\n   {list}"))?;
+			log::warning(format!("⚠️ The following binaries required to launch the network cannot be found locally:\n   {list}"))?;
 
 			// Prompt for automatic sourcing of binaries
 			let list = style(format!(

--- a/crates/pop-parachains/src/up/chain_specs.rs
+++ b/crates/pop-parachains/src/up/chain_specs.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
+
 use crate::{
 	up::{
 		sourcing::{
@@ -107,4 +108,89 @@ pub(super) async fn chain_spec_generator(
 		return Ok(Some(binary));
 	}
 	Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use tempfile::tempdir;
+
+	#[tokio::test]
+	async fn kusama_works() -> anyhow::Result<()> {
+		let expected = Runtime::Kusama;
+		let version = "v1.2.7";
+		let temp_dir = tempdir()?;
+		let binary = chain_spec_generator("kusama-local", Some(version), temp_dir.path())
+			.await?
+			.unwrap();
+		assert!(matches!(binary, Binary::Source { name, source, cache }
+			if name == format!("{}-{}", expected.name().to_lowercase(), expected.binary()) &&
+				source == Source::GitHub(ReleaseArchive {
+					owner: "r0gue-io".to_string(),
+					repository: "polkadot-runtimes".to_string(),
+					tag: Some(version.to_string()),
+					tag_format: None,
+					archive: format!("chain-spec-generator-{}.tar.gz", target()?),
+					contents: ["chain-spec-generator"].map(|b| (b, Some(format!("kusama-{b}").to_string()))).to_vec(),
+					latest: binary.latest().map(|l| l.to_string()),
+				}) &&
+				cache == temp_dir.path()
+		));
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn paseo_works() -> anyhow::Result<()> {
+		let expected = Runtime::Paseo;
+		let version = "v1.2.4";
+		let temp_dir = tempdir()?;
+		let binary = chain_spec_generator("paseo-local", Some(version), temp_dir.path())
+			.await?
+			.unwrap();
+		assert!(matches!(binary, Binary::Source { name, source, cache }
+			if name == format!("{}-{}", expected.name().to_lowercase(), expected.binary()) &&
+				source == Source::GitHub(ReleaseArchive {
+					owner: "r0gue-io".to_string(),
+					repository: "paseo-runtimes".to_string(),
+					tag: Some(version.to_string()),
+					tag_format: None,
+					archive: format!("chain-spec-generator-{}.tar.gz", target()?),
+					contents: ["chain-spec-generator"].map(|b| (b, Some(format!("paseo-{b}").to_string()))).to_vec(),
+					latest: binary.latest().map(|l| l.to_string()),
+				}) &&
+				cache == temp_dir.path()
+		));
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn polkadot_works() -> anyhow::Result<()> {
+		let expected = Runtime::Polkadot;
+		let version = "v1.2.7";
+		let temp_dir = tempdir()?;
+		let binary = chain_spec_generator("polkadot-local", Some(version), temp_dir.path())
+			.await?
+			.unwrap();
+		assert!(matches!(binary, Binary::Source { name, source, cache }
+			if name == format!("{}-{}", expected.name().to_lowercase(), expected.binary()) &&
+				source == Source::GitHub(ReleaseArchive {
+					owner: "r0gue-io".to_string(),
+					repository: "polkadot-runtimes".to_string(),
+					tag: Some(version.to_string()),
+					tag_format: None,
+					archive: format!("chain-spec-generator-{}.tar.gz", target()?),
+					contents: ["chain-spec-generator"].map(|b| (b, Some(format!("polkadot-{b}").to_string()))).to_vec(),
+					latest: binary.latest().map(|l| l.to_string()),
+				}) &&
+				cache == temp_dir.path()
+		));
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn chain_spec_generator_returns_none_when_no_match() -> anyhow::Result<()> {
+		let temp_dir = tempdir()?;
+		assert_eq!(chain_spec_generator("rococo-local", None, temp_dir.path()).await?, None);
+		Ok(())
+	}
 }

--- a/crates/pop-parachains/src/up/chain_specs.rs
+++ b/crates/pop-parachains/src/up/chain_specs.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0
+use crate::{
+	up::{
+		sourcing::{
+			self,
+			traits::{Source as _, *},
+			GitHub::*,
+			Source,
+		},
+		target,
+	},
+	Binary, Error,
+};
+use std::path::Path;
+use strum::{EnumProperty as _, VariantArray as _};
+use strum_macros::{AsRefStr, EnumProperty, VariantArray};
+
+/// A supported runtime.
+#[derive(AsRefStr, Debug, EnumProperty, PartialEq, VariantArray)]
+pub(super) enum Runtime {
+	/// Kusama.
+	#[strum(props(
+		Repository = "https://github.com/r0gue-io/polkadot-runtimes",
+		Binary = "chain-spec-generator",
+		Chain = "kusama-local",
+		Fallback = "v1.2.7"
+	))]
+	Kusama,
+	/// Paseo.
+	#[strum(props(
+		Repository = "https://github.com/r0gue-io/paseo-runtimes",
+		Binary = "chain-spec-generator",
+		Chain = "paseo-local",
+		Fallback = "v1.2.4"
+	))]
+	Paseo,
+	/// Polkadot.
+	#[strum(props(
+		Repository = "https://github.com/r0gue-io/polkadot-runtimes",
+		Binary = "chain-spec-generator",
+		Chain = "polkadot-local",
+		Fallback = "v1.2.7"
+	))]
+	Polkadot,
+}
+
+impl TryInto for &Runtime {
+	/// Attempt the conversion.
+	///
+	/// # Arguments
+	/// * `tag` - If applicable, a tag used to determine a specific release.
+	/// * `latest` - If applicable, some specifier used to determine the latest source.
+	fn try_into(&self, tag: Option<String>, latest: Option<String>) -> Result<Source, Error> {
+		Ok(match self {
+			_ => {
+				// Source from GitHub release asset
+				let repo = crate::GitHub::parse(self.repository())?;
+				let name = self.name().to_lowercase();
+				let binary = self.binary();
+				Source::GitHub(ReleaseArchive {
+					owner: repo.org,
+					repository: repo.name,
+					tag,
+					tag_format: self.tag_format().map(|t| t.into()),
+					archive: format!("{binary}-{}.tar.gz", target()?),
+					contents: vec![(binary, Some(format!("{name}-{binary}")))],
+					latest,
+				})
+			},
+		})
+	}
+}
+
+impl Runtime {
+	/// The chain spec identifier.
+	fn chain(&self) -> &'static str {
+		self.get_str("Chain").expect("expected specification of `Chain`")
+	}
+
+	/// The name of the runtime.
+	fn name(&self) -> &str {
+		self.as_ref()
+	}
+}
+
+impl sourcing::traits::Source for Runtime {}
+
+pub(super) async fn chain_spec_generator(
+	chain: &str,
+	version: Option<&str>,
+	cache: &Path,
+) -> Result<Option<Binary>, Error> {
+	for runtime in Runtime::VARIANTS.iter().filter(|r| chain.to_lowercase().ends_with(r.chain())) {
+		let name = format!("{}-{}", runtime.name().to_lowercase(), runtime.binary());
+		let releases = runtime.releases().await?;
+		let tag = Binary::resolve_version(&name, version, &releases, cache);
+		// Only set latest when caller has not explicitly specified a version to use
+		let latest = version
+			.is_none()
+			.then(|| releases.iter().nth(0).map(|v| v.to_string()))
+			.flatten();
+		let binary = Binary::Source {
+			name: name.to_string(),
+			source: TryInto::try_into(&runtime, tag, latest)?,
+			cache: cache.to_path_buf(),
+		};
+		return Ok(Some(binary));
+	}
+	Ok(None)
+}

--- a/crates/pop-parachains/src/up/parachains.rs
+++ b/crates/pop-parachains/src/up/parachains.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 use super::{
-	sourcing,
+	chain_specs::chain_spec_generator,
 	sourcing::{
+		self,
 		traits::{Source as _, *},
 		GitHub::ReleaseArchive,
 		Source,
@@ -50,7 +51,7 @@ impl TryInto for Parachain {
 					tag,
 					tag_format: self.tag_format().map(|t| t.into()),
 					archive: format!("{}-{}.tar.gz", self.binary(), target()?),
-					contents: vec![self.binary()],
+					contents: vec![(self.binary(), None)],
 					latest,
 				})
 			},
@@ -66,13 +67,17 @@ impl sourcing::traits::Source for Parachain {}
 /// * `id` - The parachain identifier.
 /// * `command` - The command specified.
 /// * `version` - The version of the parachain binary to be used.
-/// * `version` - The version of the relay chain binary being used.
+/// * `runtime_version` - The version of the runtime to be used.
+/// * `relay_chain_version` - The version of the relay chain binary being used.
+/// * `chain` - The chain specified.
 /// * `cache` - The cache to be used.
 pub(super) async fn system(
 	id: u32,
 	command: &str,
 	version: Option<&str>,
-	relay_chain: &str,
+	runtime_version: Option<&str>,
+	relay_chain_version: &str,
+	chain: Option<&str>,
 	cache: &Path,
 ) -> Result<Option<super::Parachain>, Error> {
 	let para = &Parachain::System;
@@ -84,14 +89,22 @@ pub(super) async fn system(
 		Some(version) => (Some(version.to_string()), None),
 		None => {
 			// Default to same version as relay chain when not explicitly specified
-			let version = relay_chain.to_string();
 			// Only set latest when caller has not explicitly specified a version to use
-			(Some(version), para.releases().await?.into_iter().nth(0))
+			(Some(relay_chain_version.to_string()), para.releases().await?.into_iter().nth(0))
 		},
 	};
 	let source = TryInto::try_into(para, tag, latest)?;
 	let binary = Binary::Source { name: name.to_string(), source, cache: cache.to_path_buf() };
-	return Ok(Some(super::Parachain { id, binary }));
+	let chain_spec_generator = match chain {
+		Some(chain) => chain_spec_generator(chain, runtime_version, cache).await?,
+		None => None,
+	};
+	return Ok(Some(super::Parachain {
+		id,
+		binary,
+		chain: chain.map(|c| c.to_string()),
+		chain_spec_generator,
+	}));
 }
 
 /// Initialises the configuration required to launch a parachain.
@@ -100,11 +113,13 @@ pub(super) async fn system(
 /// * `id` - The parachain identifier.
 /// * `command` - The command specified.
 /// * `version` - The version of the parachain binary to be used.
+/// * `chain` - The chain specified.
 /// * `cache` - The cache to be used.
 pub(super) async fn from(
 	id: u32,
 	command: &str,
 	version: Option<&str>,
+	chain: Option<&str>,
 	cache: &Path,
 ) -> Result<Option<super::Parachain>, Error> {
 	for para in Parachain::VARIANTS.iter().filter(|p| p.binary() == command) {
@@ -120,7 +135,12 @@ pub(super) async fn from(
 			source: TryInto::try_into(para, tag, latest)?,
 			cache: cache.to_path_buf(),
 		};
-		return Ok(Some(super::Parachain { id, binary }));
+		return Ok(Some(super::Parachain {
+			id,
+			binary,
+			chain: chain.map(|c| c.to_string()),
+			chain_spec_generator: None,
+		}));
 	}
 	Ok(None)
 }
@@ -128,11 +148,22 @@ pub(super) async fn from(
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use std::path::PathBuf;
 	use tempfile::tempdir;
 
 	#[tokio::test]
 	async fn system_matches_command() -> anyhow::Result<()> {
-		assert!(system(1000, "polkadot", None, "v1.12.0", tempdir()?.path()).await?.is_none());
+		assert!(system(
+			1000,
+			"polkadot",
+			None,
+			None,
+			"v1.12.0",
+			Some("asset-hub-rococo-local"),
+			tempdir()?.path()
+		)
+		.await?
+		.is_none());
 		Ok(())
 	}
 
@@ -143,9 +174,10 @@ mod tests {
 		let para_id = 1000;
 
 		let temp_dir = tempdir()?;
-		let parachain = system(para_id, expected.binary(), None, version, temp_dir.path())
-			.await?
-			.unwrap();
+		let parachain =
+			system(para_id, expected.binary(), None, None, version, None, temp_dir.path())
+				.await?
+				.unwrap();
 		assert_eq!(para_id, parachain.id);
 		assert!(matches!(parachain.binary, Binary::Source { name, source, cache }
 			if name == expected.binary() && source == Source::GitHub(ReleaseArchive {
@@ -154,7 +186,7 @@ mod tests {
 					tag: Some(version.to_string()),
 					tag_format: Some("polkadot-{tag}".to_string()),
 					archive: format!("{name}-{}.tar.gz", target()?),
-					contents: vec![expected.binary()],
+					contents: vec![(expected.binary(), None)],
 					latest: parachain.binary.latest().map(|l| l.to_string()),
 				}) && cache == temp_dir.path()
 		));
@@ -168,9 +200,10 @@ mod tests {
 		let para_id = 1000;
 
 		let temp_dir = tempdir()?;
-		let parachain = system(para_id, expected.binary(), Some(version), version, temp_dir.path())
-			.await?
-			.unwrap();
+		let parachain =
+			system(para_id, expected.binary(), Some(version), None, version, None, temp_dir.path())
+				.await?
+				.unwrap();
 		assert_eq!(para_id, parachain.id);
 		assert!(matches!(parachain.binary, Binary::Source { name, source, cache }
 			if name == expected.binary() && source == Source::GitHub(ReleaseArchive {
@@ -179,7 +212,7 @@ mod tests {
 					tag: Some(version.to_string()),
 					tag_format: Some("polkadot-{tag}".to_string()),
 					archive: format!("{name}-{}.tar.gz", target()?),
-					contents: vec![expected.binary()],
+					contents: vec![(expected.binary(), None)],
 					latest: parachain.binary.latest().map(|l| l.to_string()),
 				}) && cache == temp_dir.path()
 		));
@@ -193,8 +226,9 @@ mod tests {
 		let para_id = 2000;
 
 		let temp_dir = tempdir()?;
-		let parachain =
-			from(para_id, expected.binary(), Some(version), temp_dir.path()).await?.unwrap();
+		let parachain = from(para_id, expected.binary(), Some(version), None, temp_dir.path())
+			.await?
+			.unwrap();
 		assert_eq!(para_id, parachain.id);
 		assert!(matches!(parachain.binary, Binary::Source { name, source, cache }
 			if name == expected.binary() && source == Source::GitHub(ReleaseArchive {
@@ -203,7 +237,7 @@ mod tests {
 					tag: Some(version.to_string()),
 					tag_format: None,
 					archive: format!("{name}-{}.tar.gz", target()?),
-					contents: vec![expected.binary()],
+					contents: vec![(expected.binary(), None)],
 					latest: parachain.binary.latest().map(|l| l.to_string()),
 				}) && cache == temp_dir.path()
 		));
@@ -212,7 +246,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn from_handles_unsupported_command() -> anyhow::Result<()> {
-		assert!(from(2000, "none", None, tempdir()?.path()).await?.is_none());
+		assert!(from(2000, "none", None, None, &PathBuf::default()).await?.is_none());
 		Ok(())
 	}
 }

--- a/crates/pop-parachains/src/up/relay.rs
+++ b/crates/pop-parachains/src/up/relay.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
+
 use super::{
 	chain_specs::chain_spec_generator,
 	sourcing::{
@@ -146,6 +147,28 @@ mod tests {
 				}) && cache == temp_dir.path()
 		));
 		assert_eq!(relay.workers, expected.workers());
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn default_with_chain_spec_generator_works() -> anyhow::Result<()> {
+		let runtime_version = "v1.2.7";
+		let temp_dir = tempdir()?;
+		let relay =
+			default(None, Some(runtime_version), Some("paseo-local"), temp_dir.path()).await?;
+		assert_eq!(relay.chain, "paseo-local");
+		let chain_spec_generator = relay.chain_spec_generator.unwrap();
+		assert!(matches!(chain_spec_generator, Binary::Source { name, source, cache }
+			if name == "paseo-chain-spec-generator" && source == Source::GitHub(ReleaseArchive {
+					owner: "r0gue-io".to_string(),
+					repository: "paseo-runtimes".to_string(),
+					tag: Some(runtime_version.to_string()),
+					tag_format: None,
+					archive: format!("chain-spec-generator-{}.tar.gz", target()?),
+					contents: [("chain-spec-generator", Some("paseo-chain-spec-generator".to_string()))].to_vec(),
+					latest: chain_spec_generator.latest().map(|l| l.to_string()),
+				}) && cache == temp_dir.path()
+		));
 		Ok(())
 	}
 

--- a/crates/pop-parachains/tests/parachain.rs
+++ b/crates/pop-parachains/tests/parachain.rs
@@ -1,23 +1,166 @@
 // SPDX-License-Identifier: GPL-3.0
+
 use anyhow::Result;
 use pop_parachains::Zombienet;
 
-const CONFIG_FILE_PATH: &str = "../../tests/networks/pop.toml";
 const BINARY_VERSION: &str = "v1.13.0";
-const RUNTIME_VERSION: &str = "v1.2.7";
 
 #[tokio::test]
-async fn test_spawn_polkadot_and_two_parachains() -> Result<()> {
+async fn launch_kusama() -> Result<()> {
 	let temp_dir = tempfile::tempdir()?;
 	let cache = temp_dir.path().to_path_buf();
 
 	let mut zombienet = Zombienet::new(
 		&cache,
-		CONFIG_FILE_PATH,
+		"../../tests/networks/kusama.toml",
 		Some(BINARY_VERSION),
-		Some(RUNTIME_VERSION),
+		Some("v1.2.7"),
+		None,
+		None,
+		None,
+	)
+	.await?;
+
+	for binary in zombienet.binaries().filter(|b| !b.exists()) {
+		binary.source(true, &(), true).await?;
+	}
+
+	zombienet.spawn().await?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn launch_paseo() -> Result<()> {
+	let temp_dir = tempfile::tempdir()?;
+	let cache = temp_dir.path().to_path_buf();
+
+	let mut zombienet = Zombienet::new(
+		&cache,
+		"../../tests/networks/paseo.toml",
 		Some(BINARY_VERSION),
-		Some(RUNTIME_VERSION),
+		Some("v1.2.4"),
+		None,
+		None,
+		None,
+	)
+	.await?;
+
+	for binary in zombienet.binaries().filter(|b| !b.exists()) {
+		binary.source(true, &(), true).await?;
+	}
+
+	zombienet.spawn().await?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn launch_polkadot() -> Result<()> {
+	let temp_dir = tempfile::tempdir()?;
+	let cache = temp_dir.path().to_path_buf();
+
+	let mut zombienet = Zombienet::new(
+		&cache,
+		"../../tests/networks/polkadot.toml",
+		Some(BINARY_VERSION),
+		Some("v1.2.7"),
+		None,
+		None,
+		None,
+	)
+	.await?;
+
+	for binary in zombienet.binaries().filter(|b| !b.exists()) {
+		binary.source(true, &(), true).await?;
+	}
+
+	zombienet.spawn().await?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn launch_polkadot_and_system_parachain() -> Result<()> {
+	let temp_dir = tempfile::tempdir()?;
+	let cache = temp_dir.path().to_path_buf();
+
+	let mut zombienet = Zombienet::new(
+		&cache,
+		"../../tests/networks/polkadot+collectives.toml",
+		Some(BINARY_VERSION),
+		Some("v1.2.7"),
+		Some(BINARY_VERSION),
+		Some("v1.2.7"),
+		None,
+	)
+	.await?;
+
+	for binary in zombienet.binaries().filter(|b| !b.exists()) {
+		binary.source(true, &(), true).await?;
+	}
+
+	zombienet.spawn().await?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn launch_rococo() -> Result<()> {
+	let temp_dir = tempfile::tempdir()?;
+	let cache = temp_dir.path().to_path_buf();
+
+	let mut zombienet = Zombienet::new(
+		&cache,
+		"../../tests/networks/rococo.toml",
+		Some(BINARY_VERSION),
+		None,
+		None,
+		None,
+		None,
+	)
+	.await?;
+
+	for binary in zombienet.binaries().filter(|b| !b.exists()) {
+		binary.source(true, &(), true).await?;
+	}
+
+	zombienet.spawn().await?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn launch_rococo_and_system_parachain() -> Result<()> {
+	let temp_dir = tempfile::tempdir()?;
+	let cache = temp_dir.path().to_path_buf();
+
+	let mut zombienet = Zombienet::new(
+		&cache,
+		"../../tests/networks/rococo+coretime.toml",
+		Some(BINARY_VERSION),
+		None,
+		Some(BINARY_VERSION),
+		None,
+		None,
+	)
+	.await?;
+
+	for binary in zombienet.binaries().filter(|b| !b.exists()) {
+		binary.source(true, &(), true).await?;
+	}
+
+	zombienet.spawn().await?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn launch_rococo_and_two_parachains() -> Result<()> {
+	let temp_dir = tempfile::tempdir()?;
+	let cache = temp_dir.path().to_path_buf();
+
+	let mut zombienet = Zombienet::new(
+		&cache,
+		"../../tests/networks/pop.toml",
+		Some(BINARY_VERSION),
+		None,
+		Some(BINARY_VERSION),
+		None,
 		Some(&vec!["https://github.com/r0gue-io/pop-node".to_string()]),
 	)
 	.await?;

--- a/crates/pop-parachains/tests/parachain.rs
+++ b/crates/pop-parachains/tests/parachain.rs
@@ -3,7 +3,8 @@ use anyhow::Result;
 use pop_parachains::Zombienet;
 
 const CONFIG_FILE_PATH: &str = "../../tests/networks/pop.toml";
-const TESTING_POLKADOT_VERSION: &str = "v1.12.0";
+const BINARY_VERSION: &str = "v1.13.0";
+const RUNTIME_VERSION: &str = "v1.2.7";
 
 #[tokio::test]
 async fn test_spawn_polkadot_and_two_parachains() -> Result<()> {
@@ -13,8 +14,10 @@ async fn test_spawn_polkadot_and_two_parachains() -> Result<()> {
 	let mut zombienet = Zombienet::new(
 		&cache,
 		CONFIG_FILE_PATH,
-		Some(&TESTING_POLKADOT_VERSION.to_string()),
-		Some(&TESTING_POLKADOT_VERSION.to_string()),
+		Some(BINARY_VERSION),
+		Some(RUNTIME_VERSION),
+		Some(BINARY_VERSION),
+		Some(RUNTIME_VERSION),
 		Some(&vec!["https://github.com/r0gue-io/pop-node".to_string()]),
 	)
 	.await?;

--- a/tests/networks/kusama.toml
+++ b/tests/networks/kusama.toml
@@ -1,0 +1,12 @@
+# pop up parachain -f ./tests/networks/kusama.toml
+
+[relaychain]
+chain = "kusama-local"
+
+[[relaychain.nodes]]
+name = "alice"
+validator = true
+
+[[relaychain.nodes]]
+name = "bob"
+validator = true

--- a/tests/networks/paseo.toml
+++ b/tests/networks/paseo.toml
@@ -1,0 +1,12 @@
+# pop up parachain -f ./tests/networks/paseo.toml
+
+[relaychain]
+chain = "paseo-local"
+
+[[relaychain.nodes]]
+name = "alice"
+validator = true
+
+[[relaychain.nodes]]
+name = "bob"
+validator = true

--- a/tests/networks/polkadot+collectives.toml
+++ b/tests/networks/polkadot+collectives.toml
@@ -1,0 +1,19 @@
+# pop up parachain -f ./tests/networks/polkadot.toml
+
+[relaychain]
+chain = "polkadot-local"
+
+[[relaychain.nodes]]
+name = "alice"
+validator = true
+
+[[relaychain.nodes]]
+name = "bob"
+validator = true
+
+[[parachains]]
+id = 1000
+chain = "collectives-polkadot-local"
+
+[[parachains.collators]]
+name = "collectives-01"

--- a/tests/networks/polkadot.toml
+++ b/tests/networks/polkadot.toml
@@ -1,0 +1,12 @@
+# pop up parachain -f ./tests/networks/polkadot.toml
+
+[relaychain]
+chain = "polkadot-local"
+
+[[relaychain.nodes]]
+name = "alice"
+validator = true
+
+[[relaychain.nodes]]
+name = "bob"
+validator = true


### PR DESCRIPTION
Adds `chain-spec-generator` support, so that `pop up` can be used to launch local `paseo`, `kusama` and `polkadot` networks. 