### PR TITLE
feat: enable building without project type specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_toml"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4895c018bb228aa6b3ba1a0285543fcb4b704734c3fb1f72afaa75aa769500c1"
+dependencies = [
+ "serde",
+ "toml 0.8.14",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4488,6 +4498,7 @@ name = "pop-contracts"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "cargo_toml",
  "contract-build",
  "contract-extrinsics",
  "duct",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4480,6 +4480,7 @@ name = "pop-common"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "cargo_toml",
  "git2",
  "git2_credentials",
  "mockito",
@@ -4499,7 +4500,6 @@ name = "pop-contracts"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "cargo_toml",
  "contract-build",
  "contract-extrinsics",
  "duct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ repository = "https://github.com/r0gue-io/pop-cli"
 [workspace.dependencies]
 anyhow = "1.0"
 assert_cmd = "2.0.14"
+cargo_toml = "0.20.3"
 dirs = "5.0"
 duct = "0.13"
 env_logger = "0.11.1"

--- a/crates/pop-cli/src/cli.rs
+++ b/crates/pop-cli/src/cli.rs
@@ -21,6 +21,10 @@ pub(crate) mod traits {
 		fn outro(&mut self, message: impl Display) -> Result<()>;
 		/// Prints a footer of the prompt sequence with a failure style.
 		fn outro_cancel(&mut self, message: impl Display) -> Result<()>;
+		/// Prints a success message.
+		fn success(&mut self, message: impl Display) -> Result<()>;
+		/// Prints a warning message.
+		fn warning(&mut self, message: impl Display) -> Result<()>;
 	}
 
 	/// A confirmation prompt.
@@ -74,6 +78,16 @@ impl traits::Cli for Cli {
 	fn outro_cancel(&mut self, message: impl Display) -> Result<()> {
 		cliclack::outro_cancel(message)
 	}
+
+	/// Prints a success message.
+	fn success(&mut self, message: impl Display) -> Result<()> {
+		cliclack::log::success(message)
+	}
+
+	/// Prints a warning message.
+	fn warning(&mut self, message: impl Display) -> Result<()> {
+		cliclack::log::warning(message)
+	}
 }
 
 /// A confirmation prompt using cliclack.
@@ -122,6 +136,8 @@ pub(crate) mod tests {
 		multiselect_expectation:
 			Option<(String, Option<bool>, bool, Option<Vec<(String, String)>>)>,
 		outro_cancel_expectation: Option<String>,
+		success_expectations: Vec<String>,
+		warning_expectations: Vec<String>,
 	}
 
 	impl MockCli {
@@ -134,8 +150,8 @@ pub(crate) mod tests {
 			self
 		}
 
-		pub(crate) fn expect_info(mut self, text: impl Display) -> Self {
-			self.info_expectations.push(text.to_string());
+		pub(crate) fn expect_info(mut self, message: impl Display) -> Self {
+			self.info_expectations.push(message.to_string());
 			self
 		}
 
@@ -165,6 +181,16 @@ pub(crate) mod tests {
 			self
 		}
 
+		pub(crate) fn expect_success(mut self, message: impl Display) -> Self {
+			self.success_expectations.push(message.to_string());
+			self
+		}
+
+		pub(crate) fn expect_warning(mut self, message: impl Display) -> Self {
+			self.warning_expectations.push(message.to_string());
+			self
+		}
+
 		pub(crate) fn verify(self) -> anyhow::Result<()> {
 			if let Some((expectation, _)) = self.confirm_expectation {
 				panic!("`{expectation}` confirm expectation not satisfied")
@@ -184,6 +210,18 @@ pub(crate) mod tests {
 			if let Some(expectation) = self.outro_cancel_expectation {
 				panic!("`{expectation}` outro cancel expectation not satisfied")
 			}
+			if !self.success_expectations.is_empty() {
+				panic!(
+					"`{}` success log expectations not satisfied",
+					self.success_expectations.join(",")
+				)
+			}
+			if !self.warning_expectations.is_empty() {
+				panic!(
+					"`{}` warning log expectations not satisfied",
+					self.warning_expectations.join(",")
+				)
+			}
 			Ok(())
 		}
 	}
@@ -198,9 +236,9 @@ pub(crate) mod tests {
 			MockConfirm::default()
 		}
 
-		fn info(&mut self, text: impl Display) -> Result<()> {
-			let text = text.to_string();
-			self.info_expectations.retain(|x| *x != text);
+		fn info(&mut self, message: impl Display) -> Result<()> {
+			let message = message.to_string();
+			self.info_expectations.retain(|x| *x != message);
 			Ok(())
 		}
 
@@ -247,6 +285,18 @@ pub(crate) mod tests {
 					"outro message does not satisfy expectation"
 				);
 			}
+			Ok(())
+		}
+
+		fn success(&mut self, message: impl Display) -> Result<()> {
+			let message = message.to_string();
+			self.success_expectations.retain(|x| *x != message);
+			Ok(())
+		}
+
+		fn warning(&mut self, message: impl Display) -> Result<()> {
+			let message = message.to_string();
+			self.warning_expectations.retain(|x| *x != message);
 			Ok(())
 		}
 	}

--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -13,8 +13,8 @@ pub struct BuildContractCommand {
 	pub(crate) path: Option<PathBuf>,
 	/// The default compilation includes debug functionality, increasing contract size and gas usage.
 	/// For production, always build in release mode to exclude debug features.
-	#[clap(long = "release")]
-	build_release: bool,
+	#[clap(long = "release", short)]
+	pub(crate) release: bool,
 }
 
 impl BuildContractCommand {
@@ -24,7 +24,7 @@ impl BuildContractCommand {
 		intro(format!("{}: Building your contract", style(" Pop CLI ").black().on_magenta()))?;
 		set_theme(Theme);
 
-		let result_build = build_smart_contract(&self.path, self.build_release)?;
+		let result_build = build_smart_contract(self.path.as_deref(), self.release)?;
 		outro("Build completed successfully!")?;
 		log::success(result_build.to_string())?;
 		Ok(())

--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::style::Theme;
+use crate::cli::{traits::Cli as _, Cli};
 use clap::Args;
-use cliclack::{clear_screen, intro, log, outro, set_theme};
-use console::style;
 use pop_contracts::build_smart_contract;
-use std::path::PathBuf;
+use std::{path::PathBuf, thread::sleep, time::Duration};
 
 #[derive(Args)]
 pub struct BuildContractCommand {
@@ -15,18 +13,26 @@ pub struct BuildContractCommand {
 	/// For production, always build in release mode to exclude debug features.
 	#[clap(long = "release", short)]
 	pub(crate) release: bool,
+	// Deprecation flag, used to specify whether the deprecation warning is shown.
+	#[clap(skip)]
+	pub(crate) valid: bool,
 }
 
 impl BuildContractCommand {
 	/// Executes the command.
 	pub(crate) fn execute(self) -> anyhow::Result<()> {
-		clear_screen()?;
-		intro(format!("{}: Building your contract", style(" Pop CLI ").black().on_magenta()))?;
-		set_theme(Theme);
+		Cli.intro("Building your contract")?;
 
-		let result_build = build_smart_contract(self.path.as_deref(), self.release)?;
-		outro("Build completed successfully!")?;
-		log::success(result_build.to_string())?;
+		// Show warning if specified as deprecated.
+		if !self.valid {
+			Cli.warning("NOTE: this command is deprecated. Please use `pop build` (or simply `pop b`) in future...")?;
+			sleep(Duration::from_secs(3));
+		}
+
+		// Build contract.
+		let build_result = build_smart_contract(self.path.as_deref(), self.release)?;
+		Cli.success(build_result)?;
+		Cli.outro("Build completed successfully!")?;
 		Ok(())
 	}
 }

--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -7,11 +7,12 @@ use std::{path::PathBuf, thread::sleep, time::Duration};
 
 #[derive(Args)]
 pub struct BuildContractCommand {
-	#[arg(long, help = "Path for the contract project, [default: current directory]")]
+	/// Path for the contract project [default: current directory]
+	#[arg(long)]
 	pub(crate) path: Option<PathBuf>,
 	/// The default compilation includes debug functionality, increasing contract size and gas usage.
 	/// For production, always build in release mode to exclude debug features.
-	#[clap(long = "release", short)]
+	#[clap(short, long)]
 	pub(crate) release: bool,
 	// Deprecation flag, used to specify whether the deprecation warning is shown.
 	#[clap(skip)]

--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -7,7 +7,7 @@ use std::{path::PathBuf, thread::sleep, time::Duration};
 
 #[derive(Args)]
 pub struct BuildContractCommand {
-	#[arg(short = 'p', long, help = "Path for the contract project, [default: current directory]")]
+	#[arg(long, help = "Path for the contract project, [default: current directory]")]
 	pub(crate) path: Option<PathBuf>,
 	/// The default compilation includes debug functionality, increasing contract size and gas usage.
 	/// For production, always build in release mode to exclude debug features.

--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -27,6 +27,10 @@ impl BuildContractCommand {
 		self.build(&mut cli::Cli)
 	}
 
+	/// Builds a smart contract
+	///
+	/// # Arguments
+	/// * `cli` - The CLI implementation to be used.
 	fn build(self, cli: &mut impl cli::traits::Cli) -> anyhow::Result<&'static str> {
 		cli.intro("Building your contract")?;
 

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -31,7 +31,7 @@ pub(crate) struct BuildArgs {
 	pub(crate) release: bool,
 }
 
-/// Build a parachain or smart contract.
+/// Build a parachain, smart contract or Rust package.
 #[derive(Subcommand)]
 pub(crate) enum Command {
 	/// [DEPRECATED] Build a parachain

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -46,7 +46,8 @@ impl Command {
 	/// Executes the command.
 	pub(crate) fn execute(args: BuildArgs) -> anyhow::Result<()> {
 		// Check if both parachain and contract features enabled
-		if cfg!(all(feature = "parachain", feature = "contract")) {
+		#[cfg(all(feature = "parachain", feature = "contract"))]
+		{
 			// Detect if smart contract project, otherwise assume a parachain project
 			if pop_contracts::is_smart_contract(args.path.as_deref()) {
 				return BuildContractCommand { path: args.path, release: args.release }.execute();
@@ -54,13 +55,12 @@ impl Command {
 			return BuildParachainCommand { path: args.path, release: args.release }.execute();
 		}
 		// If only parachain feature enabled, build as parachain
-		if cfg!(feature = "parachain") {
+		#[cfg(all(feature = "parachain", not(feature = "contract")))]
+		{
 			return BuildParachainCommand { path: args.path, release: args.release }.execute();
 		}
 		// If only contract feature enabled, build as contract
-		if cfg!(feature = "contract") {
-			return BuildContractCommand { path: args.path, release: args.release }.execute();
-		}
-		Ok(())
+		#[cfg(all(feature = "contract", not(feature = "parachain")))]
+		return BuildContractCommand { path: args.path, release: args.release }.execute();
 	}
 }

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -18,11 +18,7 @@ pub(crate) mod parachain;
 pub(crate) struct BuildArgs {
 	#[command(subcommand)]
 	pub command: Option<Command>,
-	#[arg(
-		short = 'p',
-		long = "path",
-		help = "Directory path for your project, [default: current directory]"
-	)]
+	#[arg(long = "path", help = "Directory path for your project, [default: current directory]")]
 	pub(crate) path: Option<PathBuf>,
 	/// For production, always build in release mode to exclude debug features.
 	#[clap(long = "release", short)]

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -109,12 +109,12 @@ mod tests {
 	#[test]
 	fn build_works() -> anyhow::Result<()> {
 		let name = "hello_world";
+		let temp_dir = tempfile::tempdir()?;
+		let path = temp_dir.path();
+		cmd("cargo", ["new", name, "--bin"]).dir(&path).run()?;
 
 		for package in [None, Some(name.to_string())] {
 			for release in [false, true] {
-				let temp_dir = tempfile::tempdir()?;
-				let path = temp_dir.path();
-				cmd("cargo", ["new", name, "--bin"]).dir(&path).run()?;
 				let project = if package.is_some() { "package" } else { "project" };
 				let mode = if release { "RELEASE" } else { "DEBUG" };
 				let mut cli = MockCli::new()

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -14,6 +14,9 @@ pub struct BuildParachainCommand {
 		help = "Directory path for your project, [default: current directory]"
 	)]
 	pub(crate) path: Option<PathBuf>,
+	/// For production, always build in release mode to exclude debug features.
+	#[clap(long = "release", short)]
+	pub(crate) release: bool,
 }
 
 impl BuildParachainCommand {

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -7,10 +7,14 @@ use std::{path::PathBuf, thread::sleep, time::Duration};
 
 #[derive(Args)]
 pub struct BuildParachainCommand {
-	#[arg(long = "path", help = "Directory path for your project, [default: current directory]")]
+	/// Directory path for your project [default: current directory]
+	#[arg(long)]
 	pub(crate) path: Option<PathBuf>,
+	/// The package to be built.
+	#[arg(short = 'p', long)]
+	pub(crate) package: Option<String>,
 	/// For production, always build in release mode to exclude debug features.
-	#[clap(long = "release", short, default_value = "true")]
+	#[clap(short, long, default_value = "true")]
 	pub(crate) release: bool,
 	// Deprecation flag, used to specify whether the deprecation warning is shown.
 	#[clap(skip)]
@@ -20,7 +24,8 @@ pub struct BuildParachainCommand {
 impl BuildParachainCommand {
 	/// Executes the command.
 	pub(crate) fn execute(self) -> anyhow::Result<()> {
-		Cli.intro("Building your parachain")?;
+		let project = if self.package.is_some() { "package" } else { "parachain" };
+		Cli.intro(format!("Building your {project}"))?;
 
 		// Show warning if specified as deprecated.
 		if !self.valid {
@@ -35,9 +40,9 @@ impl BuildParachainCommand {
 
 		// Build parachain.
 		Cli.warning("NOTE: this may take some time...")?;
-		build_parachain(self.path.as_deref(), self.release)?;
+		build_parachain(self.path.as_deref(), self.package, self.release)?;
 		let mode = if self.release { "RELEASE" } else { "DEBUG" };
-		Cli.info(format!("The parachain was built in {mode} mode.",))?;
+		Cli.info(format!("The {project} was built in {mode} mode.",))?;
 		Cli.outro("Build completed successfully!")?;
 		Ok(())
 	}

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -65,13 +65,13 @@ mod tests {
 	#[test]
 	fn build_works() -> anyhow::Result<()> {
 		let name = "hello_world";
+		let temp_dir = tempfile::tempdir()?;
+		let path = temp_dir.path();
+		cmd("cargo", ["new", name, "--bin"]).dir(&path).run()?;
 
 		for package in [None, Some(name.to_string())] {
 			for release in [false, true] {
 				for valid in [false, true] {
-					let temp_dir = tempfile::tempdir()?;
-					let path = temp_dir.path();
-					cmd("cargo", ["new", name, "--bin"]).dir(&path).run()?;
 					let project = if package.is_some() { "package" } else { "parachain" };
 					let mode = if release { "RELEASE" } else { "DEBUG" };
 					let mut cli = MockCli::new()

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::style::{style, Theme};
+use crate::cli::{traits::Cli as _, Cli};
 use clap::Args;
-use cliclack::{clear_screen, intro, log::warning, outro, set_theme};
 use pop_parachains::build_parachain;
-use std::path::PathBuf;
+use std::{path::PathBuf, thread::sleep, time::Duration};
 
 #[derive(Args)]
 pub struct BuildParachainCommand {
@@ -15,21 +14,35 @@ pub struct BuildParachainCommand {
 	)]
 	pub(crate) path: Option<PathBuf>,
 	/// For production, always build in release mode to exclude debug features.
-	#[clap(long = "release", short)]
+	#[clap(long = "release", short, default_value = "true")]
 	pub(crate) release: bool,
+	// Deprecation flag, used to specify whether the deprecation warning is shown.
+	#[clap(skip)]
+	pub(crate) valid: bool,
 }
 
 impl BuildParachainCommand {
 	/// Executes the command.
 	pub(crate) fn execute(self) -> anyhow::Result<()> {
-		clear_screen()?;
-		intro(format!("{}: Building your parachain", style(" Pop CLI ").black().on_magenta()))?;
-		set_theme(Theme);
+		Cli.intro("Building your parachain")?;
 
-		warning("NOTE: this may take some time...")?;
+		// Show warning if specified as deprecated.
+		if !self.valid {
+			Cli.warning("NOTE: this command is deprecated. Please use `pop build` (or simply `pop b`) in future...")?;
+			sleep(Duration::from_secs(3))
+		} else {
+			if !self.release {
+				Cli.warning("NOTE: this command now defaults to DEBUG builds. Please use `--release` (or simply `-r`) for a release build...")?;
+				sleep(Duration::from_secs(3))
+			}
+		}
+
+		// Build parachain.
+		Cli.warning("NOTE: this may take some time...")?;
 		build_parachain(&self.path)?;
-
-		outro("Build Completed Successfully!")?;
+		let mode = if self.release { "RELEASE" } else { "DEBUG" };
+		Cli.info(format!("The parachain was built in {mode} mode.",))?;
+		Cli.outro("Build Completed Successfully!")?;
 		Ok(())
 	}
 }

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -29,6 +29,10 @@ impl BuildParachainCommand {
 		self.build(&mut cli::Cli)
 	}
 
+	/// Builds a parachain.
+	///
+	/// # Arguments
+	/// * `cli` - The CLI implementation to be used.
 	fn build(self, cli: &mut impl cli::traits::Cli) -> anyhow::Result<&'static str> {
 		let project = if self.package.is_some() { "package" } else { "parachain" };
 		cli.intro(format!("Building your {project}"))?;

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -7,11 +7,7 @@ use std::{path::PathBuf, thread::sleep, time::Duration};
 
 #[derive(Args)]
 pub struct BuildParachainCommand {
-	#[arg(
-		short = 'p',
-		long = "path",
-		help = "Directory path for your project, [default: current directory]"
-	)]
+	#[arg(long = "path", help = "Directory path for your project, [default: current directory]")]
 	pub(crate) path: Option<PathBuf>,
 	/// For production, always build in release mode to exclude debug features.
 	#[clap(long = "release", short, default_value = "true")]

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -35,10 +35,10 @@ impl BuildParachainCommand {
 
 		// Build parachain.
 		Cli.warning("NOTE: this may take some time...")?;
-		build_parachain(&self.path)?;
+		build_parachain(self.path.as_deref(), self.release)?;
 		let mode = if self.release { "RELEASE" } else { "DEBUG" };
 		Cli.info(format!("The parachain was built in {mode} mode.",))?;
-		Cli.outro("Build Completed Successfully!")?;
+		Cli.outro("Build completed successfully!")?;
 		Ok(())
 	}
 }

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -74,10 +74,13 @@ impl Command {
 			},
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::Build(args) => match args.command {
-				#[cfg(feature = "parachain")]
-				build::Command::Parachain(cmd) => cmd.execute().map(|_| Value::Null),
-				#[cfg(feature = "contract")]
-				build::Command::Contract(cmd) => cmd.execute().map(|_| Value::Null),
+				None => build::Command::execute(args).map(|_| Value::Null),
+				Some(cmd) => match cmd {
+					#[cfg(feature = "parachain")]
+					build::Command::Parachain(cmd) => cmd.execute().map(|_| Value::Null),
+					#[cfg(feature = "contract")]
+					build::Command::Contract(cmd) => cmd.execute().map(|_| Value::Null),
+				},
 			},
 			#[cfg(feature = "contract")]
 			Self::Call(args) => match args.command {

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -84,7 +84,7 @@ impl Command {
 			},
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::Build(args) => match args.command {
-				None => build::Command::execute(args).map(|_| Value::Null),
+				None => build::Command::execute(args).map(|t| json!(t)),
 				Some(cmd) => match cmd {
 					#[cfg(feature = "parachain")]
 					build::Command::Parachain(cmd) => cmd.execute().map(|_| Value::Null),

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -23,8 +23,7 @@ pub(crate) enum Command {
 	#[clap(alias = "n")]
 	#[cfg(any(feature = "parachain", feature = "contract"))]
 	New(new::NewArgs),
-	/// Build a parachain or smart contract.
-	#[clap(alias = "b")]
+	#[clap(alias = "b", about = about_build())]
 	#[cfg(any(feature = "parachain", feature = "contract"))]
 	Build(build::BuildArgs),
 	/// Call a smart contract.
@@ -42,6 +41,16 @@ pub(crate) enum Command {
 	/// Remove generated/cached artifacts.
 	#[clap(alias = "C")]
 	Clean(clean::CleanArgs),
+}
+
+/// Help message for the build command.
+fn about_build() -> &'static str {
+	#[cfg(all(feature = "parachain", feature = "contract"))]
+	return "Build a parachain, smart contract or Rust package.";
+	#[cfg(all(feature = "parachain", not(feature = "contract")))]
+	return "Build a parachain or Rust package.";
+	#[cfg(all(feature = "contract", not(feature = "parachain")))]
+	return "Build a smart contract or Rust package.";
 }
 
 impl Command {

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -71,7 +71,7 @@ impl UpContractCommand {
 			log::warning("NOTE: contract has not yet been built.")?;
 			intro(format!("{}: Building a contract", style(" Pop CLI ").black().on_magenta()))?;
 			// Build the contract in release mode
-			let result = build_smart_contract(&self.path, true)?;
+			let result = build_smart_contract(self.path.as_deref(), true)?;
 			log::success(result.to_string())?;
 		}
 

--- a/crates/pop-cli/tests/parachain.rs
+++ b/crates/pop-cli/tests/parachain.rs
@@ -24,7 +24,7 @@ fn test_parachain_build_after_instantiating_template() -> Result<()> {
 	Command::cargo_bin("pop")
 		.unwrap()
 		.current_dir(&temp_dir)
-		.args(&["build", "parachain", "-p", "./test_parachain"])
+		.args(&["build", "parachain", "--path", "./test_parachain"])
 		.assert()
 		.success();
 

--- a/crates/pop-common/Cargo.toml
+++ b/crates/pop-common/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+cargo_toml.workspace = true
 git2.workspace = true
 git2_credentials.workspace = true
 regex.workspace = true

--- a/crates/pop-common/src/errors.rs
+++ b/crates/pop-common/src/errors.rs
@@ -1,23 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use thiserror::Error;
-
 use crate::templates;
+use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
 	#[error("Configuration error: {0}")]
 	Config(String),
-
 	#[error("a git error occurred: {0}")]
 	Git(String),
-
 	#[error("IO error: {0}")]
 	IO(#[from] std::io::Error),
-
 	#[error("ParseError error: {0}")]
 	ParseError(#[from] url::ParseError),
-
 	#[error("TemplateError error: {0}")]
 	TemplateError(#[from] templates::Error),
 }

--- a/crates/pop-common/src/lib.rs
+++ b/crates/pop-common/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod errors;
 pub mod git;
 pub mod helpers;
+pub mod manifest;
 pub mod templates;
 
 pub use errors::Error;
 pub use git::{Git, GitHub, Release};
 pub use helpers::replace_in_file;
+
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));

--- a/crates/pop-common/src/manifest.rs
+++ b/crates/pop-common/src/manifest.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
-pub use cargo_toml::Manifest;
+pub use cargo_toml::{Dependency, Manifest};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 

--- a/crates/pop-common/src/manifest.rs
+++ b/crates/pop-common/src/manifest.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pub use cargo_toml::Manifest;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// An error specific to reading a manifest.
+#[derive(Error, Debug)]
+pub enum Error {
+	#[error("Failed to get manifest path: {0}")]
+	ManifestPath(String),
+	#[error("Manifest error: {0}")]
+	ManifestError(#[from] cargo_toml::Error),
+}
+
+/// Parses the contents of a `Cargo.toml` manifest.
+///
+/// # Arguments
+/// * `path` - The optional path to the manifest, defaulting to the current directory if not specified.
+pub fn from_path(path: Option<&Path>) -> Result<Manifest, Error> {
+	// Resolve manifest path
+	let path = match path {
+		Some(path) => match path.ends_with("Cargo.toml") {
+			true => path.to_path_buf(),
+			false => path.join("Cargo.toml"),
+		},
+		None => PathBuf::from("./Cargo.toml"),
+	};
+	if !path.exists() {
+		return Err(Error::ManifestPath(path.display().to_string()));
+	}
+	Ok(Manifest::from_path(path)?)
+}

--- a/crates/pop-contracts/Cargo.toml
+++ b/crates/pop-contracts/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-cargo_toml.workspace = true
 duct.workspace = true
 flate2.workspace = true
 reqwest.workspace = true

--- a/crates/pop-contracts/Cargo.toml
+++ b/crates/pop-contracts/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+cargo_toml.workspace = true
 duct.workspace = true
 flate2.workspace = true
 reqwest.workspace = true

--- a/crates/pop-contracts/src/build.rs
+++ b/crates/pop-contracts/src/build.rs
@@ -33,3 +33,27 @@ pub fn build_smart_contract(path: Option<&Path>, release: bool) -> anyhow::Resul
 pub fn is_supported(path: Option<&Path>) -> Result<bool, Error> {
 	Ok(pop_common::manifest::from_path(path)?.dependencies.contains_key("ink"))
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use contract_build::new_contract_project;
+	use duct::cmd;
+
+	#[test]
+	fn is_supported_works() -> anyhow::Result<()> {
+		let temp_dir = tempfile::tempdir()?;
+		let path = temp_dir.path();
+
+		// Standard rust project
+		let name = "hello_world";
+		cmd("cargo", ["new", name]).dir(&path).run()?;
+		assert!(!is_supported(Some(&path.join(name)))?);
+
+		// Contract
+		let name = "flipper";
+		new_contract_project(name, Some(&path))?;
+		assert!(is_supported(Some(&path.join(name)))?);
+		Ok(())
+	}
+}

--- a/crates/pop-contracts/src/build.rs
+++ b/crates/pop-contracts/src/build.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use contract_build::{execute, BuildMode, ExecuteArgs};
-use std::path::PathBuf;
+use std::path::Path;
 
 use crate::utils::helpers::get_manifest_path;
 
 /// Build the smart contract located at the specified `path` in `build_release` mode.
-pub fn build_smart_contract(path: &Option<PathBuf>, build_release: bool) -> anyhow::Result<String> {
+pub fn build_smart_contract(path: Option<&Path>, build_release: bool) -> anyhow::Result<String> {
 	let manifest_path = get_manifest_path(path)?;
 
 	let build_mode = match build_release {
@@ -21,4 +21,16 @@ pub fn build_smart_contract(path: &Option<PathBuf>, build_release: bool) -> anyh
 	let formatted_result = result.display();
 
 	Ok(formatted_result)
+}
+
+/// Determines whether the manifest at the supplied path relates is a smart contract project.
+pub fn is_smart_contract(path: Option<&Path>) -> bool {
+	let Ok(manifest) = get_manifest_path(path) else {
+		return false;
+	};
+	// Very simply check for now, can be improved by reading the manifest toml and iterating over the dependencies
+	match std::fs::read_to_string(manifest) {
+		Ok(contents) => contents.contains("ink ="),
+		Err(_) => false,
+	}
 }

--- a/crates/pop-contracts/src/call.rs
+++ b/crates/pop-contracts/src/call.rs
@@ -54,7 +54,7 @@ pub async fn set_up_call(
 	call_opts: CallOpts,
 ) -> anyhow::Result<CallExec<DefaultConfig, DefaultEnvironment, Keypair>> {
 	let token_metadata = TokenMetadata::query::<DefaultConfig>(&call_opts.url).await?;
-	let manifest_path = get_manifest_path(&call_opts.path)?;
+	let manifest_path = get_manifest_path(call_opts.path.as_deref())?;
 	let signer = create_signer(&call_opts.suri)?;
 
 	let extrinsic_opts = ExtrinsicOptsBuilder::new(signer)

--- a/crates/pop-contracts/src/call.rs
+++ b/crates/pop-contracts/src/call.rs
@@ -24,7 +24,7 @@ use url::Url;
 pub struct CallOpts {
 	/// Path to the contract build folder.
 	pub path: Option<PathBuf>,
-	/// The address of the the contract to call.
+	/// The address of the contract to call.
 	pub contract: String,
 	/// The name of the contract message to call.
 	pub message: String,
@@ -37,7 +37,7 @@ pub struct CallOpts {
 	/// Maximum proof size for the instantiation.
 	pub proof_size: Option<u64>,
 	/// Websocket endpoint of a node.
-	pub url: url::Url,
+	pub url: Url,
 	/// Secret key URI for the account deploying the contract.
 	pub suri: String,
 	/// Submit an extrinsic for on-chain execution.
@@ -48,7 +48,7 @@ pub struct CallOpts {
 ///
 /// # Arguments
 ///
-/// * `call_opts` - attributes for the `call` command.
+/// * `call_opts` - options for the `call` command.
 ///
 pub async fn set_up_call(
 	call_opts: CallOpts,

--- a/crates/pop-contracts/src/errors.rs
+++ b/crates/pop-contracts/src/errors.rs
@@ -57,4 +57,7 @@ pub enum Error {
 
 	#[error("HTTP error: {0}")]
 	HttpError(#[from] reqwest::Error),
+
+	#[error("Build error: {0}")]
+	BuildError(#[from] crate::build::Error),
 }

--- a/crates/pop-contracts/src/errors.rs
+++ b/crates/pop-contracts/src/errors.rs
@@ -20,8 +20,8 @@ pub enum Error {
 	HttpError(#[from] reqwest::Error),
 	#[error("Failed to install {0}")]
 	InstallContractsNode(String),
-    #[error("{0}")]
-    InstantiateContractError(String),
+	#[error("{0}")]
+	InstantiateContractError(String),
 	#[error("Invalid name: {0}")]
 	InvalidName(String),
 	#[error("IO error: {0}")]
@@ -44,6 +44,6 @@ pub enum Error {
 	TestCommand(String),
 	#[error("Unsupported platform: {os}")]
 	UnsupportedPlatform { os: &'static str },
-    #[error("{0}")]
-    UploadContractError(String),
+	#[error("{0}")]
+	UploadContractError(String),
 }

--- a/crates/pop-contracts/src/errors.rs
+++ b/crates/pop-contracts/src/errors.rs
@@ -4,60 +4,42 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-	#[error("Failed to create new contract project: {0}")]
-	NewContract(String),
-
-	#[error("IO error: {0}")]
-	IO(#[from] std::io::Error),
-
-	#[error("Failed to execute test command: {0}")]
-	TestCommand(String),
-
-	#[error("Failed to parse balance: {0}")]
-	BalanceParsing(String),
-
-	#[error("Failed to parse account address: {0}")]
-	AccountAddressParsing(String),
-
-	#[error("Failed to get manifest path: {0}")]
-	ManifestPath(String),
-
-	#[error("Failed to parse secret URI: {0}")]
-	ParseSecretURI(String),
-
-	#[error("Failed to create keypair from URI: {0}")]
-	KeyPairCreation(String),
-
-	#[error("Failed to parse hex encoded bytes: {0}")]
-	HexParsing(String),
-
-	#[error("Pre-submission dry-run failed: {0}")]
-	DryRunUploadContractError(String),
-
-	#[error("Pre-submission dry-run failed: {0}")]
-	DryRunCallContractError(String),
-
 	#[error("Anyhow error: {0}")]
 	AnyhowError(#[from] anyhow::Error),
-
-	#[error("Failed to install {0}")]
-	InstallContractsNode(String),
-
-	#[error("ParseError error: {0}")]
-	ParseError(#[from] url::ParseError),
-
-	#[error("Invalid name: {0}")]
-	InvalidName(String),
-
-	#[error("The `Repository` property is missing from the template variant")]
-	RepositoryMissing,
-
-	#[error("Unsupported platform: {os}")]
-	UnsupportedPlatform { os: &'static str },
-
+	#[error("Failed to parse account address: {0}")]
+	AccountAddressParsing(String),
+	#[error("Failed to parse balance: {0}")]
+	BalanceParsing(String),
+	#[error("Pre-submission dry-run failed: {0}")]
+	DryRunUploadContractError(String),
+	#[error("Pre-submission dry-run failed: {0}")]
+	DryRunCallContractError(String),
+	#[error("Failed to parse hex encoded bytes: {0}")]
+	HexParsing(String),
 	#[error("HTTP error: {0}")]
 	HttpError(#[from] reqwest::Error),
-
-	#[error("Build error: {0}")]
-	BuildError(#[from] crate::build::Error),
+	#[error("Failed to install {0}")]
+	InstallContractsNode(String),
+	#[error("Invalid name: {0}")]
+	InvalidName(String),
+	#[error("IO error: {0}")]
+	IO(#[from] std::io::Error),
+	#[error("Failed to create keypair from URI: {0}")]
+	KeyPairCreation(String),
+	#[error("Manifest error: {0}")]
+	ManifestError(#[from] pop_common::manifest::Error),
+	#[error("Failed to get manifest path: {0}")]
+	ManifestPath(String),
+	#[error("Failed to create new contract project: {0}")]
+	NewContract(String),
+	#[error("ParseError error: {0}")]
+	ParseError(#[from] url::ParseError),
+	#[error("Failed to parse secret URI: {0}")]
+	ParseSecretURI(String),
+	#[error("The `Repository` property is missing from the template variant")]
+	RepositoryMissing,
+	#[error("Failed to execute test command: {0}")]
+	TestCommand(String),
+	#[error("Unsupported platform: {os}")]
+	UnsupportedPlatform { os: &'static str },
 }

--- a/crates/pop-contracts/src/lib.rs
+++ b/crates/pop-contracts/src/lib.rs
@@ -10,7 +10,7 @@ mod test;
 mod up;
 mod utils;
 
-pub use build::{build_smart_contract, is_smart_contract};
+pub use build::{build_smart_contract, is_supported};
 pub use call::{
 	call_smart_contract, dry_run_call, dry_run_gas_estimate_call, set_up_call, CallOpts,
 };

--- a/crates/pop-contracts/src/lib.rs
+++ b/crates/pop-contracts/src/lib.rs
@@ -10,7 +10,7 @@ mod test;
 mod up;
 mod utils;
 
-pub use build::build_smart_contract;
+pub use build::{build_smart_contract, is_smart_contract};
 pub use call::{
 	call_smart_contract, dry_run_call, dry_run_gas_estimate_call, set_up_call, CallOpts,
 };

--- a/crates/pop-contracts/src/up.rs
+++ b/crates/pop-contracts/src/up.rs
@@ -83,7 +83,7 @@ pub async fn set_up_deployment(
 pub async fn set_up_upload(
 	up_opts: UpOpts,
 ) -> anyhow::Result<UploadExec<DefaultConfig, DefaultEnvironment, Keypair>> {
-	let manifest_path = get_manifest_path(&up_opts.path)?;
+	let manifest_path = get_manifest_path(up_opts.path.as_deref())?;
 
 	let signer = create_signer(&up_opts.suri)?;
 	let extrinsic_opts = ExtrinsicOptsBuilder::new(signer)

--- a/crates/pop-contracts/src/up.rs
+++ b/crates/pop-contracts/src/up.rs
@@ -49,7 +49,7 @@ pub struct UpOpts {
 pub async fn set_up_deployment(
 	up_opts: UpOpts,
 ) -> anyhow::Result<InstantiateExec<DefaultConfig, DefaultEnvironment, Keypair>> {
-	let manifest_path = get_manifest_path(&up_opts.path)?;
+	let manifest_path = get_manifest_path(up_opts.path.as_deref())?;
 
 	let token_metadata = TokenMetadata::query::<DefaultConfig>(&up_opts.url).await?;
 

--- a/crates/pop-contracts/src/utils/helpers.rs
+++ b/crates/pop-contracts/src/utils/helpers.rs
@@ -10,7 +10,7 @@ use std::{
 };
 use subxt::{Config, PolkadotConfig as DefaultConfig};
 
-pub fn get_manifest_path(path: &Option<PathBuf>) -> Result<ManifestPath, Error> {
+pub fn get_manifest_path(path: Option<&Path>) -> Result<ManifestPath, Error> {
 	if let Some(path) = path {
 		let full_path = PathBuf::from(path.to_string_lossy().to_string() + "/Cargo.toml");
 		return ManifestPath::try_from(Some(full_path))
@@ -67,7 +67,7 @@ mod tests {
 	#[test]
 	fn test_get_manifest_path() -> Result<(), Error> {
 		let temp_dir = setup_test_environment()?;
-		get_manifest_path(&Some(PathBuf::from(temp_dir.path().join("test_contract"))))?;
+		get_manifest_path(Some(&PathBuf::from(temp_dir.path().join("test_contract"))))?;
 		Ok(())
 	}
 

--- a/crates/pop-contracts/tests/contract.rs
+++ b/crates/pop-contracts/tests/contract.rs
@@ -42,7 +42,7 @@ fn test_contract_build() -> std::result::Result<(), Error> {
 	let temp_contract_dir = setup_test_environment()?;
 
 	let formatted_result =
-		build_smart_contract(&Some(temp_contract_dir.path().join("test_contract")), true)?;
+		build_smart_contract(Some(&temp_contract_dir.path().join("test_contract")), true)?;
 	assert!(formatted_result.contains("RELEASE"));
 
 	verify_build_files(temp_contract_dir)?;
@@ -50,7 +50,7 @@ fn test_contract_build() -> std::result::Result<(), Error> {
 	let temp_debug_contract_dir = setup_test_environment()?;
 	// Test building in debug mode
 	let formatted_result_debug_mode =
-		build_smart_contract(&Some(temp_debug_contract_dir.path().join("test_contract")), false)?;
+		build_smart_contract(Some(&temp_debug_contract_dir.path().join("test_contract")), false)?;
 	assert!(formatted_result_debug_mode.contains("DEBUG"));
 
 	verify_build_files(temp_debug_contract_dir)?;
@@ -61,7 +61,7 @@ fn test_contract_build() -> std::result::Result<(), Error> {
 const CONTRACTS_NETWORK_URL: &str = "wss://rococo-contracts-rpc.polkadot.io";
 
 fn build_smart_contract_test_environment(temp_dir: &TempDir) -> Result<(), Error> {
-	build_smart_contract(&Some(temp_dir.path().join("test_contract")), true)?;
+	build_smart_contract(Some(&temp_dir.path().join("test_contract")), true)?;
 	Ok(())
 }
 

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -41,3 +41,32 @@ pub fn is_supported(path: Option<&Path>) -> Result<bool, Error> {
 			|| manifest.workspace.as_ref().map_or(false, |w| w.dependencies.contains_key(d))
 	}))
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use duct::cmd;
+	use pop_common::manifest::{self, Dependency};
+	use std::fs::write;
+
+	#[test]
+	fn is_supported_works() -> anyhow::Result<()> {
+		let temp_dir = tempfile::tempdir()?;
+		let path = temp_dir.path();
+
+		// Standard rust project
+		let name = "hello_world";
+		cmd("cargo", ["new", name]).dir(&path).run()?;
+		assert!(!is_supported(Some(&path.join(name)))?);
+
+		// Parachain
+		let mut manifest = manifest::from_path(Some(&path.join(name)))?;
+		manifest
+			.dependencies
+			.insert("cumulus-client-collator".into(), Dependency::Simple("^0.14.0".into()));
+		let manifest = toml_edit::ser::to_string_pretty(&manifest)?;
+		write(path.join(name).join("Cargo.toml"), manifest)?;
+		assert!(is_supported(Some(&path.join(name)))?);
+		Ok(())
+	}
+}

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -8,9 +8,18 @@ use std::path::Path;
 ///
 /// # Arguments
 /// * `path` - The optional path to the parachain manifest, defaulting to the current directory if not specified.
+/// * `package` - The optional package to be built.
 /// * `release` - Whether the parachain should be built without any debugging functionality.
-pub fn build_parachain(path: Option<&Path>, release: bool) -> anyhow::Result<()> {
+pub fn build_parachain(
+	path: Option<&Path>,
+	package: Option<String>,
+	release: bool,
+) -> anyhow::Result<()> {
 	let mut args = vec!["build"];
+	if let Some(package) = package.as_deref() {
+		args.push("--package");
+		args.push(package)
+	}
 	if release {
 		args.push("--release");
 	}

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -1,13 +1,34 @@
 // SPDX-License-Identifier: GPL-3.0
 
+use crate::errors::Error;
 use duct::cmd;
-use std::path::PathBuf;
+use std::path::Path;
 
 /// Build the parachain located in the specified `path`.
-pub fn build_parachain(path: &Option<PathBuf>) -> anyhow::Result<()> {
-	cmd("cargo", vec!["build", "--release"])
-		.dir(path.clone().unwrap_or("./".into()))
-		.run()?;
-
+///
+/// # Arguments
+/// * `path` - The optional path to the parachain manifest, defaulting to the current directory if not specified.
+/// * `release` - Whether the parachain should be built without any debugging functionality.
+pub fn build_parachain(path: Option<&Path>, release: bool) -> anyhow::Result<()> {
+	let mut args = vec!["build"];
+	if release {
+		args.push("--release");
+	}
+	cmd("cargo", args).dir(path.unwrap_or_else(|| Path::new("./"))).run()?;
 	Ok(())
+}
+
+/// Determines whether the manifest at the supplied path is a supported parachain project.
+///
+/// # Arguments
+/// * `path` - The optional path to the manifest, defaulting to the current directory if not specified.
+pub fn is_supported(path: Option<&Path>) -> Result<bool, Error> {
+	let manifest = pop_common::manifest::from_path(path)?;
+	// Simply check for a parachain dependency
+	const DEPENDENCIES: [&str; 4] =
+		["cumulus-client-collator", "cumulus-primitives-core", "parachains-common", "polkadot-sdk"];
+	Ok(DEPENDENCIES.into_iter().any(|d| {
+		manifest.dependencies.contains_key(d)
+			|| manifest.workspace.as_ref().map_or(false, |w| w.dependencies.contains_key(d))
+	}))
 }

--- a/crates/pop-parachains/src/errors.rs
+++ b/crates/pop-parachains/src/errors.rs
@@ -5,57 +5,42 @@ use zombienet_sdk::OrchestratorError;
 
 #[derive(Error, Debug)]
 pub enum Error {
-	#[error("Failed to access the current directory")]
-	CurrentDirAccess,
-
-	#[error("Failed to locate the workspace")]
-	WorkspaceLocate,
-
-	#[error("Failed to create pallet directory")]
-	PalletDirCreation,
-
-	#[error("IO error: {0}")]
-	IO(#[from] std::io::Error),
-
-	#[error("HTTP error: {0}")]
-	HttpError(#[from] reqwest::Error),
-
-	#[error("Missing binary: {0}")]
-	MissingBinary(String),
-
-	#[error("Configuration error: {0}")]
-	Config(String),
-
-	#[error("Unsupported command: {0}")]
-	UnsupportedCommand(String),
-
-	#[error("ParseError error: {0}")]
-	ParseError(#[from] url::ParseError),
-
-	#[error("Orchestrator error: {0}")]
-	OrchestratorError(#[from] OrchestratorError),
-
-	#[error("Toml error: {0}")]
-	TomlError(#[from] toml_edit::de::Error),
-
-	#[error("Anyhow error: {0}")]
-	AnyhowError(#[from] anyhow::Error),
-
 	#[error("User aborted due to existing target folder.")]
 	Aborted,
-
-	#[error("Failed to execute rustfmt")]
-	RustfmtError(std::io::Error),
-
-	#[error("Template error: {0}")]
-	TemplateError(#[from] pop_common::templates::Error),
-
-	#[error("Failed to parse the endowment value")]
-	EndowmentError,
-
-	#[error("Unsupported platform: {arch} {os}")]
-	UnsupportedPlatform { arch: &'static str, os: &'static str },
-
+	#[error("Anyhow error: {0}")]
+	AnyhowError(#[from] anyhow::Error),
 	#[error("Archive error: {0}")]
 	ArchiveError(String),
+	#[error("Configuration error: {0}")]
+	Config(String),
+	#[error("Failed to access the current directory")]
+	CurrentDirAccess,
+	#[error("Failed to parse the endowment value")]
+	EndowmentError,
+	#[error("HTTP error: {0}")]
+	HttpError(#[from] reqwest::Error),
+	#[error("IO error: {0}")]
+	IO(#[from] std::io::Error),
+	#[error("Manifest error: {0}")]
+	ManifestError(#[from] pop_common::manifest::Error),
+	#[error("Missing binary: {0}")]
+	MissingBinary(String),
+	#[error("Orchestrator error: {0}")]
+	OrchestratorError(#[from] OrchestratorError),
+	#[error("Failed to create pallet directory")]
+	PalletDirCreation,
+	#[error("ParseError error: {0}")]
+	ParseError(#[from] url::ParseError),
+	#[error("Failed to execute rustfmt")]
+	RustfmtError(std::io::Error),
+	#[error("Template error: {0}")]
+	TemplateError(#[from] pop_common::templates::Error),
+	#[error("Toml error: {0}")]
+	TomlError(#[from] toml_edit::de::Error),
+	#[error("Unsupported command: {0}")]
+	UnsupportedCommand(String),
+	#[error("Failed to locate the workspace")]
+	WorkspaceLocate,
+	#[error("Unsupported platform: {arch} {os}")]
+	UnsupportedPlatform { arch: &'static str, os: &'static str },
 }

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -10,7 +10,7 @@ mod templates;
 mod up;
 mod utils;
 
-pub use build::build_parachain;
+pub use build::{build_parachain, is_supported};
 pub use errors::Error;
 pub use indexmap::IndexSet;
 pub use new_pallet::{create_pallet_template, TemplatePalletConfig};

--- a/crates/pop-parachains/src/up/mod.rs
+++ b/crates/pop-parachains/src/up/mod.rs
@@ -482,6 +482,7 @@ struct RelayChain {
 	/// The additional workers required by the relay chain node.
 	workers: [&'static str; 2],
 	/// The name of the chain.
+	#[allow(dead_code)]
 	chain: String,
 	/// If applicable, the binary used to generate a chain specification.
 	chain_spec_generator: Option<Binary>,


### PR DESCRIPTION
Enables building without needing to specify the project type - i.e. `pop b -r`

TODO:
- [x] formalise project detection - e.g. reading manifest dependencies properly to check for ink
- [x] update `-p` to support package specification, so it can act as a simple wrapper to `cargo b -p`
- [x] tests