### PR TITLE
refactor: downloading contracts code instead of cloning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4470,6 +4470,7 @@ name = "pop-common"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "flate2",
  "git2",
  "git2_credentials",
  "mockito",
@@ -4478,6 +4479,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.2",
+ "tar",
  "tempfile",
  "thiserror",
  "tokio",

--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -56,13 +56,13 @@ mod tests {
 	use pop_contracts::{create_smart_contract, Contract::Standard};
 	use std::fs::create_dir_all;
 
-	#[test]
-	fn build_works() -> anyhow::Result<()> {
+	#[tokio::test]
+	async fn build_works() -> anyhow::Result<()> {
 		let name = "flipper";
 		let temp_dir = tempfile::tempdir()?;
 		let path = temp_dir.path();
 		create_dir_all(path.join(name))?;
-		create_smart_contract(name, &path.join(name), &Standard)?;
+		create_smart_contract(name, &path.join(name), &Standard).await?;
 
 		for release in [false, true] {
 			for valid in [false, true] {

--- a/crates/pop-cli/src/commands/new/contract.rs
+++ b/crates/pop-cli/src/commands/new/contract.rs
@@ -63,7 +63,7 @@ impl NewContractCommand {
 
 		is_template_supported(contract_type, &template)?;
 
-		generate_contract_from_template(name, contract_config.path, &template)?;
+		generate_contract_from_template(name, contract_config.path, &template).await?;
 		Ok(())
 	}
 }
@@ -128,7 +128,7 @@ fn display_select_options(contract_type: &ContractType) -> Result<&Contract> {
 	Ok(prompt.interact()?)
 }
 
-fn generate_contract_from_template(
+async fn generate_contract_from_template(
 	name: &String,
 	path: Option<PathBuf>,
 	template: &Contract,
@@ -144,7 +144,7 @@ fn generate_contract_from_template(
 	fs::create_dir_all(contract_path.as_path())?;
 	let spinner = cliclack::spinner();
 	spinner.start("Generating contract...");
-	create_smart_contract(&name, contract_path.as_path(), template)?;
+	create_smart_contract(&name, contract_path.as_path(), template).await?;
 	spinner.clear();
 	// Replace spinner with success.
 	console::Term::stderr().clear_last_lines(2)?;

--- a/crates/pop-cli/src/commands/up/parachain.rs
+++ b/crates/pop-cli/src/commands/up/parachain.rs
@@ -8,7 +8,8 @@ use cliclack::{
 };
 use console::{Emoji, Style, Term};
 use duct::cmd;
-use pop_parachains::{Error, IndexSet, NetworkNode, Status, Zombienet};
+use pop_common::Status;
+use pop_parachains::{Error, IndexSet, NetworkNode, Zombienet};
 use std::{path::PathBuf, time::Duration};
 use tokio::time::sleep;
 

--- a/crates/pop-common/Cargo.toml
+++ b/crates/pop-common/Cargo.toml
@@ -11,15 +11,17 @@ repository.workspace = true
 anyhow.workspace = true
 git2.workspace = true
 git2_credentials.workspace = true
+flate2.workspace = true
 regex.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 strum.workspace = true
+tar.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 url.workspace = true
 
 [dev-dependencies]
 mockito.workspace = true
-tempfile.workspace = true

--- a/crates/pop-common/src/errors.rs
+++ b/crates/pop-common/src/errors.rs
@@ -12,6 +12,9 @@ pub enum Error {
 	#[error("a git error occurred: {0}")]
 	Git(String),
 
+	#[error("HTTP error: {0}")]
+	HttpError(#[from] reqwest::Error),
+
 	#[error("IO error: {0}")]
 	IO(#[from] std::io::Error),
 

--- a/crates/pop-common/src/git.rs
+++ b/crates/pop-common/src/git.rs
@@ -296,30 +296,23 @@ pub async fn from_archive(
 	contents: &[(&str, PathBuf)],
 	status: &impl Status,
 ) -> Result<(), Error> {
-	println!("Downloading from {url}...");
-	println!("{:?}", contents);
 	// Download archive
 	status.update(&format!("Downloading from {url}..."));
 	let response = reqwest::get(url).await?.error_for_status()?;
 	let mut file = tempfile()?;
 	file.write_all(&response.bytes().await?)?;
 	file.seek(SeekFrom::Start(0))?;
-	println!("Extracting.");
 	// Extract contents
 	status.update("Extracting from archive...");
 	let tar = GzDecoder::new(file);
-	println!("decoded.");
 	let mut archive = Archive::new(tar);
 	let temp_dir = tempdir()?;
 	let working_dir = temp_dir.path();
-	println!("to unpack.");
 	archive.unpack(working_dir)?;
 	for (name, dest) in contents {
-		println!("in: {:?} - {:?}", name, dest);
 		fs::rename(working_dir.join(name), dest)?;
 	}
 	status.update("Sourcing complete.");
-	println!("ok.");
 	Ok(())
 }
 

--- a/crates/pop-common/src/git.rs
+++ b/crates/pop-common/src/git.rs
@@ -296,23 +296,30 @@ pub async fn from_archive(
 	contents: &[(&str, PathBuf)],
 	status: &impl Status,
 ) -> Result<(), Error> {
+	println!("Downloading from {url}...");
+	println!("{:?}", contents);
 	// Download archive
 	status.update(&format!("Downloading from {url}..."));
 	let response = reqwest::get(url).await?.error_for_status()?;
 	let mut file = tempfile()?;
 	file.write_all(&response.bytes().await?)?;
 	file.seek(SeekFrom::Start(0))?;
+	println!("Extracting.");
 	// Extract contents
 	status.update("Extracting from archive...");
 	let tar = GzDecoder::new(file);
+	println!("decoded.");
 	let mut archive = Archive::new(tar);
 	let temp_dir = tempdir()?;
 	let working_dir = temp_dir.path();
+	println!("to unpack.");
 	archive.unpack(working_dir)?;
 	for (name, dest) in contents {
+		println!("in: {:?} - {:?}", name, dest);
 		fs::rename(working_dir.join(name), dest)?;
 	}
 	status.update("Sourcing complete.");
+	println!("ok.");
 	Ok(())
 }
 

--- a/crates/pop-common/src/lib.rs
+++ b/crates/pop-common/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod errors;
 pub mod git;
 pub mod helpers;
+pub mod status;
 pub mod templates;
 
 pub use errors::Error;
-pub use git::{Git, GitHub, Release};
+pub use git::{from_archive, Git, GitHub, Release};
 pub use helpers::replace_in_file;
+pub use status::Status;
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));

--- a/crates/pop-common/src/status.rs
+++ b/crates/pop-common/src/status.rs
@@ -1,0 +1,10 @@
+/// Trait for observing status updates.
+pub trait Status {
+	/// Update the observer with the provided `status`.
+	fn update(&self, status: &str);
+}
+
+impl Status for () {
+	// no-op: status updates are ignored
+	fn update(&self, _: &str) {}
+}

--- a/crates/pop-contracts/src/call.rs
+++ b/crates/pop-contracts/src/call.rs
@@ -164,11 +164,11 @@ mod tests {
 
 	const CONTRACTS_NETWORK_URL: &str = "wss://rococo-contracts-rpc.polkadot.io";
 
-	fn generate_smart_contract_test_environment() -> Result<tempfile::TempDir> {
+	async fn generate_smart_contract_test_environment() -> Result<tempfile::TempDir> {
 		let temp_dir = tempfile::tempdir().expect("Could not create temp dir");
 		let temp_contract_dir = temp_dir.path().join("testing");
 		fs::create_dir(&temp_contract_dir)?;
-		create_smart_contract("testing", temp_contract_dir.as_path(), &Contract::Standard)?;
+		create_smart_contract("testing", temp_contract_dir.as_path(), &Contract::Standard).await?;
 		Ok(temp_dir)
 	}
 	// Function that mocks the build process generating the contract artifacts.
@@ -186,7 +186,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_set_up_call() -> Result<()> {
-		let temp_dir = generate_smart_contract_test_environment()?;
+		let temp_dir = generate_smart_contract_test_environment().await?;
 		mock_build_process(temp_dir.path().join("testing"))?;
 
 		let call_opts = CallOpts {
@@ -208,7 +208,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_set_up_call_error_contract_not_build() -> Result<()> {
-		let temp_dir = generate_smart_contract_test_environment()?;
+		let temp_dir = generate_smart_contract_test_environment().await?;
 		let call_opts = CallOpts {
 			path: Some(temp_dir.path().join("testing")),
 			contract: "5CLPm1CeUvJhZ8GCDZCR7nWZ2m3XXe4X5MtAQK69zEjut36A".to_string(),
@@ -252,7 +252,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_dry_run_call_error_contract_not_deployed() -> Result<()> {
-		let temp_dir = generate_smart_contract_test_environment()?;
+		let temp_dir = generate_smart_contract_test_environment().await?;
 		mock_build_process(temp_dir.path().join("testing"))?;
 
 		let call_opts = CallOpts {
@@ -274,7 +274,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_dry_run_estimate_call_error_contract_not_deployed() -> Result<()> {
-		let temp_dir = generate_smart_contract_test_environment()?;
+		let temp_dir = generate_smart_contract_test_environment().await?;
 		mock_build_process(temp_dir.path().join("testing"))?;
 
 		let call_opts = CallOpts {

--- a/crates/pop-contracts/src/errors.rs
+++ b/crates/pop-contracts/src/errors.rs
@@ -52,6 +52,9 @@ pub enum Error {
 	#[error("The `Repository` property is missing from the template variant")]
 	RepositoryMissing,
 
+	#[error("The `Archive` property is missing from the template variant")]
+	ArchiveMissing,
+
 	#[error("Unsupported platform: {os}")]
 	UnsupportedPlatform { os: &'static str },
 

--- a/crates/pop-contracts/src/new.rs
+++ b/crates/pop-contracts/src/new.rs
@@ -4,11 +4,10 @@ use crate::{errors::Error, utils::helpers::canonicalized_path, Contract};
 use anyhow::Result;
 use contract_build::new_contract_project;
 use heck::ToUpperCamelCase;
-use pop_common::{from_archive, replace_in_file, templates::Template, Git};
+use pop_common::{from_archive, replace_in_file, templates::Template};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use url::Url;
 
 /// Create a new smart contract.
 ///
@@ -59,12 +58,11 @@ async fn create_template_contract(
 	template: &Contract,
 ) -> Result<()> {
 	let template_repository = template.repository_url()?;
+	let archive_name = template.archive_name().ok_or(Error::ArchiveMissing)?;
 	// Fetch the repository from archive into the temporary directory.
 	let temp_dir = ::tempfile::TempDir::new_in(std::env::temp_dir())?;
-	let contents: Vec<_> = ["ink-examples-main"]
-		.into_iter()
-		.map(|b| (b, temp_dir.path().to_path_buf()))
-		.collect();
+	let contents: Vec<_> =
+		[archive_name].into_iter().map(|b| (b, temp_dir.path().to_path_buf())).collect();
 	from_archive(template_repository, &contents, &{}).await?;
 	// Retrieve only the template contract files.
 	extract_contract_files(template.to_string(), temp_dir.path(), canonicalized_path.as_path())?;

--- a/crates/pop-contracts/src/templates.rs
+++ b/crates/pop-contracts/src/templates.rs
@@ -64,7 +64,10 @@ pub enum Contract {
 		serialize = "erc20",
 		message = "Erc20",
 		detailed_message = "The implementation of the ERC-20 standard in ink!",
-		props(Type = "ERC", Repository = "https://github.com/use-ink/ink-examples")
+		props(
+			Type = "ERC",
+			Repository = "https://github.com/use-ink/ink-examples/archive/refs/heads/main.tar.gz"
+		)
 	)]
 	ERC20,
 	/// The implementation of the ERC-721 standard in ink!
@@ -72,7 +75,10 @@ pub enum Contract {
 		serialize = "erc721",
 		message = "Erc721",
 		detailed_message = "The implementation of the ERC-721 standard in ink!",
-		props(Type = "ERC", Repository = "https://github.com/use-ink/ink-examples")
+		props(
+			Type = "ERC",
+			Repository = "https://github.com/use-ink/ink-examples/archive/refs/heads/main.tar.gz"
+		)
 	)]
 	ERC721,
 	/// The implementation of the ERC-1155 standard in ink!
@@ -80,7 +86,10 @@ pub enum Contract {
 		serialize = "erc1155",
 		message = "Erc1155",
 		detailed_message = "The implementation of the ERC-1155 standard in ink!",
-		props(Type = "ERC", Repository = "https://github.com/use-ink/ink-examples")
+		props(
+			Type = "ERC",
+			Repository = "https://github.com/use-ink/ink-examples/archive/refs/heads/main.tar.gz"
+		)
 	)]
 	ERC1155,
 }
@@ -105,9 +114,18 @@ mod tests {
 
 	fn templates_urls() -> HashMap<String, &'static str> {
 		HashMap::from([
-			("erc20".to_string(), "https://github.com/use-ink/ink-examples"),
-			("erc721".to_string(), "https://github.com/use-ink/ink-examples"),
-			("erc1155".to_string(), "https://github.com/use-ink/ink-examples"),
+			(
+				"erc20".to_string(),
+				"https://github.com/use-ink/ink-examples/archive/refs/heads/main.tar.gz",
+			),
+			(
+				"erc721".to_string(),
+				"https://github.com/use-ink/ink-examples/archive/refs/heads/main.tar.gz",
+			),
+			(
+				"erc1155".to_string(),
+				"https://github.com/use-ink/ink-examples/archive/refs/heads/main.tar.gz",
+			),
 		])
 	}
 

--- a/crates/pop-contracts/src/templates.rs
+++ b/crates/pop-contracts/src/templates.rs
@@ -2,6 +2,7 @@
 
 // pub to ease downstream imports
 pub use pop_common::templates::{Template, Type};
+use strum::EnumProperty as _;
 use strum_macros::{AsRefStr, Display, EnumMessage, EnumProperty, EnumString, VariantArray};
 
 /// Supported contract types.
@@ -66,7 +67,8 @@ pub enum Contract {
 		detailed_message = "The implementation of the ERC-20 standard in ink!",
 		props(
 			Type = "ERC",
-			Repository = "https://github.com/use-ink/ink-examples/archive/refs/heads/main.tar.gz"
+			Repository = "https://github.com/use-ink/ink-examples/archive/refs/heads/main.tar.gz",
+			Archive = "ink-examples-main"
 		)
 	)]
 	ERC20,
@@ -77,7 +79,8 @@ pub enum Contract {
 		detailed_message = "The implementation of the ERC-721 standard in ink!",
 		props(
 			Type = "ERC",
-			Repository = "https://github.com/use-ink/ink-examples/archive/refs/heads/main.tar.gz"
+			Repository = "https://github.com/use-ink/ink-examples/archive/refs/heads/main.tar.gz",
+			Archive = "ink-examples-main"
 		)
 	)]
 	ERC721,
@@ -88,13 +91,21 @@ pub enum Contract {
 		detailed_message = "The implementation of the ERC-1155 standard in ink!",
 		props(
 			Type = "ERC",
-			Repository = "https://github.com/use-ink/ink-examples/archive/refs/heads/main.tar.gz"
+			Repository = "https://github.com/use-ink/ink-examples/archive/refs/heads/main.tar.gz",
+			Archive = "ink-examples-main"
 		)
 	)]
 	ERC1155,
 }
 
 impl Template for Contract {}
+
+impl Contract {
+	/// Returns the archive name, if defined.
+	pub fn archive_name(&self) -> Option<&str> {
+		self.get_str("Archive")
+	}
+}
 
 #[cfg(test)]
 mod tests {
@@ -136,6 +147,16 @@ mod tests {
 			(ERC721, "The implementation of the ERC-721 standard in ink!"),
 			(ERC1155, "The implementation of the ERC-1155 standard in ink!"),
 		])
+	}
+
+	fn template_archive_names() -> HashMap<Contract, Option<&'static str>> {
+		[
+			(Contract::Standard, None),
+			(Contract::ERC20, Some("ink-examples-main")),
+			(Contract::ERC721, Some("ink-examples-main")),
+			(Contract::ERC1155, Some("ink-examples-main")),
+		]
+		.into()
 	}
 
 	#[test]
@@ -209,5 +230,13 @@ mod tests {
 	fn test_convert_string_to_type() {
 		assert_eq!(ContractType::from_str("Examples").unwrap(), ContractType::Examples);
 		assert_eq!(ContractType::from_str("Erc").unwrap_or_default(), ContractType::Erc);
+	}
+
+	#[test]
+	fn test_archive_name() {
+		let archive_names = template_archive_names();
+		for template in Contract::VARIANTS {
+			assert_eq!(template.archive_name(), archive_names[template]);
+		}
 	}
 }

--- a/crates/pop-contracts/src/up.rs
+++ b/crates/pop-contracts/src/up.rs
@@ -228,7 +228,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn set_up_deployment_works() -> Result<()> {
-		let temp_dir = generate_smart_contract_test_environment()?;
+		let temp_dir = generate_smart_contract_test_environment().await?;
 		mock_build_process(temp_dir.path().join("testing"))?;
 		let up_opts = UpOpts {
 			path: Some(temp_dir.path().join("testing")),
@@ -247,7 +247,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn set_up_upload_works() -> Result<()> {
-		let temp_dir = generate_smart_contract_test_environment()?;
+		let temp_dir = generate_smart_contract_test_environment().await?;
 		mock_build_process(temp_dir.path().join("testing"))?;
 		let up_opts = UpOpts {
 			path: Some(temp_dir.path().join("testing")),
@@ -266,7 +266,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn dry_run_gas_estimate_instantiate_works() -> Result<()> {
-		let temp_dir = generate_smart_contract_test_environment()?;
+		let temp_dir = generate_smart_contract_test_environment().await?;
 		mock_build_process(temp_dir.path().join("testing"))?;
 		let up_opts = UpOpts {
 			path: Some(temp_dir.path().join("testing")),
@@ -288,7 +288,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn dry_run_gas_estimate_instantiate_throw_custom_error() -> Result<()> {
-		let temp_dir = generate_smart_contract_test_environment()?;
+		let temp_dir = generate_smart_contract_test_environment().await?;
 		mock_build_process(temp_dir.path().join("testing"))?;
 		let up_opts = UpOpts {
 			path: Some(temp_dir.path().join("testing")),
@@ -311,7 +311,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn dry_run_upload_throw_custom_error() -> Result<()> {
-		let temp_dir = generate_smart_contract_test_environment()?;
+		let temp_dir = generate_smart_contract_test_environment().await?;
 		mock_build_process(temp_dir.path().join("testing"))?;
 		let up_opts = UpOpts {
 			path: Some(temp_dir.path().join("testing")),
@@ -333,7 +333,7 @@ mod tests {
 	#[tokio::test]
 	async fn instantiate_and_upload() -> Result<()> {
 		const LOCALHOST_URL: &str = "ws://127.0.0.1:9944";
-		let temp_dir = generate_smart_contract_test_environment()?;
+		let temp_dir = generate_smart_contract_test_environment().await?;
 		mock_build_process(temp_dir.path().join("testing"))?;
 		// Run contracts-node
 		let cache = temp_dir.path().join("cache");

--- a/crates/pop-contracts/src/up.rs
+++ b/crates/pop-contracts/src/up.rs
@@ -131,11 +131,11 @@ mod tests {
 
 	const CONTRACTS_NETWORK_URL: &str = "wss://rococo-contracts-rpc.polkadot.io";
 
-	fn generate_smart_contract_test_environment() -> Result<tempfile::TempDir> {
+	async fn generate_smart_contract_test_environment() -> Result<tempfile::TempDir> {
 		let temp_dir = tempfile::tempdir().expect("Could not create temp dir");
 		let temp_contract_dir = temp_dir.path().join("testing");
 		fs::create_dir(&temp_contract_dir)?;
-		create_smart_contract("testing", temp_contract_dir.as_path(), &Contract::Standard)?;
+		create_smart_contract("testing", temp_contract_dir.as_path(), &Contract::Standard).await?;
 		Ok(temp_dir)
 	}
 	// Function that mocks the build process generating the contract artifacts.
@@ -153,7 +153,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_set_up_deployment() -> Result<()> {
-		let temp_dir = generate_smart_contract_test_environment()?;
+		let temp_dir = generate_smart_contract_test_environment().await?;
 		mock_build_process(temp_dir.path().join("testing"))?;
 		let up_opts = UpOpts {
 			path: Some(temp_dir.path().join("testing")),
@@ -171,7 +171,7 @@ mod tests {
 	}
 	#[tokio::test]
 	async fn test_dry_run_gas_estimate_instantiate_throw_custom_error() -> Result<()> {
-		let temp_dir = generate_smart_contract_test_environment()?;
+		let temp_dir = generate_smart_contract_test_environment().await?;
 		mock_build_process(temp_dir.path().join("testing"))?;
 		let up_opts = UpOpts {
 			path: Some(temp_dir.path().join("testing")),

--- a/crates/pop-contracts/src/utils/helpers.rs
+++ b/crates/pop-contracts/src/utils/helpers.rs
@@ -65,9 +65,9 @@ mod tests {
 		Ok(temp_dir)
 	}
 
-	#[test]
-	fn test_get_manifest_path() -> Result<(), Error> {
-		let temp_dir = setup_test_environment()?;
+	#[tokio::test]
+	async fn test_get_manifest_path() -> Result<(), Error> {
+		let temp_dir = setup_test_environment().await?;
 		get_manifest_path(Some(&PathBuf::from(temp_dir.path().join("test_contract"))))?;
 		Ok(())
 	}

--- a/crates/pop-contracts/src/utils/helpers.rs
+++ b/crates/pop-contracts/src/utils/helpers.rs
@@ -52,7 +52,7 @@ mod tests {
 	use anyhow::{Error, Result};
 	use std::fs;
 
-	fn setup_test_environment() -> Result<tempfile::TempDir, Error> {
+	async fn setup_test_environment() -> Result<tempfile::TempDir, Error> {
 		let temp_dir = tempfile::tempdir().expect("Could not create temp dir");
 		let temp_contract_dir = temp_dir.path().join("test_contract");
 		fs::create_dir(&temp_contract_dir)?;
@@ -60,13 +60,14 @@ mod tests {
 			"test_contract",
 			temp_contract_dir.as_path(),
 			&crate::Contract::Standard,
-		)?;
+		)
+		.await?;
 		Ok(temp_dir)
 	}
 
-	#[test]
-	fn test_get_manifest_path() -> Result<(), Error> {
-		let temp_dir = setup_test_environment()?;
+	#[tokio::test]
+	async fn test_get_manifest_path() -> Result<(), Error> {
+		let temp_dir = setup_test_environment().await?;
 		get_manifest_path(&Some(PathBuf::from(temp_dir.path().join("test_contract"))))?;
 		Ok(())
 	}

--- a/crates/pop-contracts/tests/contract.rs
+++ b/crates/pop-contracts/tests/contract.rs
@@ -9,11 +9,12 @@ use std::fs;
 use tempfile::TempDir;
 use url::Url;
 
-fn setup_test_environment() -> std::result::Result<tempfile::TempDir, Error> {
+async fn setup_test_environment() -> std::result::Result<tempfile::TempDir, Error> {
 	let temp_dir = tempfile::tempdir().expect("Could not create temp dir");
 	let temp_contract_dir = temp_dir.path().join("test_contract");
 	fs::create_dir(&temp_contract_dir)?;
-	create_smart_contract("test_contract", temp_contract_dir.as_path(), &Contract::Standard)?;
+	create_smart_contract("test_contract", temp_contract_dir.as_path(), &Contract::Standard)
+		.await?;
 	Ok(temp_dir)
 }
 
@@ -36,10 +37,10 @@ fn verify_build_files(temp_contract_dir: TempDir) -> Result<()> {
 	Ok(())
 }
 
-#[test]
-fn test_contract_build() -> std::result::Result<(), Error> {
+#[tokio::test]
+async fn test_contract_build() -> std::result::Result<(), Error> {
 	// Test building in release mode
-	let temp_contract_dir = setup_test_environment()?;
+	let temp_contract_dir = setup_test_environment().await?;
 
 	let formatted_result =
 		build_smart_contract(&Some(temp_contract_dir.path().join("test_contract")), true)?;
@@ -47,7 +48,7 @@ fn test_contract_build() -> std::result::Result<(), Error> {
 
 	verify_build_files(temp_contract_dir)?;
 
-	let temp_debug_contract_dir = setup_test_environment()?;
+	let temp_debug_contract_dir = setup_test_environment().await?;
 	// Test building in debug mode
 	let formatted_result_debug_mode =
 		build_smart_contract(&Some(temp_debug_contract_dir.path().join("test_contract")), false)?;
@@ -67,7 +68,7 @@ fn build_smart_contract_test_environment(temp_dir: &TempDir) -> Result<(), Error
 
 #[tokio::test]
 async fn test_set_up_deployment() -> std::result::Result<(), Error> {
-	let temp_dir = setup_test_environment()?;
+	let temp_dir = setup_test_environment().await?;
 	build_smart_contract_test_environment(&temp_dir)?;
 
 	let call_opts = UpOpts {
@@ -88,7 +89,7 @@ async fn test_set_up_deployment() -> std::result::Result<(), Error> {
 
 #[tokio::test]
 async fn test_dry_run_gas_estimate_instantiate() -> std::result::Result<(), Error> {
-	let temp_dir = setup_test_environment()?;
+	let temp_dir = setup_test_environment().await?;
 	build_smart_contract_test_environment(&temp_dir)?;
 
 	let call_opts = UpOpts {

--- a/crates/pop-parachains/src/errors.rs
+++ b/crates/pop-parachains/src/errors.rs
@@ -50,6 +50,9 @@ pub enum Error {
 	#[error("Template error: {0}")]
 	TemplateError(#[from] pop_common::templates::Error),
 
+	#[error("{0}")]
+	CommonError(#[from] pop_common::Error),
+
 	#[error("Failed to parse the endowment value")]
 	EndowmentError,
 

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -16,7 +16,7 @@ pub use indexmap::IndexSet;
 pub use new_pallet::{create_pallet_template, TemplatePalletConfig};
 pub use new_parachain::instantiate_template_dir;
 pub use templates::{Config, Parachain, Provider};
-pub use up::{Binary, Status, Zombienet};
+pub use up::{Binary, Zombienet};
 pub use utils::helpers::is_initial_endowment_valid;
 pub use utils::pallet_helpers::resolve_pallet_path;
 /// Information about the Node. External export from Zombienet-SDK.

--- a/crates/pop-parachains/src/up/mod.rs
+++ b/crates/pop-parachains/src/up/mod.rs
@@ -3,7 +3,7 @@
 use crate::errors::Error;
 use glob::glob;
 use indexmap::IndexMap;
-use pop_common::git::GitHub;
+use pop_common::{git::GitHub, Status};
 use sourcing::{GitHub::*, Source, Source::*};
 use std::{
 	fmt::Debug,
@@ -783,17 +783,6 @@ impl Repository {
 
 		Ok(Self { url, reference, package })
 	}
-}
-
-/// Trait for observing status updates.
-pub trait Status {
-	/// Update the observer with the provided `status`.
-	fn update(&self, status: &str);
-}
-
-impl Status for () {
-	// no-op: status updates are ignored
-	fn update(&self, _: &str) {}
 }
 
 /// Attempts to resolve the package manifest from the specified path.


### PR DESCRIPTION
For contract templates, we were previously cloning the repository. This PR refactors the process to download source code archives from GitHub instead, as it is faster and cleaner.

To achieve this, a bit of refactoring was needed, moving some logic from the `pop_parachains` crate to the `pop_common` crate, such as the `from_archive` function and the `Status` trait.

_There are a lot of file changes because the `create_smart_contract` function was refactored to be async, which required updating all the related tests._