### PR TITLE
fix: Correct TG link

### DIFF
--- a/crates/pop-telemetry/README.md
+++ b/crates/pop-telemetry/README.md
@@ -72,6 +72,6 @@ If you have any questions or concerns regarding our telemetry practices, please 
 hesitate to contact us:
 
 - Contact form: [r0gue.io/contact](https://r0gue.io/contact)
-- Telegram: [@Pop_Network](https://t.me/Pop_Network)
+- Telegram: [Pop_Network](https://t.me/onpopio)
 
 Thank you for your support and understanding.


### PR DESCRIPTION
Documentation of crate `pop-telemetry` was using the old TG link.