### PR TITLE
feat(new): ux improvements

### DIFF
--- a/crates/pop-cli/src/commands/new/parachain.rs
+++ b/crates/pop-cli/src/commands/new/parachain.rs
@@ -193,10 +193,12 @@ fn generate_parachain_from_template(
 			.unwrap_or_default()
 	))?;
 
-	// warn about audit status and licensing
-	warning(format!("NOTE: the resulting parachain is not guaranteed to be audited or reviewed for security vulnerabilities.\n{}",
-		style(format!("Please consult the source repository at {} to assess production suitability and licensing restrictions.", template.repository_url()?))
-			.dim()))?;
+	if !template.is_audited() {
+		// warn about audit status and licensing
+		warning(format!("NOTE: the resulting parachain is not guaranteed to be audited or reviewed for security vulnerabilities.\n{}",
+						style(format!("Please consult the source repository at {} to assess production suitability and licensing restrictions.", template.repository_url()?))
+							.dim()))?;
+	}
 
 	// add next steps
 	let mut next_steps = vec![

--- a/crates/pop-parachains/src/templates.rs
+++ b/crates/pop-parachains/src/templates.rs
@@ -232,6 +232,8 @@ mod tests {
 			("evm".to_string(), Template::EVM),
 			("cpt".to_string(), Template::ParityContracts),
 			("fpt".to_string(), Template::ParityFPT),
+			("test_01".to_string(), Template::TestTemplate01),
+			("test_02".to_string(), Template::TestTemplate02),
 		])
 	}
 
@@ -243,6 +245,8 @@ mod tests {
 			("evm".to_string(), "https://github.com/r0gue-io/evm-parachain"),
 			("cpt".to_string(), "https://github.com/paritytech/substrate-contracts-node"),
 			("fpt".to_string(), "https://github.com/paritytech/frontier-parachain-template"),
+			("test_01".to_string(), ""),
+			("test_02".to_string(), ""),
 		])
 	}
 
@@ -254,6 +258,8 @@ mod tests {
 			(Template::EVM, Some("./network.toml")),
 			(Template::ParityContracts, Some("./zombienet.toml")),
 			(Template::ParityFPT, Some("./zombienet-config.toml")),
+			(Template::TestTemplate01, Some("")),
+			(Template::TestTemplate02, Some("")),
 		]
 		.into()
 	}

--- a/crates/pop-parachains/src/templates.rs
+++ b/crates/pop-parachains/src/templates.rs
@@ -85,7 +85,7 @@ pub enum Template {
 		props(
 			Provider = "Pop",
 			Repository = "https://github.com/r0gue-io/base-parachain",
-			Network = "./network.toml",
+			Network = "./network.toml"
 		)
 	)]
 	Standard,
@@ -96,7 +96,7 @@ pub enum Template {
 		props(
 			Provider = "Pop",
 			Repository = "https://github.com/r0gue-io/assets-parachain",
-			Network = "./network.toml",
+			Network = "./network.toml"
 		)
 	)]
 	Assets,
@@ -107,7 +107,7 @@ pub enum Template {
 		props(
 			Provider = "Pop",
 			Repository = "https://github.com/r0gue-io/contracts-parachain",
-			Network = "./network.toml",
+			Network = "./network.toml"
 		)
 	)]
 	Contracts,
@@ -118,7 +118,7 @@ pub enum Template {
 		props(
 			Provider = "Pop",
 			Repository = "https://github.com/r0gue-io/evm-parachain",
-			Network = "./network.toml",
+			Network = "./network.toml"
 		)
 	)]
 	EVM,
@@ -130,7 +130,7 @@ pub enum Template {
 		props(
 			Provider = "Parity",
 			Repository = "https://github.com/paritytech/substrate-contracts-node",
-			Network = "./zombienet.toml",
+			Network = "./zombienet.toml"
 		)
 	)]
 	ParityContracts,
@@ -141,7 +141,7 @@ pub enum Template {
 		props(
 			Provider = "Parity",
 			Repository = "https://github.com/paritytech/frontier-parachain-template",
-			Network = "./zombienet-config.toml",
+			Network = "./zombienet-config.toml"
 		)
 	)]
 	ParityFPT,
@@ -156,7 +156,8 @@ pub enum Template {
 			Provider = "Test",
 			Repository = "",
 			Network = "",
-			SupportedVersions = "v1.0.0,v2.0.0"
+			SupportedVersions = "v1.0.0,v2.0.0",
+			IsAudited = "true"
 		)
 	)]
 	TestTemplate01,
@@ -203,6 +204,10 @@ impl Template {
 	pub fn is_supported_version(&self, version: &str) -> bool {
 		// if `SupportedVersion` is None, then all versions are supported. Otherwise, ensure version is present.
 		self.supported_versions().map_or(true, |versions| versions.contains(&version))
+	}
+
+	pub fn is_audited(&self) -> bool {
+		self.get_str("IsAudited").map_or(false, |s| s == "true")
 	}
 }
 
