### PR TITLE
refactor: standardise commands

### DIFF
--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use std::path::PathBuf;
-
+use crate::style::Theme;
 use clap::Args;
 use cliclack::{clear_screen, intro, log, outro, set_theme};
 use console::style;
-
-use crate::style::Theme;
 use pop_contracts::build_smart_contract;
+use std::path::PathBuf;
 
 #[derive(Args)]
 pub struct BuildContractCommand {
@@ -20,7 +18,8 @@ pub struct BuildContractCommand {
 }
 
 impl BuildContractCommand {
-	pub(crate) fn execute(&self) -> anyhow::Result<()> {
+	/// Executes the command.
+	pub(crate) fn execute(self) -> anyhow::Result<()> {
 		clear_screen()?;
 		intro(format!("{}: Building your contract", style(" Pop CLI ").black().on_magenta()))?;
 		set_theme(Theme);

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -7,15 +7,17 @@ pub(crate) mod contract;
 #[cfg(feature = "parachain")]
 pub(crate) mod parachain;
 
+/// Arguments for building a project.
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
 pub(crate) struct BuildArgs {
 	#[command(subcommand)]
-	pub command: BuildCommands,
+	pub command: Command,
 }
 
+/// Build a parachain or smart contract.
 #[derive(Subcommand)]
-pub(crate) enum BuildCommands {
+pub(crate) enum Command {
 	/// Build a parachain
 	#[cfg(feature = "parachain")]
 	#[clap(alias = "p")]

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -17,7 +17,8 @@ pub struct BuildParachainCommand {
 }
 
 impl BuildParachainCommand {
-	pub(crate) fn execute(&self) -> anyhow::Result<()> {
+	/// Executes the command.
+	pub(crate) fn execute(self) -> anyhow::Result<()> {
 		clear_screen()?;
 		intro(format!("{}: Building your parachain", style(" Pop CLI ").black().on_magenta()))?;
 		set_theme(Theme);

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
+use crate::style::Theme;
 use anyhow::anyhow;
 use clap::Args;
 use cliclack::{clear_screen, intro, log, outro, outro_cancel, set_theme};
@@ -9,8 +10,6 @@ use pop_contracts::{
 };
 use sp_weights::Weight;
 use std::path::PathBuf;
-
-use crate::style::Theme;
 
 #[derive(Args)]
 pub struct CallContractCommand {
@@ -54,7 +53,8 @@ pub struct CallContractCommand {
 }
 
 impl CallContractCommand {
-	pub(crate) async fn execute(&self) -> anyhow::Result<()> {
+	/// Executes the command.
+	pub(crate) async fn execute(self) -> anyhow::Result<()> {
 		clear_screen()?;
 		intro(format!("{}: Calling a contract", style(" Pop CLI ").black().on_magenta()))?;
 		set_theme(Theme);

--- a/crates/pop-cli/src/commands/call/mod.rs
+++ b/crates/pop-cli/src/commands/call/mod.rs
@@ -5,15 +5,17 @@ use clap::{Args, Subcommand};
 #[cfg(feature = "contract")]
 pub(crate) mod contract;
 
+/// Arguments for calling a smart contract.
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
 pub(crate) struct CallArgs {
 	#[command(subcommand)]
-	pub command: CallCommands,
+	pub command: Command,
 }
 
+/// Call a smart contract.
 #[derive(Subcommand)]
-pub(crate) enum CallCommands {
+pub(crate) enum Command {
 	/// Call a contract
 	#[cfg(feature = "contract")]
 	#[clap(alias = "c")]

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -1,8 +1,97 @@
 // SPDX-License-Identifier: GPL-3.0
 
+use clap::Subcommand;
+use serde_json::{json, Value};
+
 pub(crate) mod build;
 pub(crate) mod call;
 pub(crate) mod install;
 pub(crate) mod new;
 pub(crate) mod test;
 pub(crate) mod up;
+
+#[derive(Subcommand)]
+#[command(subcommand_required = true)]
+pub(crate) enum Command {
+	/// Generate a new parachain, pallet or smart contract.
+	#[clap(alias = "n")]
+	#[cfg(any(feature = "parachain", feature = "contract"))]
+	New(new::NewArgs),
+	/// Build a parachain or smart contract.
+	#[clap(alias = "b")]
+	#[cfg(any(feature = "parachain", feature = "contract"))]
+	Build(build::BuildArgs),
+	/// Call a smart contract.
+	#[clap(alias = "c")]
+	#[cfg(feature = "contract")]
+	Call(call::CallArgs),
+	/// Launch a local network or deploy a smart contract.
+	#[clap(alias = "u")]
+	#[cfg(any(feature = "parachain", feature = "contract"))]
+	Up(up::UpArgs),
+	/// Test a smart contract.
+	#[clap(alias = "t")]
+	#[cfg(feature = "contract")]
+	Test(test::TestArgs),
+	/// Set up the environment for development by installing required packages.
+	#[clap(alias = "i")]
+	Install(install::InstallArgs),
+}
+
+impl Command {
+	/// Executes the command.
+	pub(crate) async fn execute(self) -> anyhow::Result<Value> {
+		match self {
+			#[cfg(any(feature = "parachain", feature = "contract"))]
+			Self::New(args) => match args.command {
+				#[cfg(feature = "parachain")]
+				new::Command::Parachain(cmd) => match cmd.execute().await {
+					Ok(template) => {
+						// telemetry should never cause a panic or early exit
+						Ok(
+							json!({template.provider().unwrap_or("provider-missing"): template.name()}),
+						)
+					},
+					Err(e) => Err(e),
+				},
+				#[cfg(feature = "parachain")]
+				new::Command::Pallet(cmd) => {
+					// When more contract selections are added the tel data will likely need to go deeper in the stack
+					cmd.execute().await.map(|_| json!("template"))
+				},
+				#[cfg(feature = "contract")]
+				new::Command::Contract(cmd) => {
+					// When more contract selections are added, the tel data will likely need to go deeper in the stack
+					cmd.execute().await.map(|_| json!("default"))
+				},
+			},
+			#[cfg(any(feature = "parachain", feature = "contract"))]
+			Self::Build(args) => match args.command {
+				#[cfg(feature = "parachain")]
+				build::Command::Parachain(cmd) => cmd.execute().map(|_| Value::Null),
+				#[cfg(feature = "contract")]
+				build::Command::Contract(cmd) => cmd.execute().map(|_| Value::Null),
+			},
+			#[cfg(feature = "contract")]
+			Self::Call(args) => match args.command {
+				call::Command::Contract(cmd) => cmd.execute().await.map(|_| Value::Null),
+			},
+			#[cfg(any(feature = "parachain", feature = "contract"))]
+			Self::Up(args) => match args.command {
+				#[cfg(feature = "parachain")]
+				up::Command::Parachain(cmd) => cmd.execute().await.map(|_| Value::Null),
+				#[cfg(feature = "contract")]
+				up::Command::Contract(cmd) => cmd.execute().await.map(|_| Value::Null),
+			},
+			#[cfg(feature = "contract")]
+			Self::Test(args) => match args.command {
+				test::Command::Contract(cmd) => match cmd.execute() {
+					Ok(feature) => Ok(json!(feature)),
+					Err(e) => Err(e),
+				},
+			},
+			#[cfg(any(feature = "parachain", feature = "contract"))]
+			Self::Install(args) => install::Command.execute(args).await.map(|_| Value::Null),
+		}
+	}
+}

--- a/crates/pop-cli/src/commands/new/contract.rs
+++ b/crates/pop-cli/src/commands/new/contract.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use std::{env::current_dir, fs, path::PathBuf};
-
+use crate::style::Theme;
 use clap::Args;
 use cliclack::{clear_screen, confirm, intro, outro, outro_cancel, set_theme};
 use console::style;
-
-use crate::style::Theme;
 use pop_contracts::create_smart_contract;
+use std::{env::current_dir, fs, path::PathBuf};
 
 #[derive(Args)]
 pub struct NewContractCommand {
@@ -18,7 +16,8 @@ pub struct NewContractCommand {
 }
 
 impl NewContractCommand {
-	pub(crate) async fn execute(&self) -> anyhow::Result<()> {
+	/// Executes the command.
+	pub(crate) async fn execute(self) -> anyhow::Result<()> {
 		clear_screen()?;
 		intro(format!(
 			"{}: Generating new contract \"{}\"!",

--- a/crates/pop-cli/src/commands/new/mod.rs
+++ b/crates/pop-cli/src/commands/new/mod.rs
@@ -9,22 +9,24 @@ pub mod pallet;
 #[cfg(feature = "parachain")]
 pub mod parachain;
 
+/// Arguments for generating a new project.
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
 pub struct NewArgs {
 	#[command(subcommand)]
-	pub command: NewCommands,
+	pub command: Command,
 }
 
+/// Generate a new parachain, pallet or smart contract.
 #[derive(Subcommand)]
-pub enum NewCommands {
+pub enum Command {
 	/// Generate a new parachain
 	#[cfg(feature = "parachain")]
 	#[clap(alias = "p")]
 	Parachain(parachain::NewParachainCommand),
 	/// Generate a new pallet
 	#[cfg(feature = "parachain")]
-	#[clap(alias = "m")] // (m)odule, as p used above
+	#[clap(alias = "P")]
 	Pallet(pallet::NewPalletCommand),
 	/// Generate a new smart contract
 	#[cfg(feature = "contract")]

--- a/crates/pop-cli/src/commands/new/pallet.rs
+++ b/crates/pop-cli/src/commands/new/pallet.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
+
 use crate::style::Theme;
 use clap::Args;
 use cliclack::{clear_screen, confirm, intro, outro, outro_cancel, set_theme};
@@ -19,7 +20,8 @@ pub struct NewPalletCommand {
 }
 
 impl NewPalletCommand {
-	pub(crate) async fn execute(&self) -> anyhow::Result<()> {
+	/// Executes the command.
+	pub(crate) async fn execute(self) -> anyhow::Result<()> {
 		clear_screen()?;
 		intro(format!(
 			"{}: Generating new pallet \"{}\"!",

--- a/crates/pop-cli/src/commands/new/parachain.rs
+++ b/crates/pop-cli/src/commands/new/parachain.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
+
 use crate::style::{style, Theme};
 use anyhow::Result;
 use clap::{
@@ -72,7 +73,8 @@ macro_rules! enum_variants {
 }
 
 impl NewParachainCommand {
-	pub(crate) async fn execute(&self) -> Result<Template> {
+	/// Executes the command.
+	pub(crate) async fn execute(self) -> Result<Template> {
 		clear_screen()?;
 		set_theme(Theme);
 
@@ -158,6 +160,7 @@ async fn guide_user_to_generate_parachain() -> Result<NewParachainCommand> {
 		initial_endowment: Some(customizable_options.initial_endowment),
 	})
 }
+
 fn generate_parachain_from_template(
 	name_template: &String,
 	provider: &Provider,
@@ -388,9 +391,9 @@ mod tests {
 
 	use super::*;
 	use crate::{
-		commands::new::{NewArgs, NewCommands::Parachain},
+		commands::new::{Command::Parachain, NewArgs},
 		Cli,
-		Commands::New,
+		Command::New,
 	};
 	use clap::Parser;
 	use git2::Repository;
@@ -410,10 +413,10 @@ mod tests {
 			panic!("unable to parse command")
 		};
 		// Execute
-		let name = command.name.as_ref().unwrap();
+		let name = command.name.clone().unwrap();
 		command.execute().await?;
 		// check for git_init
-		let repo = Repository::open(Path::new(name))?;
+		let repo = Repository::open(Path::new(&name))?;
 		let reflog = repo.reflog("HEAD")?;
 		assert_eq!(reflog.len(), 1);
 		Ok(())
@@ -422,8 +425,9 @@ mod tests {
 	#[tokio::test]
 	async fn test_new_parachain_command_execute() -> Result<()> {
 		let dir = tempdir()?;
+		let name = dir.path().join("test_parachain").to_str().unwrap().to_string();
 		let command = NewParachainCommand {
-			name: Some(dir.path().join("test_parachain").to_str().unwrap().to_string()),
+			name: Some(name.clone()),
 			provider: Some(Provider::Pop),
 			template: Some(Template::Standard),
 			release_tag: None,
@@ -434,7 +438,7 @@ mod tests {
 		command.execute().await?;
 
 		// check for git_init
-		let repo = Repository::open(Path::new(&command.name.unwrap()))?;
+		let repo = Repository::open(Path::new(&name))?;
 		let reflog = repo.reflog("HEAD")?;
 		assert_eq!(reflog.len(), 1);
 

--- a/crates/pop-cli/src/commands/test/contract.rs
+++ b/crates/pop-cli/src/commands/test/contract.rs
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use std::path::PathBuf;
-
+use crate::style::style;
 use clap::Args;
 use cliclack::{clear_screen, intro, outro};
 use pop_contracts::{test_e2e_smart_contract, test_smart_contract};
-
-use crate::style::style;
+use std::path::PathBuf;
 
 #[derive(Args)]
 pub(crate) struct TestContractCommand {
@@ -17,7 +15,8 @@ pub(crate) struct TestContractCommand {
 }
 
 impl TestContractCommand {
-	pub(crate) fn execute(&self) -> anyhow::Result<&str> {
+	/// Executes the command.
+	pub(crate) fn execute(self) -> anyhow::Result<&'static str> {
 		clear_screen()?;
 
 		if self.features.is_some() && self.features.clone().unwrap().contains("e2e-tests") {

--- a/crates/pop-cli/src/commands/test/mod.rs
+++ b/crates/pop-cli/src/commands/test/mod.rs
@@ -5,15 +5,17 @@ use clap::{Args, Subcommand};
 #[cfg(feature = "contract")]
 pub mod contract;
 
+/// Arguments for testing.
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
 pub(crate) struct TestArgs {
 	#[command(subcommand)]
-	pub command: TestCommands,
+	pub command: Command,
 }
 
+/// Test a smart contract.
 #[derive(Subcommand)]
-pub(crate) enum TestCommands {
+pub(crate) enum Command {
 	/// Test a smart contract
 	#[cfg(feature = "contract")]
 	#[clap(alias = "c")]

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
+use crate::style::style;
 use anyhow::anyhow;
 use clap::Args;
 use cliclack::{clear_screen, confirm, intro, log, outro, outro_cancel};
@@ -10,8 +11,6 @@ use pop_contracts::{
 use sp_core::Bytes;
 use sp_weights::Weight;
 use std::path::PathBuf;
-
-use crate::style::style;
 
 #[derive(Args)]
 pub struct UpContractCommand {
@@ -54,8 +53,10 @@ pub struct UpContractCommand {
 	#[clap(short('y'), long)]
 	skip_confirm: bool,
 }
+
 impl UpContractCommand {
-	pub(crate) async fn execute(&self) -> anyhow::Result<()> {
+	/// Executes the command.
+	pub(crate) async fn execute(self) -> anyhow::Result<()> {
 		clear_screen()?;
 
 		// Check if build exists in the specified "Contract build folder"
@@ -64,7 +65,7 @@ impl UpContractCommand {
 		);
 
 		if !build_path.as_path().exists() {
-			log::warning(format!("NOTE: contract has not yet been built."))?;
+			log::warning("NOTE: contract has not yet been built.")?;
 			intro(format!("{}: Building a contract", style(" Pop CLI ").black().on_magenta()))?;
 			// Build the contract in release mode
 			let result = build_smart_contract(&self.path, true)?;

--- a/crates/pop-cli/src/commands/up/mod.rs
+++ b/crates/pop-cli/src/commands/up/mod.rs
@@ -1,21 +1,23 @@
 // SPDX-License-Identifier: GPL-3.0
 
+use clap::{Args, Subcommand};
+
 #[cfg(feature = "contract")]
 mod contract;
 #[cfg(feature = "parachain")]
 mod parachain;
 
-use clap::{Args, Subcommand};
-
+/// Arguments for launching or deploying.
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
 pub(crate) struct UpArgs {
 	#[command(subcommand)]
-	pub(crate) command: UpCommands,
+	pub(crate) command: Command,
 }
 
+/// Launch a local network or deploy a smart contract.
 #[derive(Subcommand)]
-pub(crate) enum UpCommands {
+pub(crate) enum Command {
 	#[cfg(feature = "parachain")]
 	/// Launch a local network.
 	#[clap(alias = "p")]

--- a/crates/pop-cli/src/commands/up/parachain.rs
+++ b/crates/pop-cli/src/commands/up/parachain.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
+
 use crate::style::{style, Theme};
 use clap::Args;
 use cliclack::{
@@ -35,8 +36,10 @@ pub(crate) struct ZombienetCommand {
 	#[arg(short, long, action)]
 	verbose: bool,
 }
+
 impl ZombienetCommand {
-	pub(crate) async fn execute(&self) -> anyhow::Result<()> {
+	/// Executes the command.
+	pub(crate) async fn execute(self) -> anyhow::Result<()> {
 		clear_screen()?;
 		intro(format!("{}: Launch a local network", style(" Pop CLI ").black().on_magenta()))?;
 		set_theme(Theme);
@@ -304,10 +307,7 @@ impl ZombienetCommand {
 	}
 }
 
-pub(crate) async fn run_custom_command(
-	spinner: &ProgressBar,
-	command: &str,
-) -> Result<(), anyhow::Error> {
+async fn run_custom_command(spinner: &ProgressBar, command: &str) -> Result<(), anyhow::Error> {
 	spinner.set_message(format!("Spinning up network & running command: {}", command.to_string()));
 	sleep(Duration::from_secs(15)).await;
 

--- a/crates/pop-cli/src/main.rs
+++ b/crates/pop-cli/src/main.rs
@@ -3,55 +3,20 @@
 #[cfg(not(any(feature = "contract", feature = "parachain")))]
 compile_error!("feature \"contract\" or feature \"parachain\" must be enabled");
 
+use anyhow::{anyhow, Result};
+use clap::Parser;
+use commands::*;
+use serde_json::json;
+use std::{fs::create_dir_all, path::PathBuf};
+#[cfg(feature = "telemetry")]
+use {
+	pop_telemetry::{config_file_path, record_cli_command, record_cli_used, Telemetry},
+	std::env::args,
+};
+
 #[cfg(any(feature = "parachain", feature = "contract"))]
 mod commands;
 mod style;
-
-use anyhow::anyhow;
-use anyhow::Result;
-use clap::{Parser, Subcommand};
-use commands::*;
-#[cfg(feature = "telemetry")]
-use pop_telemetry::{config_file_path, record_cli_command, record_cli_used, Telemetry};
-use serde_json::{json, Value};
-#[cfg(feature = "telemetry")]
-use std::env::args;
-use std::{fs::create_dir_all, path::PathBuf};
-
-#[derive(Parser)]
-#[command(author, version, about, styles=style::get_styles())]
-pub struct Cli {
-	#[command(subcommand)]
-	command: Commands,
-}
-
-#[derive(Subcommand)]
-#[command(subcommand_required = true)]
-enum Commands {
-	/// Generate a new parachain, pallet or smart contract.
-	#[clap(alias = "n")]
-	#[cfg(any(feature = "parachain", feature = "contract"))]
-	New(new::NewArgs),
-	/// Build a parachain or smart contract.
-	#[clap(alias = "b")]
-	#[cfg(any(feature = "parachain", feature = "contract"))]
-	Build(build::BuildArgs),
-	/// Call a smart contract.
-	#[clap(alias = "c")]
-	#[cfg(feature = "contract")]
-	Call(call::CallArgs),
-	/// Deploy a parachain or smart contract.
-	#[clap(alias = "u")]
-	#[cfg(any(feature = "parachain", feature = "contract"))]
-	Up(up::UpArgs),
-	/// Test a smart contract.
-	#[clap(alias = "t")]
-	#[cfg(feature = "contract")]
-	Test(test::TestArgs),
-	/// Set up the environment for development by installing required packages
-	#[clap(alias = "i")]
-	Install(install::InstallArgs),
-}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -59,56 +24,7 @@ async fn main() -> Result<()> {
 	let maybe_tel = init().unwrap_or(None);
 
 	let cli = Cli::parse();
-	let res = match cli.command {
-		#[cfg(any(feature = "parachain", feature = "contract"))]
-		Commands::New(args) => match args.command {
-			#[cfg(feature = "parachain")]
-			new::NewCommands::Parachain(cmd) => match cmd.execute().await {
-				Ok(template) => {
-					// telemetry should never cause a panic or early exit
-					Ok(json!({template.provider().unwrap_or("provider-missing"): template.name()}))
-				},
-				Err(e) => Err(e),
-			},
-			#[cfg(feature = "parachain")]
-			new::NewCommands::Pallet(cmd) => {
-				// When more contract selections are added the tel data will likely need to go deeper in the stack
-				cmd.execute().await.map(|_| json!("template"))
-			},
-			#[cfg(feature = "contract")]
-			new::NewCommands::Contract(cmd) => {
-				// When more contract selections are added, the tel data will likely need to go deeper in the stack
-				cmd.execute().await.map(|_| json!("default"))
-			},
-		},
-		#[cfg(any(feature = "parachain", feature = "contract"))]
-		Commands::Build(args) => match &args.command {
-			#[cfg(feature = "parachain")]
-			build::BuildCommands::Parachain(cmd) => cmd.execute().map(|_| Value::Null),
-			#[cfg(feature = "contract")]
-			build::BuildCommands::Contract(cmd) => cmd.execute().map(|_| Value::Null),
-		},
-		#[cfg(feature = "contract")]
-		Commands::Call(args) => match &args.command {
-			call::CallCommands::Contract(cmd) => cmd.execute().await.map(|_| Value::Null),
-		},
-		#[cfg(any(feature = "parachain", feature = "contract"))]
-		Commands::Up(args) => match &args.command {
-			#[cfg(feature = "parachain")]
-			up::UpCommands::Parachain(cmd) => cmd.execute().await.map(|_| Value::Null),
-			#[cfg(feature = "contract")]
-			up::UpCommands::Contract(cmd) => cmd.execute().await.map(|_| Value::Null),
-		},
-		#[cfg(feature = "contract")]
-		Commands::Test(args) => match &args.command {
-			test::TestCommands::Contract(cmd) => match cmd.execute() {
-				Ok(feature) => Ok(json!(feature)),
-				Err(e) => Err(e),
-			},
-		},
-		#[cfg(any(feature = "parachain", feature = "contract"))]
-		Commands::Install(args) => args.execute().await.map(|_| Value::Null),
-	};
+	let res = cli.command.execute().await;
 
 	#[cfg(feature = "telemetry")]
 	if let Some(tel) = maybe_tel.clone() {
@@ -132,6 +48,14 @@ async fn main() -> Result<()> {
 	res.map(|_| ())
 }
 
+#[derive(Parser)]
+#[command(author, version, about, styles=style::get_styles())]
+pub struct Cli {
+	#[command(subcommand)]
+	command: Command,
+}
+
+/// Determines the cache to be used.
 fn cache() -> Result<PathBuf> {
 	let cache_path = dirs::cache_dir()
 		.ok_or(anyhow!("the cache directory could not be determined"))?
@@ -141,6 +65,7 @@ fn cache() -> Result<PathBuf> {
 	Ok(cache_path)
 }
 
+/// Initializes telemetry.
 #[cfg(feature = "telemetry")]
 fn init() -> Result<Option<Telemetry>> {
 	env_logger::init();
@@ -158,6 +83,7 @@ fn init() -> Result<Option<Telemetry>> {
 	Ok(maybe_tel)
 }
 
+/// Parses command line arguments.
 #[cfg(feature = "telemetry")]
 fn parse_args(args: Vec<String>) -> (String, String) {
 	// command is always present as clap will print help if not set


### PR DESCRIPTION
Ensures all commands follow the same [`command.execute()`](https://en.wikipedia.org/wiki/Command_pattern) pattern.

Also adds some doc comments and standardises on a coding style for consistency.