### PR TITLE
fix: handle IO error if rename fails

### DIFF
--- a/crates/pop-parachains/src/up/sourcing.rs
+++ b/crates/pop-parachains/src/up/sourcing.rs
@@ -239,9 +239,9 @@ async fn from_archive(
 	for (name, dest) in contents {
 		let src = working_dir.join(name);
 		if src.exists() {
-			if let Err(_e) = rename(&src, &dest) {
+			if let Err(_e) = rename(&src, dest) {
 				// If rename fails (e.g., due to cross-device linking), fallback to copy and remove
-				std::fs::copy(&src, &dest)?;
+				std::fs::copy(&src, dest)?;
 				std::fs::remove_file(&src)?;
 			}
 		} else {

--- a/crates/pop-parachains/src/up/sourcing.rs
+++ b/crates/pop-parachains/src/up/sourcing.rs
@@ -237,7 +237,19 @@ async fn from_archive(
 	let working_dir = temp_dir.path();
 	archive.unpack(working_dir)?;
 	for (name, dest) in contents {
-		rename(working_dir.join(name), dest)?;
+		let src = working_dir.join(name);
+		if src.exists() {
+			if let Err(_e) = rename(&src, &dest) {
+				// If rename fails (e.g., due to cross-device linking), fallback to copy and remove
+				std::fs::copy(&src, &dest)?;
+				std::fs::remove_file(&src)?;
+			}
+		} else {
+			return Err(Error::ArchiveError(format!(
+				"Expected file '{}' in archive, but it was not found.",
+				name
+			)));
+		}
 	}
 	status.update("Sourcing complete.");
 	Ok(())


### PR DESCRIPTION
![image](https://github.com/r0gue-io/pop-cli/assets/15621959/21715476-0324-4373-9cb2-bffde23b25f1)
this should fix there errs. not sure about cause, probably something related to /tmp permissions