### PR TITLE
draft: build parachain on missing local binaries

### DIFF
--- a/crates/pop-cli/src/commands/up/parachain.rs
+++ b/crates/pop-cli/src/commands/up/parachain.rs
@@ -7,9 +7,10 @@ use cliclack::{
 };
 use console::{Emoji, Style};
 use duct::cmd;
-use pop_parachains::{Error, NetworkNode, Source, Status, Zombienet};
+use pop_parachains::{build_parachain, Error, NetworkNode, Source, Status, Zombienet};
 use std::{fs::remove_dir_all, time::Duration};
 use tokio::time::sleep;
+use std::path::PathBuf;
 
 #[derive(Args)]
 pub(crate) struct ZombienetCommand {
@@ -160,6 +161,9 @@ impl ZombienetCommand {
 			// Check for any local binaries which need to be built manually
 			let local: Vec<_> = missing.iter().filter(|(_, _, local)| *local).collect();
 			if local.len() > 0 {
+				for (name, binary, _) in local.iter() {
+					let _ = build_parachain(&Some(PathBuf::from(binary.name.clone())));
+				}
 				outro_cancel(
 					"🚫 Please manually build the missing binaries at the paths specified and try again.",
 				)?;

--- a/crates/pop-cli/src/commands/up/parachain.rs
+++ b/crates/pop-cli/src/commands/up/parachain.rs
@@ -84,6 +84,23 @@ impl ZombienetCommand {
 			.to_string();
 			log::warning(format!("⚠️ The following binaries specified in the network configuration file cannot be found locally:\n   {list}"))?;
 
+			// Check for any local binaries which need to be built manually
+			let local: Vec<_> = missing.iter().filter(|(_, _, local)| *local).collect();
+			if local.len() > 0 {
+
+				for (name, binary, _) in local.iter() {
+					intro(format!("{}: Building your parachain", style(" Pop CLI ")
+						.black()
+						.on_magenta()
+					))?;
+					let _ = build_parachain(&Some(PathBuf::from(name.clone())))?;
+				}
+				outro_cancel(
+					"🚫 Please manually build the missing binaries at the paths specified and retry node spinup.",
+				)?;
+				return Ok(());
+			}
+
 			// Prompt for automatic sourcing of remote binaries
 			let remote: Vec<_> = missing.iter().filter(|(_, _, local)| !local).collect();
 			if remote.len() > 0 {
@@ -156,18 +173,6 @@ impl ZombienetCommand {
 
 				// Remove working directory once completed successfully
 				remove_dir_all(working_dir)?
-			}
-
-			// Check for any local binaries which need to be built manually
-			let local: Vec<_> = missing.iter().filter(|(_, _, local)| *local).collect();
-			if local.len() > 0 {
-				for (name, binary, _) in local.iter() {
-					let _ = build_parachain(&Some(PathBuf::from(binary.name.clone())));
-				}
-				outro_cancel(
-					"🚫 Please manually build the missing binaries at the paths specified and try again.",
-				)?;
-				return Ok(());
 			}
 		}
 


### PR DESCRIPTION
While trying to spin up a substrate node using `pop up parachain`, the command will fail if the node has not been built/compiled already using `pop build parachain`.

This PR will automatically check if there is a build/binary existing for the node and then allow `pop up...` to progress. 