### PR TITLE
feat: add OpenZeppelin template

### DIFF
--- a/crates/pop-parachains/src/templates.rs
+++ b/crates/pop-parachains/src/templates.rs
@@ -20,6 +20,13 @@ pub enum Provider {
 	Pop,
 	#[strum(
 		ascii_case_insensitive,
+		serialize = "openzeppelin",
+		message = "OpenZeppelin",
+		detailed_message = "The standard for secure blockchain applications."
+	)]
+	OpenZeppelin,
+	#[strum(
+		ascii_case_insensitive,
 		serialize = "parity",
 		message = "Parity",
 		detailed_message = "Solutions for a trust-free world."
@@ -42,6 +49,7 @@ impl Provider {
 	pub fn default_template(&self) -> Template {
 		match &self {
 			Provider::Pop => Template::Standard,
+			Provider::OpenZeppelin => Template::OpenZeppelinGeneric,
 			Provider::Parity => Template::ParityContracts,
 		}
 	}
@@ -133,6 +141,20 @@ pub enum Template {
 		)
 	)]
 	EVM,
+	// OpenZeppelin
+	#[strum(
+		serialize = "polkadot-generic-runtime-template",
+		message = "Generic Runtime Template",
+		detailed_message = "A generic template for Substrate Runtime",
+		props(
+			Provider = "OpenZeppelin",
+			Repository = "https://github.com/OpenZeppelin/polkadot-generic-runtime-template",
+			Network = "./zombienet-config/devnet.toml",
+			SupportedVersions = "v1.0.0",
+			IsAudited = "true"
+		)
+	)]
+	OpenZeppelinGeneric,
 	/// Minimal Substrate node configured for smart contracts via pallet-contracts.
 	#[strum(
 		serialize = "cpt",
@@ -248,6 +270,8 @@ mod tests {
 			("assets".to_string(), Template::Assets),
 			("contracts".to_string(), Template::Contracts),
 			("evm".to_string(), Template::EVM),
+			// openzeppelin
+			("polkadot-generic-runtime-template".to_string(), Template::OpenZeppelinGeneric),
 			("cpt".to_string(), Template::ParityContracts),
 			("fpt".to_string(), Template::ParityFPT),
 			("test_01".to_string(), Template::TestTemplate01),
@@ -261,6 +285,11 @@ mod tests {
 			("assets".to_string(), "https://github.com/r0gue-io/assets-parachain"),
 			("contracts".to_string(), "https://github.com/r0gue-io/contracts-parachain"),
 			("evm".to_string(), "https://github.com/r0gue-io/evm-parachain"),
+			// openzeppelin
+			(
+				"polkadot-generic-runtime-template".to_string(),
+				"https://github.com/OpenZeppelin/polkadot-generic-runtime-template",
+			),
 			("cpt".to_string(), "https://github.com/paritytech/substrate-contracts-node"),
 			("fpt".to_string(), "https://github.com/paritytech/frontier-parachain-template"),
 			("test_01".to_string(), ""),
@@ -274,6 +303,7 @@ mod tests {
 			(Template::Assets, Some("./network.toml")),
 			(Template::Contracts, Some("./network.toml")),
 			(Template::EVM, Some("./network.toml")),
+			(Template::OpenZeppelinGeneric, Some("./zombienet-config/devnet.toml")),
 			(Template::ParityContracts, Some("./zombienet.toml")),
 			(Template::ParityFPT, Some("./zombienet-config.toml")),
 			(Template::TestTemplate01, Some("")),


### PR DESCRIPTION
This PR adds support for the OpenZeppelin Generic Polkadot Runtime Template.

Non-audited OpenZeppelin templates are not supported. OpenZeppelin's only release is not in the monorepo format. So, any future releases will need additional changes to support the monorepo. 

Co-authored-by: Frank Bell <60948618+evilrobot-01@users.noreply.github.com>