### PR TITLE
refactor: handle errors and fix docs

### DIFF
--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -253,12 +253,12 @@ impl BuildSpecCommand {
 		let mut chain_spec = ChainSpec::from(&plain_chain_spec)?;
 		chain_spec.replace_para_id(para_id)?;
 		let relay = self.relay.unwrap_or(RelayChain::PaseoLocal).to_string();
-		chain_spec.replace_relay_chain(&relay);
+		chain_spec.replace_relay_chain(&relay)?;
 		let chain_type = self.chain_type.unwrap_or(ChainType::Development).to_string();
-		chain_spec.replace_chain_type(&chain_type);
+		chain_spec.replace_chain_type(&chain_type)?;
 		if self.protocol_id.is_some() {
 			let protocol_id = self.protocol_id.unwrap_or(DEFAULT_PROTOCOL_ID.to_string());
-			chain_spec.replace_protocol_id(&protocol_id);
+			chain_spec.replace_protocol_id(&protocol_id)?;
 		}
 		chain_spec.to_file(&plain_chain_spec)?;
 

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -251,7 +251,7 @@ impl BuildSpecCommand {
 
 		// Customize spec based on input.
 		let mut chain_spec = ChainSpec::from(&plain_chain_spec)?;
-		chain_spec.replace_para_id(para_id);
+		chain_spec.replace_para_id(para_id)?;
 		let relay = self.relay.unwrap_or(RelayChain::PaseoLocal).to_string();
 		chain_spec.replace_relay_chain(&relay);
 		let chain_type = self.chain_type.unwrap_or(ChainType::Development).to_string();

--- a/crates/pop-parachains/README.md
+++ b/crates/pop-parachains/README.md
@@ -33,6 +33,30 @@ let package = None;  // The optional package to be built.
 let binary_path = build_parachain(&path, package, &Profile::Release, None).unwrap();
 ```
 
+Generate a plain chain specification file and customize it with your specific parachain values:
+
+```rust,no_run
+use pop_common::Profile;
+use pop_parachains::{build_parachain, export_wasm_file, generate_plain_chain_spec, generate_raw_chain_spec, generate_genesis_state_file, ChainSpec};
+use std::path::Path;
+
+let path = Path::new("./"); // Location of the parachain project.
+let package = None;  // The optional package to be built.
+// The path to the node binary executable.
+let binary_path = build_parachain(&path, package, &Profile::Release, None).unwrap();;
+// Generate a plain chain specification file of a parachain
+let plain_chain_spec_path = path.join("plain-parachain-chainspec.json");
+generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true);
+// Customize your chain specification
+let mut chain_spec = ChainSpec::from(&plain_chain_spec_path).unwrap();
+chain_spec.replace_para_id(2002);
+chain_spec.replace_relay_chain("paseo-local");
+chain_spec.replace_chain_type("Development");
+chain_spec.replace_protocol_id("my-protocol");
+// Writes the chain specification to a file
+chain_spec.to_file(&plain_chain_spec_path).unwrap();
+```
+
 Generate a raw chain specification file and export the WASM and genesis state files:
 
 ```rust,no_run

--- a/crates/pop-parachains/README.md
+++ b/crates/pop-parachains/README.md
@@ -49,7 +49,7 @@ let plain_chain_spec_path = path.join("plain-parachain-chainspec.json");
 generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true);
 // Customize your chain specification
 let mut chain_spec = ChainSpec::from(&plain_chain_spec_path).unwrap();
-chain_spec.replace_para_id(2002).unwrap();
+chain_spec.replace_para_id(2002);
 chain_spec.replace_relay_chain("paseo-local");
 chain_spec.replace_chain_type("Development");
 chain_spec.replace_protocol_id("my-protocol");

--- a/crates/pop-parachains/README.md
+++ b/crates/pop-parachains/README.md
@@ -49,7 +49,7 @@ let plain_chain_spec_path = path.join("plain-parachain-chainspec.json");
 generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true);
 // Customize your chain specification
 let mut chain_spec = ChainSpec::from(&plain_chain_spec_path).unwrap();
