### PR TITLE
refactor: ensure the UX for new contracts is consistent with the parachains.

### DIFF
--- a/crates/pop-common/src/helpers.rs
+++ b/crates/pop-common/src/helpers.rs
@@ -5,7 +5,7 @@ use std::{
 	collections::HashMap,
 	fs,
 	io::{Read, Write},
-	path::PathBuf,
+	path::{Path, PathBuf},
 };
 
 /// Replaces occurrences of specified strings in a file with new values.
@@ -31,6 +31,18 @@ pub fn replace_in_file(file_path: PathBuf, replacements: HashMap<&str, &str>) ->
 	Ok(())
 }
 
+/// Gets the last component (name of a project) of a path or returns a default value if the path has no valid last component.
+///
+/// # Arguments
+/// * `path` - Location path of the project.
+/// * `default` - The default string to return if the path has no valid last component.
+pub fn get_project_name_from_path(path: &Path, default: &str) -> String {
+	path.file_name()
+		.and_then(|name| name.to_str())
+		.map(|name| name.to_string())
+		.unwrap_or_else(|| default.to_string())
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -49,6 +61,20 @@ mod tests {
 		replace_in_file(file_path.clone(), replacements_in_cargo)?;
 		let content = fs::read_to_string(file_path).expect("Could not read file");
 		assert_eq!(content.trim(), "name = changed_name, version = 5.0.1");
+		Ok(())
+	}
+
+	#[test]
+	fn get_project_name_from_path_works() -> Result<(), Error> {
+		let path = Path::new("./path/to/project/my-parachain");
+		assert_eq!(get_project_name_from_path(path, "default_name"), "my-parachain");
+		Ok(())
+	}
+
+	#[test]
+	fn get_project_name_from_path_default_value() -> Result<(), Error> {
+		let path = Path::new("./");
+		assert_eq!(get_project_name_from_path(path, "my-contract"), "my-contract");
 		Ok(())
 	}
 }

--- a/crates/pop-common/src/lib.rs
+++ b/crates/pop-common/src/lib.rs
@@ -4,5 +4,5 @@ pub mod helpers;
 
 pub use errors::Error;
 pub use git::{Git, GitHub, Release};
-pub use helpers::replace_in_file;
+pub use helpers::{get_project_name_from_path, replace_in_file};
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
Ensure the UX for new contracts is consistent with the parachains. Remove the `--path` flag for contracts to match the behavior of parachains. Restructure the user guidance for generating a new contract to follow the same order as parachains: 1. template to use 2. name (path) of the project.