### PR TITLE
test: increase coverage build function

### DIFF
--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0
-
-use std::path::PathBuf;
-
 use clap::Args;
 use cliclack::{clear_screen, intro, log, outro, set_theme};
 use console::style;
+use std::path::PathBuf;
 
+#[cfg(test)]
+use crate::mock::build_smart_contract;
 use crate::style::Theme;
+#[cfg(not(test))]
 use pop_contracts::build_smart_contract;
 
 #[derive(Args)]
@@ -24,6 +25,35 @@ impl BuildContractCommand {
 		let result_build = build_smart_contract(&self.path)?;
 		outro("Build completed successfully!")?;
 		log::success(result_build.to_string())?;
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::new::contract::NewContractCommand;
+	use anyhow::{Error, Result};
+
+	async fn setup_test_environment() -> Result<tempfile::TempDir, Error> {
+		let temp_contract_dir = tempfile::tempdir().expect("Could not create temp dir");
+		let command = NewContractCommand {
+			name: "test_contract".to_string(),
+			path: Some(PathBuf::from(temp_contract_dir.path())),
+		};
+		command.execute().await?;
+
+		Ok(temp_contract_dir)
+	}
+
+	#[tokio::test]
+	async fn test_build_success() -> Result<()> {
+		let temp_dir = setup_test_environment().await?;
+		let command = BuildContractCommand {
+			path: Some(PathBuf::from(temp_dir.path().join("test_contract"))),
+		};
+
+		command.execute()?;
 		Ok(())
 	}
 }

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0
 
+#[cfg(test)]
+use crate::mock::build_parachain;
 use crate::style::{style, Theme};
 use clap::Args;
 use cliclack::{clear_screen, intro, log::warning, outro, set_theme};
+#[cfg(not(test))]
 use pop_parachains::build_parachain;
 use std::path::PathBuf;
 
@@ -26,6 +29,41 @@ impl BuildParachainCommand {
 		build_parachain(&self.path)?;
 
 		outro("Build Completed Successfully!")?;
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::new::parachain::NewParachainCommand;
+	use anyhow::{Error, Result};
+	use pop_parachains::{Provider, Template};
+
+	async fn setup_test_environment() -> Result<tempfile::TempDir, Error> {
+		let temp_dir = tempfile::tempdir().expect("Could not create temp dir");
+		let command = NewParachainCommand {
+			name: Some(temp_dir.path().join("test_parachain").to_str().unwrap().to_string()),
+			provider: Some(Provider::Pop),
+			template: Some(Template::Standard),
+			release_tag: None,
+			symbol: Some("UNIT".to_string()),
+			decimals: Some(12),
+			initial_endowment: Some("1u64 << 60".to_string()),
+		};
+		command.execute().await?;
+
+		Ok(temp_dir)
+	}
+
+	#[tokio::test]
+	async fn test_build_success() -> Result<()> {
+		let temp_dir = setup_test_environment().await?;
+		let command = BuildParachainCommand {
+			path: Some(PathBuf::from(temp_dir.path().join("test_parachain"))),
+		};
+
+		command.execute()?;
 		Ok(())
 	}
 }

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0
-
 #[cfg(test)]
 use crate::mock::build_parachain;
 use crate::style::{style, Theme};

--- a/crates/pop-cli/src/main.rs
+++ b/crates/pop-cli/src/main.rs
@@ -5,6 +5,8 @@ compile_error!("feature \"contract\" or feature \"parachain\" must be enabled");
 
 #[cfg(any(feature = "parachain", feature = "contract"))]
 mod commands;
+#[cfg(test)]
+mod mock;
 mod style;
 
 use anyhow::anyhow;

--- a/crates/pop-cli/src/mock.rs
+++ b/crates/pop-cli/src/mock.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 use std::path::PathBuf;
 
 // Mock the build function for parachains

--- a/crates/pop-cli/src/mock.rs
+++ b/crates/pop-cli/src/mock.rs
@@ -1,7 +1,13 @@
 use std::path::PathBuf;
 
-// Mock the build function
+// Mock the build function for parachains
 #[cfg(test)]
 pub fn build_parachain(_path: &Option<PathBuf>) -> anyhow::Result<()> {
 	Ok(())
+}
+
+// Mock the build function for smart contracts
+#[cfg(test)]
+pub fn build_smart_contract(_path: &Option<PathBuf>) -> anyhow::Result<String> {
+	Ok("Ok".to_string())
 }