-chain_spec.replace_para_id(2002);
+chain_spec.replace_para_id(2002).unwrap();
 chain_spec.replace_relay_chain("paseo-local");
 chain_spec.replace_chain_type("Development");
 chain_spec.replace_protocol_id("my-protocol");

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -255,30 +255,42 @@ impl ChainSpec {
 	///
 	/// # Arguments
 	/// * `relay_name` - The new value for the relay chain field in the specification.
-	pub fn replace_relay_chain(&mut self, relay_name: &str) {
+	pub fn replace_relay_chain(&mut self, relay_name: &str) -> Result<(), Error> {
 		// Replace relay_chain
-		let replace = self.0.get_mut("relay_chain").expect("expected `relay_chain`");
+		let replace = self
+			.0
+			.get_mut("relay_chain")
+			.ok_or_else(|| Error::Config("expected `relay_chain`".into()))?;
 		*replace = json!(relay_name);
+		Ok(())
 	}
 
 	/// Replaces the chain type with the given one.
 	///
 	/// # Arguments
 	/// * `chain_type` - The new value for the chain type.
-	pub fn replace_chain_type(&mut self, chain_type: &str) {
+	pub fn replace_chain_type(&mut self, chain_type: &str) -> Result<(), Error> {
 		// Replace chainType
-		let replace = self.0.get_mut("chainType").expect("expected `chainType`");
+		let replace = self
+			.0
+			.get_mut("chainType")
+			.ok_or_else(|| Error::Config("expected `chainType`".into()))?;
 		*replace = json!(chain_type);
+		Ok(())
 	}
 
 	/// Replaces the protocol ID with the given one.
 	///
 	/// # Arguments
 	/// * `protocol_id` - The new value for the protocolId of the given specification.
-	pub fn replace_protocol_id(&mut self, protocol_id: &str) {
+	pub fn replace_protocol_id(&mut self, protocol_id: &str) -> Result<(), Error> {
 		// Replace protocolId
-		let replace = self.0.get_mut("protocolId").expect("expected `protocolId`");
+		let replace = self
+			.0
+			.get_mut("protocolId")
+			.ok_or_else(|| Error::Config("expected `protocolId`".into()))?;
 		*replace = json!(protocol_id);
+		Ok(())
 	}
 
 	/// Converts the chain specification to a string.
@@ -679,24 +691,51 @@ default_command = "pop-node"
 	#[test]
 	fn replace_relay_chain_works() -> Result<()> {
 		let mut chain_spec = ChainSpec(json!({"relay_chain": "old-relay"}));
-		chain_spec.replace_relay_chain("new-relay");
+		chain_spec.replace_relay_chain("new-relay")?;
 		assert_eq!(chain_spec.0, json!({"relay_chain": "new-relay"}));
+		Ok(())
+	}
+
+	#[test]
+	fn replace_relay_chain_fails() -> Result<()> {
+		let mut chain_spec = ChainSpec(json!({"": "old-relay"}));
+		assert!(
+			matches!(chain_spec.replace_relay_chain("new-relay"), Err(Error::Config(error)) if error == "expected `relay_chain`")
+		);
 		Ok(())
 	}
 
 	#[test]
 	fn replace_chain_type_works() -> Result<()> {
 		let mut chain_spec = ChainSpec(json!({"chainType": "old-chainType"}));
-		chain_spec.replace_chain_type("new-chainType");
+		chain_spec.replace_chain_type("new-chainType")?;
 		assert_eq!(chain_spec.0, json!({"chainType": "new-chainType"}));
+		Ok(())
+	}
+
+	#[test]
+	fn replace_chain_type_fails() -> Result<()> {
+		let mut chain_spec = ChainSpec(json!({"": "old-chainType"}));
+		assert!(
+			matches!(chain_spec.replace_chain_type("new-chainType"), Err(Error::Config(error)) if error == "expected `chainType`")
+		);
 		Ok(())
 	}
 
 	#[test]
 	fn replace_protocol_id_works() -> Result<()> {
 		let mut chain_spec = ChainSpec(json!({"protocolId": "old-protocolId"}));
-		chain_spec.replace_protocol_id("new-protocolId");
+		chain_spec.replace_protocol_id("new-protocolId")?;
 		assert_eq!(chain_spec.0, json!({"protocolId": "new-protocolId"}));
+		Ok(())
+	}
+
+	#[test]
+	fn replace_protocol_id_fails() -> Result<()> {
+		let mut chain_spec = ChainSpec(json!({"": "old-protocolId"}));
+		assert!(
+			matches!(chain_spec.replace_protocol_id("new-protocolId"), Err(Error::Config(error)) if error == "expected `protocolId`")
+		);
 		Ok(())
 	}
 


### PR DESCRIPTION
Handle errors for `replace_para_id`, `replace_relay_chain`, `replace_chain_type` and `replace_protocol_id` with test coverage for this new lines.
Followed the same format as we had when parsing other files: https://github.com/r0gue-io/pop-cli/blob/main/crates/pop-parachains/src/up/mod.rs#L125

Also, extended the code documentation of new logic.
