### PR TITLE
fix: check if contracts needs to be build before deploy

### DIFF
--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -193,7 +193,7 @@ impl From<UpContractCommand> for UpOpts {
 	}
 }
 
-/// Checks if a contract has been built by verifying the existence of the build directory.
+/// Checks if a contract has been built by verifying the existence of the build directory and the <name>.contract file.
 ///
 /// # Arguments
 /// * `path` - An optional path to the project directory. If no path is provided, the current directory is used.


### PR DESCRIPTION
A bug was found when running the` pop up contract`. The check to determine if the contract had been built was failing, causing the contract to be rebuilt every time.
I have added the fix and included a test to ensure this issue does not occur again.