@@ -352,5 +357,14 @@ mod tests {
 		assert_eq!(template.supported_versions(), None);
 		// will be true because an empty SupportedVersions defaults to all
 		assert_eq!(template.is_supported_version("v1.0.0"), true);
+	}
+
+	#[test]
+	fn test_is_audited() {
+		let template = Template::TestTemplate01;
+		assert_eq!(template.is_audited(), true);
+
+		let template = Template::TestTemplate02;
+		assert_eq!(template.is_audited(), false);
 	}
 }

--- a/crates/pop-parachains/src/utils/git.rs
+++ b/crates/pop-parachains/src/utils/git.rs
@@ -192,12 +192,32 @@ impl GitHub {
 		Ok(commit)
 	}
 
+	pub async fn get_repo_license(&self) -> Result<String> {
+		static APP_USER_AGENT: &str =
+			concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+		let client = reqwest::ClientBuilder::new().user_agent(APP_USER_AGENT).build()?;
+		let url = self.api_license_url();
+		let response = client.get(url).send().await?;
+		let value = response.json::<serde_json::Value>().await?;
+		let license = value
+			.get("license")
+			.and_then(|v| v.get("spdx_id"))
+			.and_then(|v| v.as_str())
+			.map(|v| v.to_owned())
+			.ok_or(Error::Git("Unable to find license for GitHub repo".to_string()))?;
+		Ok(license)
+	}
+
 	fn api_releases_url(&self) -> String {
 		format!("{}/repos/{}/{}/releases", self.api, self.org, self.name)
 	}
 
 	fn api_tag_information(&self, tag_name: &str) -> String {
 		format!("{}/repos/{}/{}/git/ref/tags/{}", self.api, self.org, self.name, tag_name)
+	}
+
+	fn api_license_url(&self) -> String {
+		format!("{}/repos/{}/{}/license", self.api, self.org, self.name)
 	}
 
 	fn org(repo: &Url) -> Result<&str> {
@@ -265,6 +285,16 @@ mod tests {
 			.await
 	}
 
+	async fn license_mock(mock_server: &mut Server, repo: &GitHub, payload: &str) -> Mock {
+		mock_server
+			.mock("GET", format!("/repos/{}/{}/license", repo.org, repo.name).as_str())
+			.with_status(200)
+			.with_header("content-type", "application/json")
+			.with_body(payload)
+			.create_async()
+			.await
+	}
+
 	#[tokio::test]
 	async fn test_get_latest_releases() -> Result<(), Box<dyn std::error::Error>> {
 		let mut mock_server = Server::new_async().await;
@@ -312,6 +342,27 @@ mod tests {
 		Ok(())
 	}
 
+	#[tokio::test]
+	async fn get_repo_license() -> Result<(), Box<dyn std::error::Error>> {
+		let mut mock_server = Server::new_async().await;
+
+		let expected_payload = r#"{
+			"license": {
+			"key":"unlicense",
+			"name":"The Unlicense",
+			"spdx_id":"Unlicense",
+			"url":"https://api.github.com/licenses/unlicense",
+			"node_id":"MDc6TGljZW5zZTE1"
+			}
+		}"#;
+		let repo = GitHub::parse(BASE_PARACHAIN)?.with_api(&mock_server.url());
+		let mock = license_mock(&mut mock_server, &repo, expected_payload).await;
+		let license = repo.get_repo_license().await?;
+		assert_eq!(license, "Unlicense".to_string());
+		mock.assert_async().await;
+		Ok(())
+	}
+
 	#[test]
 	fn test_get_releases_api_url() -> Result<(), Box<dyn std::error::Error>> {
 		assert_eq!(
@@ -326,6 +377,15 @@ mod tests {
 		assert_eq!(
 			GitHub::parse(POLKADOT_SDK)?.api_tag_information("polkadot-v1.11.0"),
 			"https://api.github.com/repos/paritytech/polkadot-sdk/git/ref/tags/polkadot-v1.11.0"
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn test_api_license_url() -> Result<(), Box<dyn std::error::Error>> {
+		assert_eq!(
+			GitHub::parse(POLKADOT_SDK)?.api_license_url(),
+			"https://api.github.com/repos/paritytech/polkadot-sdk/license"
 		);
 		Ok(())
 	}


### PR DESCRIPTION
This PR introduces UX improvements to the pop new parachain command.
- Warns user if template does not have any releases
- Introduces an optional "SupportedVersions" field to the Template variants.
- Introduces an optional "IsAudited" field to the Template variants. If set to true, will hide the audit warning.
- Displays the repo license for the template

SupportedVersions is introduced as a simple way to support OpenZeppelin templates. Right now, OpenZeppelin's default branch uses a monorepo style. However, the `v1.0.0` release does not use a monorepo. By specifying the supported version, we can control the flow in a consistent way. When OpenZeppelin introduces a release with the monorepo, we will be able to use the supported versions to not support v1.0.0 and we can introduce additional parameters to properly setup the sub-directory.

By default `SupportedVersion` (when not present) supports all versions and default branch. However, if something is set, then it will only support those versions.