--- a/crates/pop-cli/src/mock.rs
+++ b/crates/pop-cli/src/mock.rs
@@ -1,0 +1,7 @@
+use std::path::PathBuf;
+
+// Mock the build function
+#[cfg(test)]
+pub fn build_parachain(_path: &Option<PathBuf>) -> anyhow::Result<()> {
+	Ok(())
+}

--- a/crates/pop-contracts/src/build.rs
+++ b/crates/pop-contracts/src/build.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0
 #[cfg(test)]
 use crate::mock::execute;
+use crate::utils::helpers::get_manifest_path;
 #[cfg(not(test))]
 use contract_build::execute;
 use std::path::PathBuf;
-
-use crate::utils::helpers::get_manifest_path;
 
 /// Build the smart contract located in the specified `path`.
 pub fn build_smart_contract(path: &Option<PathBuf>) -> anyhow::Result<String> {

--- a/crates/pop-contracts/src/build.rs
+++ b/crates/pop-contracts/src/build.rs
@@ -29,7 +29,10 @@ mod tests {
 	fn test_build_contract() -> Result<()> {
 		let temp_dir = tempfile::tempdir().expect("Could not create temp dir");
 		let result = build_smart_contract(&Some(PathBuf::from(temp_dir.path())))?;
-		assert_eq!(result, "\nOriginal wasm size: \u{1b}[1m64.0K\u{1b}[0m, Optimized: \u{1b}[1m32.0K\u{1b}[0m\n\nThe contract was built in \u{1b}[1mDEBUG\u{1b}[0m mode.\n\nYour contract artifacts are ready. You can find them in:\n\u{1b}[1m/path/to/target\u{1b}[0m\n\n  - \u{1b}[1mcontract.contract\u{1b}[0m (code + metadata)\n  - \u{1b}[1mcontract.wasm\u{1b}[0m (the contract's code)\n  - \u{1b}[1mcontract.json\u{1b}[0m (the contract's metadata)");
+		assert!(result.contains("Original wasm size:"));
+		assert!(result.contains("64.0K"));
+		assert!(result.contains("Optimized:"));
+		assert!(result.contains("32.0K"));
 		Ok(())
 	}
 }

--- a/crates/pop-contracts/src/build.rs
+++ b/crates/pop-contracts/src/build.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
-use contract_build::{execute, ExecuteArgs};
+#[cfg(test)]
+use crate::mock::execute;
+#[cfg(not(test))]
+use contract_build::execute;
 use std::path::PathBuf;
 
 use crate::utils::helpers::get_manifest_path;
@@ -8,11 +11,25 @@ use crate::utils::helpers::get_manifest_path;
 pub fn build_smart_contract(path: &Option<PathBuf>) -> anyhow::Result<String> {
 	let manifest_path = get_manifest_path(path)?;
 	// Default values
-	let args = ExecuteArgs { manifest_path, ..Default::default() };
+	let args = contract_build::ExecuteArgs { manifest_path, ..Default::default() };
 
 	// Execute the build and log the output of the build
 	let result = execute(args)?;
 	let formatted_result = result.display();
 
 	Ok(formatted_result)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn test_build_contract() -> Result<()> {
+		let temp_dir = tempfile::tempdir().expect("Could not create temp dir");
+		let result = build_smart_contract(&Some(PathBuf::from(temp_dir.path())))?;
+		assert_eq!(result, "\nOriginal wasm size: \u{1b}[1m64.0K\u{1b}[0m, Optimized: \u{1b}[1m32.0K\u{1b}[0m\n\nThe contract was built in \u{1b}[1mDEBUG\u{1b}[0m mode.\n\nYour contract artifacts are ready. You can find them in:\n\u{1b}[1m/path/to/target\u{1b}[0m\n\n  - \u{1b}[1mcontract.contract\u{1b}[0m (code + metadata)\n  - \u{1b}[1mcontract.wasm\u{1b}[0m (the contract's code)\n  - \u{1b}[1mcontract.json\u{1b}[0m (the contract's metadata)");
+		Ok(())
+	}
 }

--- a/crates/pop-contracts/src/lib.rs
+++ b/crates/pop-contracts/src/lib.rs
@@ -8,6 +8,9 @@ mod test;
 mod up;
 mod utils;
 
+#[cfg(test)]
+mod mock;
+
 pub use build::build_smart_contract;
 pub use call::{
 	call_smart_contract, dry_run_call, dry_run_gas_estimate_call, set_up_call, CallOpts,

--- a/crates/pop-contracts/src/mock.rs
+++ b/crates/pop-contracts/src/mock.rs
@@ -1,9 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
 use std::path::PathBuf;
 
 use contract_build::{
 	BuildResult, ExecuteArgs, MetadataArtifacts, OptimizationResult, OutputType, Verbosity,
 };
-// Mock the call to contract_build execute function that builds the contract
+// Mock the call to the `execute` function of the `contract_build' crate that builds the contract
 pub fn execute(_args: ExecuteArgs) -> anyhow::Result<BuildResult> {
 	Ok(BuildResult {
 		dest_wasm: Some(PathBuf::from("/path/to/contract.wasm")),

--- a/crates/pop-contracts/src/mock.rs
+++ b/crates/pop-contracts/src/mock.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
-use std::path::PathBuf;
-
 use contract_build::{
 	BuildResult, ExecuteArgs, MetadataArtifacts, OptimizationResult, OutputType, Verbosity,
 };
+use std::path::PathBuf;
+
 // Mock the call to the `execute` function of the `contract_build' crate that builds the contract
 pub fn execute(_args: ExecuteArgs) -> anyhow::Result<BuildResult> {
 	Ok(BuildResult {

--- a/crates/pop-contracts/src/mock.rs
+++ b/crates/pop-contracts/src/mock.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+
+use contract_build::{
+	BuildResult, ExecuteArgs, MetadataArtifacts, OptimizationResult, OutputType, Verbosity,
+};
+// Mock the call to contract_build execute function that builds the contract
+pub fn execute(_args: ExecuteArgs) -> anyhow::Result<BuildResult> {
+	Ok(BuildResult {
+		dest_wasm: Some(PathBuf::from("/path/to/contract.wasm")),
+		metadata_result: Some(MetadataArtifacts {
+			dest_metadata: PathBuf::from("/path/to/contract.json"),
+			dest_bundle: PathBuf::from("/path/to/contract.contract"),
+		}),
+		target_directory: PathBuf::from("/path/to/target"),
+		optimization_result: Some(OptimizationResult { original_size: 64.0, optimized_size: 32.0 }),
+		build_mode: Default::default(),
+		build_artifact: Default::default(),
+		image: None,
+		verbosity: Verbosity::Quiet,
+		output_type: OutputType::Json,
+	})
+}

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
+#[cfg(test)]
+use crate::mock::cmd;
+#[cfg(not(test))]
 use duct::cmd;
 use std::path::PathBuf;
 
@@ -9,4 +12,17 @@ pub fn build_parachain(path: &Option<PathBuf>) -> anyhow::Result<()> {
 		.run()?;
 
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn test_build_parachain() -> Result<()> {
+		let temp_dir = tempfile::tempdir().expect("Could not create temp dir");
+		build_parachain(&Some(PathBuf::from(temp_dir.path())))?;
+		Ok(())
+	}
 }

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -3,14 +3,13 @@
 mod build;
 mod errors;
 mod generator;
+#[cfg(test)]
+mod mock;
 mod new_pallet;
 mod new_parachain;
 mod templates;
 mod up;
 mod utils;
-
-#[cfg(test)]
-mod mock;
 
 pub use build::build_parachain;
 pub use errors::Error;

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -9,6 +9,9 @@ mod templates;
 mod up;
 mod utils;
 
+#[cfg(test)]
+mod mock;
+
 pub use build::build_parachain;
 pub use errors::Error;
 pub use new_pallet::{create_pallet_template, TemplatePalletConfig};

--- a/crates/pop-parachains/src/mock.rs
+++ b/crates/pop-parachains/src/mock.rs
@@ -1,0 +1,4 @@
+// Mock the command that build the parachain
+pub fn cmd(_program: &str, _args: Vec<&str>) -> duct::Expression {
+	duct::cmd!("echo")
+}

--- a/crates/pop-parachains/src/mock.rs
+++ b/crates/pop-parachains/src/mock.rs
@@ -1,4 +1,6 @@
-// Mock the command that build the parachain
+// SPDX-License-Identifier: GPL-3.0
+
+// Mock the command that builds the parachain
 pub fn cmd(_program: &str, _args: Vec<&str>) -> duct::Expression {
 	duct::cmd!("echo")
 }


### PR DESCRIPTION
Unit tests for the build parachain and build contracts processes.

Utilize mocks for the external crates that are used: `duct::cmd` for building parachain and `contract_build::execute` for building contracts.