### PR TITLE
refactor(contracts-node): reduce duplicated code with binary sourcing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4530,6 +4530,7 @@ dependencies = [
  "ink_env",
  "mockito",
  "pop-common",
+ "pop-parachains",
  "reqwest 0.12.5",
  "sp-core",
  "sp-weights",

--- a/crates/pop-cli/src/commands/test/contract.rs
+++ b/crates/pop-cli/src/commands/test/contract.rs
@@ -58,14 +58,15 @@ impl TestContractCommand {
 				} else {
 					let spinner = spinner();
 					spinner.start("Sourcing substrate-contracts-node...");
+
 					let cache_path = crate::cache()?;
 					let binary = download_contracts_node(cache_path.clone()).await?;
-					let binary_path = binary.path().join(binary.name());
+
 					spinner.stop(format!(
 						"substrate-contracts-node successfully sourced. Cached at: {}",
-						binary_path.to_str().unwrap()
+						binary.path().to_str().unwrap()
 					));
-					self.node = Some(binary_path);
+					self.node = Some(binary.path());
 				}
 			} else {
 				if let Some(node_path) = maybe_contract_node_path {

--- a/crates/pop-cli/src/commands/test/contract.rs
+++ b/crates/pop-cli/src/commands/test/contract.rs
@@ -59,12 +59,13 @@ impl TestContractCommand {
 					let spinner = spinner();
 					spinner.start("Sourcing substrate-contracts-node...");
 					let cache_path = crate::cache()?;
-					let binary_path = download_contracts_node(cache_path.clone()).await?;
+					let binary = download_contracts_node(cache_path.clone()).await?;
+					let binary_path = binary.path().join(binary.name());
 					spinner.stop(format!(
 						"substrate-contracts-node successfully sourced. Cached at: {}",
 						binary_path.to_str().unwrap()
 					));
-					self.node = Some(binary_path.clone());
+					self.node = Some(binary_path);
 				}
 			} else {
 				if let Some(node_path) = maybe_contract_node_path {

--- a/crates/pop-contracts/Cargo.toml
+++ b/crates/pop-contracts/Cargo.toml
@@ -36,6 +36,7 @@ contract-extrinsics.workspace = true
 
 #  pop
 pop-common = { path = "../pop-common", version = "0.2.0" }
+pop-parachains = { path = "../pop-parachains", version = "0.2.0" }
 
 [dev-dependencies]
 mockito.workspace = true

--- a/crates/pop-contracts/src/errors.rs
+++ b/crates/pop-contracts/src/errors.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
+use pop_parachains::Error as SourcingError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -48,4 +49,6 @@ pub enum Error {
 	UnsupportedPlatform { os: &'static str },
 	#[error("{0}")]
 	UploadContractError(String),
+	#[error("Sourcing error {0}")]
+	SourcingError(SourcingError),
 }

--- a/crates/pop-contracts/src/lib.rs
+++ b/crates/pop-contracts/src/lib.rs
@@ -16,15 +16,12 @@ pub use call::{
 };
 pub use new::{create_smart_contract, is_valid_contract_name};
 pub use templates::{Contract, ContractType};
-pub use test::{
-	does_contracts_node_exist, download_contracts_node, test_e2e_smart_contract,
-	test_smart_contract,
-};
+pub use test::{does_contracts_node_exist, test_e2e_smart_contract, test_smart_contract};
 pub use up::{
 	dry_run_gas_estimate_instantiate, dry_run_upload, instantiate_smart_contract,
 	set_up_deployment, set_up_upload, upload_smart_contract, UpOpts,
 };
 pub use utils::{
-	contracts_node::{is_chain_alive, run_contracts_node},
+	contracts_node::{download_contracts_node, is_chain_alive, run_contracts_node},
 	signer::parse_hex_bytes,
 };

--- a/crates/pop-contracts/src/test.rs
+++ b/crates/pop-contracts/src/test.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::errors::Error;
+use crate::{download_contracts_node, errors::Error};
 use duct::cmd;
 use flate2::read::GzDecoder;
 use pop_common::GitHub;
@@ -60,6 +60,7 @@ pub fn test_e2e_smart_contract(path: Option<&Path>, node: Option<&Path>) -> Resu
 /// - None if the binary does not exist
 pub fn does_contracts_node_exist(cache: PathBuf) -> Option<PathBuf> {
 	let cached_location = cache.join(BIN_NAME);
+	println!("{:?}", cached_location);
 	if cmd(BIN_NAME, vec!["--version"]).run().map_or(false, |_| true) {
 		Some(PathBuf::new())
 	} else if cached_location.exists() {
@@ -69,66 +70,32 @@ pub fn does_contracts_node_exist(cache: PathBuf) -> Option<PathBuf> {
 	}
 }
 
-/// Downloads the latest contracts node binary
-pub async fn download_contracts_node(cache: PathBuf) -> Result<PathBuf, Error> {
-	let cached_file = cache.join(BIN_NAME);
-	if !cached_file.exists() {
-		let archive = archive_name_by_target()?;
+// /// Downloads the latest contracts node binary
+// pub async fn download_contracts_node(cache: PathBuf) -> Result<PathBuf, Error> {
+// 	let cached_file = cache.join(BIN_NAME);
+// 	if !cached_file.exists() {
+// 		let archive = archive_name_by_target()?;
 
-		let latest_version = latest_contract_node_release().await?;
-		let releases_url =
-			format!("{SUBSTRATE_CONTRACT_NODE}/releases/download/{latest_version}/{archive}");
-		// Download archive
-		let response = reqwest::get(releases_url.as_str()).await?.error_for_status()?;
-		let mut file = tempfile()?;
-		file.write_all(&response.bytes().await?)?;
-		file.seek(SeekFrom::Start(0))?;
-		// Extract contents
-		let tar = GzDecoder::new(file);
-		let mut archive = Archive::new(tar);
-		archive.unpack(cache.clone())?;
-		// Copy the file into the cache folder and remove the folder artifacts
-		let extracted_dir = cache.join(release_folder_by_target()?);
-		fs::copy(&extracted_dir.join(BIN_NAME), &cached_file)?;
-		fs::remove_dir_all(&extracted_dir.parent().unwrap_or(&cache.join("artifacts")))?;
-	}
+// 		let latest_version = latest_contract_node_release().await?;
+// 		let releases_url =
+// 			format!("{SUBSTRATE_CONTRACT_NODE}/releases/download/{latest_version}/{archive}");
+// 		// Download archive
+// 		let response = reqwest::get(releases_url.as_str()).await?.error_for_status()?;
+// 		let mut file = tempfile()?;
+// 		file.write_all(&response.bytes().await?)?;
+// 		file.seek(SeekFrom::Start(0))?;
+// 		// Extract contents
+// 		let tar = GzDecoder::new(file);
+// 		let mut archive = Archive::new(tar);
+// 		archive.unpack(cache.clone())?;
+// 		// Copy the file into the cache folder and remove the folder artifacts
+// 		let extracted_dir = cache.join(release_folder_by_target()?);
+// 		fs::copy(&extracted_dir.join(BIN_NAME), &cached_file)?;
+// 		fs::remove_dir_all(&extracted_dir.parent().unwrap_or(&cache.join("artifacts")))?;
+// 	}
 
-	Ok(cached_file)
-}
-
-fn release_folder_by_target() -> Result<&'static str, Error> {
-	match OS {
-		"macos" => Ok("artifacts/substrate-contracts-node-mac"),
-		"linux" => Ok("artifacts/substrate-contracts-node-linux"),
-		_ => Err(Error::UnsupportedPlatform { os: OS }),
-	}
-}
-
-async fn latest_contract_node_release() -> Result<String, Error> {
-	let repo = GitHub::parse(SUBSTRATE_CONTRACT_NODE)?;
-	match repo.releases().await {
-		Ok(releases) => {
-			// Fetching latest releases
-			for release in releases {
-				if !release.prerelease {
-					return Ok(release.tag_name);
-				}
-			}
-			// It should never reach this point, but in case we download a default version of polkadot
-			Ok(STABLE_VERSION.to_string())
-		},
-		// If an error with GitHub API return the STABLE_VERSION
-		Err(_) => Ok(STABLE_VERSION.to_string()),
-	}
-}
-
-fn archive_name_by_target() -> Result<String, Error> {
-	match OS {
-		"macos" => Ok(format!("{}-mac-universal.tar.gz", BIN_NAME)),
-		"linux" => Ok(format!("{}-linux.tar.gz", BIN_NAME)),
-		_ => Err(Error::UnsupportedPlatform { os: OS }),
-	}
-}
+// 	Ok(cached_file)
+// }
 
 #[cfg(test)]
 mod tests {

--- a/crates/pop-contracts/src/test.rs
+++ b/crates/pop-contracts/src/test.rs
@@ -1,19 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::{download_contracts_node, errors::Error};
+use crate::errors::Error;
 use duct::cmd;
-use flate2::read::GzDecoder;
-use pop_common::GitHub;
-use std::{
-	env,
-	env::consts::OS,
-	fs::{self},
-	io::{Seek, SeekFrom, Write},
-	path::Path,
-	path::PathBuf,
-};
-use tar::Archive;
-use tempfile::tempfile;
+use std::{env, path::Path, path::PathBuf};
 
 /// Run unit tests of a smart contract.
 ///
@@ -29,9 +18,7 @@ pub fn test_smart_contract(path: Option<&Path>) -> Result<(), Error> {
 	Ok(())
 }
 
-const SUBSTRATE_CONTRACT_NODE: &str = "https://github.com/paritytech/substrate-contracts-node";
 const BIN_NAME: &str = "substrate-contracts-node";
-const STABLE_VERSION: &str = "v0.41.0";
 
 /// Run e2e tests of a smart contract.
 ///
@@ -60,7 +47,6 @@ pub fn test_e2e_smart_contract(path: Option<&Path>, node: Option<&Path>) -> Resu
 /// - None if the binary does not exist
 pub fn does_contracts_node_exist(cache: PathBuf) -> Option<PathBuf> {
 	let cached_location = cache.join(BIN_NAME);
-	println!("{:?}", cached_location);
 	if cmd(BIN_NAME, vec!["--version"]).run().map_or(false, |_| true) {
 		Some(PathBuf::new())
 	} else if cached_location.exists() {
@@ -69,33 +55,6 @@ pub fn does_contracts_node_exist(cache: PathBuf) -> Option<PathBuf> {
 		None
 	}
 }
-
-// /// Downloads the latest contracts node binary
-// pub async fn download_contracts_node(cache: PathBuf) -> Result<PathBuf, Error> {
-// 	let cached_file = cache.join(BIN_NAME);
-// 	if !cached_file.exists() {
-// 		let archive = archive_name_by_target()?;
-
-// 		let latest_version = latest_contract_node_release().await?;
-// 		let releases_url =
-// 			format!("{SUBSTRATE_CONTRACT_NODE}/releases/download/{latest_version}/{archive}");
-// 		// Download archive
-// 		let response = reqwest::get(releases_url.as_str()).await?.error_for_status()?;
-// 		let mut file = tempfile()?;
-// 		file.write_all(&response.bytes().await?)?;
-// 		file.seek(SeekFrom::Start(0))?;
-// 		// Extract contents
-// 		let tar = GzDecoder::new(file);
-// 		let mut archive = Archive::new(tar);
-// 		archive.unpack(cache.clone())?;
-// 		// Copy the file into the cache folder and remove the folder artifacts
-// 		let extracted_dir = cache.join(release_folder_by_target()?);
-// 		fs::copy(&extracted_dir.join(BIN_NAME), &cached_file)?;
-// 		fs::remove_dir_all(&extracted_dir.parent().unwrap_or(&cache.join("artifacts")))?;
-// 	}
-
-// 	Ok(cached_file)
-// }
 
 #[cfg(test)]
 mod tests {

--- a/crates/pop-contracts/src/utils/contracts_node.rs
+++ b/crates/pop-contracts/src/utils/contracts_node.rs
@@ -33,6 +33,8 @@ pub async fn is_chain_alive(url: url::Url) -> Result<bool, Error> {
 	}
 }
 
+/// Downloads the latest version of the `substrate-contracts-node` binary
+/// into the specified cache location.
 pub async fn download_contracts_node(cache: PathBuf) -> Result<Binary, Error> {
 	let archive = archive_name_by_target()?;
 	let archive_bin_path = release_folder_by_target()?;
@@ -93,7 +95,7 @@ fn archive_name_by_target() -> Result<String, Error> {
 fn release_folder_by_target() -> Result<&'static str, Error> {
 	match OS {
 		"macos" => Ok("artifacts/substrate-contracts-node-mac/substrate-contracts-node"),
-		"linux" => Ok("artifacts/substrate-contracts-node-linux"),
+		"linux" => Ok("artifacts/substrate-contracts-node-linux/substrate-contracts-node"),
 		_ => Err(Error::UnsupportedPlatform { os: OS }),
 	}
 }

--- a/crates/pop-contracts/src/utils/contracts_node.rs
+++ b/crates/pop-contracts/src/utils/contracts_node.rs
@@ -68,7 +68,7 @@ pub async fn download_contracts_node(cache: PathBuf) -> Result<Binary, Error> {
 ///
 pub async fn run_contracts_node(cache: PathBuf, output: Option<&File>) -> Result<Child, Error> {
 	let contracts_node = download_contracts_node(cache).await?;
-	let mut command = Command::new(contracts_node.path().join(contracts_node.name()));
+	let mut command = Command::new(contracts_node.path());
 
 	if let Some(output) = output {
 		command.stdout(Stdio::from(output.try_clone()?));

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -19,7 +19,7 @@ pub use indexmap::IndexSet;
 pub use new_pallet::{create_pallet_template, TemplatePalletConfig};
 pub use new_parachain::instantiate_template_dir;
 pub use templates::{Config, Parachain, Provider};
-pub use up::{Binary, Status, Zombienet};
+pub use up::{Binary, GitHub, GitHubSource, Source, Status, Zombienet};
 pub use utils::helpers::is_initial_endowment_valid;
 pub use utils::pallet_helpers::resolve_pallet_path;
 /// Information about the Node. External export from Zombienet-SDK.

--- a/crates/pop-parachains/src/up/mod.rs
+++ b/crates/pop-parachains/src/up/mod.rs
@@ -3,8 +3,9 @@
 use crate::errors::Error;
 use glob::glob;
 use indexmap::IndexMap;
-use pop_common::git::GitHub;
-use sourcing::{GitHub::*, Source, Source::*};
+pub use pop_common::git::GitHub;
+use sourcing::GitHub::*;
+pub use sourcing::{GitHub as GitHubSource, Source, Source::*};
 use std::{
 	fmt::Debug,
 	fs::write,
@@ -14,7 +15,7 @@ use std::{
 use symlink::{remove_symlink_file, symlink_file};
 use tempfile::{Builder, NamedTempFile};
 use toml_edit::{value, ArrayOfTables, DocumentMut, Formatted, Item, Table, Value};
-use url::Url;
+pub use url::Url;
 use zombienet_sdk::{Network, NetworkConfig, NetworkConfigExt};
 use zombienet_support::fs::local::LocalFileSystem;
 

--- a/crates/pop-parachains/src/up/sourcing.rs
+++ b/crates/pop-parachains/src/up/sourcing.rs
@@ -225,6 +225,7 @@ async fn from_archive(
 ) -> Result<(), Error> {
 	// Download archive
 	status.update(&format!("Downloading from {url}..."));
+	println!("{:?}", url);
 	let response = reqwest::get(url).await?.error_for_status()?;
 	let mut file = tempfile()?;
 	file.write_all(&response.bytes().await?)?;
@@ -239,6 +240,7 @@ async fn from_archive(
 	for (name, dest) in contents {
 		let src = working_dir.join(name);
 		if src.exists() {
+			println!("HERE {:?} dest {:?}", src, dest);
 			if let Err(_e) = rename(&src, dest) {
 				// If rename fails (e.g., due to cross-device linking), fallback to copy and remove
 				std::fs::copy(&src, dest)?;

--- a/crates/pop-parachains/src/up/sourcing.rs
+++ b/crates/pop-parachains/src/up/sourcing.rs
@@ -225,7 +225,6 @@ async fn from_archive(
 ) -> Result<(), Error> {
 	// Download archive
 	status.update(&format!("Downloading from {url}..."));
-	println!("{:?}", url);
 	let response = reqwest::get(url).await?.error_for_status()?;
 	let mut file = tempfile()?;
 	file.write_all(&response.bytes().await?)?;
@@ -240,7 +239,6 @@ async fn from_archive(
 	for (name, dest) in contents {
 		let src = working_dir.join(name);
 		if src.exists() {
-			println!("HERE {:?} dest {:?}", src, dest);
 			if let Err(_e) = rename(&src, dest) {
 				// If rename fails (e.g., due to cross-device linking), fallback to copy and remove
 				std::fs::copy(&src, dest)?;

--- a/crates/pop-parachains/src/up/sourcing.rs
+++ b/crates/pop-parachains/src/up/sourcing.rs
@@ -18,7 +18,7 @@ use url::Url;
 
 /// The source of a binary.
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum Source {
+pub enum Source {
 	/// An archive for download.
 	#[allow(dead_code)]
 	Archive {
@@ -103,7 +103,7 @@ impl Source {
 
 /// A binary sourced from GitHub.
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum GitHub {
+pub enum GitHub {
 	/// An archive for download from a GitHub release.
 	ReleaseArchive {
 		/// The owner of the repository - i.e. https://github.com/{owner}/repository.


### PR DESCRIPTION
Refactors the usage of `substrate-contracts-node` for `pop up contract` and `pop test contract --e2e`. These now use the functionality defined in `pop-parachains` specifically for sourcing node-binaries from GitHub.