### PR TITLE
refactor: move extract_template_files into common crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file.
 
 - Handle IO error if rename fails (#241)
 - Readme commands (#243)
-- Remove unused folders after download contracts node binary (#240)
+- Remove unused directories after download contracts node binary (#240)
 - Check if contracts needs to be build before deploy (#246)
 
 ### 🚜 Refactor
@@ -163,7 +163,7 @@ All notable changes to this project will be documented in this file.
 - Structure for call command
 - Call a smart contract
 - Execute call flag
-- *(pop-cli)* Pallets folder for new ones
+- *(pop-cli)* Pallets directory for new ones
 - *(up-parachain)* Improve ux
 - Init git repo (#65)
 - *(up-parachain)* Enable optional verbose output (#79)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,29 +165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "aquamarine"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21cc1548309245035eb18aa7f0967da6bc65587005170c56e6ef2788a4cf3f4e"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "ark-bls12-377"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,12 +918,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytemuck"
-version = "1.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,15 +987,6 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
-name = "cfg-expr"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "cfg-if"
@@ -1197,26 +1159,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
 name = "const_env"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,9 +1260,9 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "sp-weights 30.0.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-weights",
  "subxt 0.35.3",
  "tokio",
  "tracing",
@@ -2157,22 +2099,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "finality-grandpa"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36530797b9bf31cd4ff126dcfee8170f86b00cfdcea3269d73133cc0415945c3"
-dependencies = [
- "either",
- "futures",
- "futures-timer",
- "log",
- "num-traits",
- "parity-scale-codec",
- "parking_lot",
- "scale-info",
-]
-
-[[package]]
 name = "finito"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,52 +2170,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-benchmarking"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130b79108bca3d8850e850c276f1012058593d6a2a8774132e72766245bbcacc"
-dependencies = [
- "frame-support",
- "frame-support-procedural",
- "frame-system",
- "linregress",
- "log",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "sp-api",
- "sp-application-crypto 36.0.0",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
- "sp-runtime-interface 27.0.0",
- "sp-std",
- "sp-storage 21.0.0",
- "static_assertions",
-]
-
-[[package]]
-name = "frame-executive"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ab937cea917f5875b0e08d55ed941f9c82c2b08628d6bf47b90c63c48ef607"
-dependencies = [
- "aquamarine",
- "frame-support",
- "frame-system",
- "frame-try-runtime",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
- "sp-std",
- "sp-tracing 17.0.0",
-]
-
-[[package]]
 name = "frame-metadata"
 version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,152 +2190,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
-]
-
-[[package]]
-name = "frame-support"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c177377726d7bb598dd942e38168c1eb6872d53810a6bf810f0a428f9a46be8"
-dependencies = [
- "aquamarine",
- "array-bytes",
- "bitflags 1.3.2",
- "docify",
- "environmental",
- "frame-metadata 16.0.0",
- "frame-support-procedural",
- "impl-trait-for-tuples",
- "k256",
- "log",
- "macro_magic",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "serde_json",
- "smallvec",
- "sp-api",
- "sp-arithmetic 26.0.0",
- "sp-core 33.0.1",
- "sp-crypto-hashing-proc-macro",
- "sp-debug-derive",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io 36.0.0",
- "sp-metadata-ir",
- "sp-runtime 37.0.0",
- "sp-staking",
- "sp-state-machine 0.41.0",
- "sp-std",
- "sp-tracing 17.0.0",
- "sp-weights 31.0.0",
- "static_assertions",
- "tt-call",
-]
-
-[[package]]
-name = "frame-support-procedural"
-version = "29.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f822826825d810d0e096e70493cbc1032ff3ccf1324d861040865635112b6aa"
-dependencies = [
- "Inflector",
- "cfg-expr",
- "derive-syn-parse",
- "expander",
- "frame-support-procedural-tools",
- "itertools 0.11.0",
- "macro_magic",
- "proc-macro-warning",
- "proc-macro2",
- "quote",
- "sp-crypto-hashing",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "frame-support-procedural-tools"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40b5cc8526c9aad01cdf46dcee6cbefd6f6c78e022607ff4cf76094919b6462"
-dependencies = [
- "frame-support-procedural-tools-derive",
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "frame-support-procedural-tools-derive"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed971c6435503a099bdac99fe4c5bea08981709e5b5a0a8535a1856f48561191"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "frame-system"
-version = "34.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85777d5cb78d8f244aa4e92a06d13c234f7980dd7095b1baeefc23a5945cad6c"
-dependencies = [
- "cfg-if",
- "docify",
- "frame-support",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
- "sp-std",
- "sp-version",
- "sp-weights 31.0.0",
-]
-
-[[package]]
-name = "frame-system-benchmarking"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2df1ebcb669ae29aec03f6f87b232f2446942fb79fad72434d8d0a0fd7df917"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
- "sp-std",
-]
-
-[[package]]
-name = "frame-system-rpc-runtime-api"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd92e3fe18b93d456efdabbd98070a1d720be5b6affe589379db9b7d9272eba5"
-dependencies = [
- "parity-scale-codec",
- "sp-api",
-]
-
-[[package]]
-name = "frame-try-runtime"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748a6c8286447388ff7a35d88fc2e0be3b26238c609c88b7774615c274452413"
-dependencies = [
- "frame-support",
- "parity-scale-codec",
- "sp-api",
- "sp-runtime 37.0.0",
- "sp-std",
 ]
 
 [[package]]
@@ -3175,25 +2909,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "indent_write"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3404,15 +3119,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -4061,15 +3767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linregress"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de04dcecc58d366391f9920245b85ffa684558a5ef6e7736e754347c3aea9c2"
-dependencies = [
- "nalgebra",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4116,70 +3813,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "macro_magic"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc33f9f0351468d26fbc53d9ce00a096c8522ecb42f19b50f34f2c422f76d21d"
-dependencies = [
- "macro_magic_core",
- "macro_magic_macros",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "macro_magic_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1687dc887e42f352865a393acae7cf79d98fab6351cde1f58e9e057da89bf150"
-dependencies = [
- "const-random",
- "derive-syn-parse",
- "macro_magic_core_macros",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "macro_magic_core_macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "macro_magic_macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
-dependencies = [
- "macro_magic_core",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
 dependencies = [
  "regex-automata 0.1.10",
-]
-
-[[package]]
-name = "matrixmultiply"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
-dependencies = [
- "autocfg",
- "rawpointer",
 ]
 
 [[package]]
@@ -4344,33 +3983,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nalgebra"
-version = "0.32.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros",
- "num-complex",
- "num-rational",
- "num-traits",
- "simba",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4452,15 +4064,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
  "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
  "num-traits",
 ]
 
@@ -4658,19 +4261,6 @@ dependencies = [
  "paste",
  "polkavm-derive 0.5.0",
  "scale-info",
-]
-
-[[package]]
-name = "pallet-pallet_template"
-version = "0.1.0"
-dependencies = [
- "parity-scale-codec",
- "polkadot-sdk-frame",
- "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
- "sp-std",
 ]
 
 [[package]]
@@ -4896,40 +4486,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "polkadot-sdk-frame"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec0dde5d78825364c0e574ef18578cb9ca909363f595344115d006379b13f73"
-dependencies = [
- "docify",
- "frame-benchmarking",
- "frame-executive",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "frame-try-runtime",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api",
- "sp-arithmetic 26.0.0",
- "sp-block-builder",
- "sp-consensus-aura",
- "sp-consensus-grandpa",
- "sp-core 33.0.1",
- "sp-inherents",
- "sp-io 36.0.0",
- "sp-offchain",
- "sp-runtime 37.0.0",
- "sp-session",
- "sp-std",
- "sp-storage 21.0.0",
- "sp-transaction-pool",
- "sp-version",
-]
-
-[[package]]
 name = "polkavm-common"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5078,8 +4634,8 @@ dependencies = [
  "predicates",
  "reqwest 0.12.5",
  "serde_json",
- "sp-core 31.0.0",
- "sp-weights 30.0.0",
+ "sp-core",
+ "sp-weights",
  "strum 0.26.2",
  "strum_macros 0.26.4",
  "tempfile",
@@ -5127,8 +4683,8 @@ dependencies = [
  "mockito",
  "pop-common",
  "reqwest 0.12.5",
- "sp-core 31.0.0",
- "sp-weights 30.0.0",
+ "sp-core",
+ "sp-weights",
  "strum 0.26.2",
  "strum_macros 0.26.4",
  "subxt 0.35.3",
@@ -5301,17 +4857,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-warning"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5408,12 +4953,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "reconnecting-jsonrpsee-ws-client"
@@ -5918,15 +5457,6 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "safe_arch"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3460605018fdc9612bce72735cba0d27efbcd9904780d44c7e3a9948f96148a"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "same-file"
@@ -6674,19 +6204,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simba"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
-
-[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6880,44 +6397,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-api"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84f09c4b928e814e07dede0ece91f1f6eae1bff946a0e5e4a76bed19a095f1"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api-proc-macro",
- "sp-core 33.0.1",
- "sp-externalities 0.28.0",
- "sp-metadata-ir",
- "sp-runtime 37.0.0",
- "sp-runtime-interface 27.0.0",
- "sp-state-machine 0.41.0",
- "sp-std",
- "sp-trie 35.0.0",
- "sp-version",
- "thiserror",
-]
-
-[[package]]
-name = "sp-api-proc-macro"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213a4bec1b18bd0750e7b81d11d8276c24f68b53cde83950b00b178ecc9ab24a"
-dependencies = [
- "Inflector",
- "blake2",
- "expander",
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "sp-application-crypto"
 version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6926,22 +6405,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-std",
-]
-
-[[package]]
-name = "sp-application-crypto"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296282f718f15d4d812664415942665302a484d3495cf8d2e2ab3192b32d2c73"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
+ "sp-core",
+ "sp-io",
  "sp-std",
 ]
 
@@ -6958,80 +6423,6 @@ dependencies = [
  "serde",
  "sp-std",
  "static_assertions",
-]
-
-[[package]]
-name = "sp-arithmetic"
-version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d0d0a4c591c421d3231ddd5e27d828618c24456d51445d21a1f79fcee97c23"
-dependencies = [
- "docify",
- "integer-sqrt",
- "num-traits",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-std",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-block-builder"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329e1cfb98f113d91d0db80a6e984cbb7e990f03ef599a8dc356723a47d40509"
-dependencies = [
- "sp-api",
- "sp-inherents",
- "sp-runtime 37.0.0",
-]
-
-[[package]]
-name = "sp-consensus-aura"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464c5ec1ffcf83739b8ff7c8ecffdb95766d6be0c30e324cd76b22180d3d6f11"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "scale-info",
- "sp-api",
- "sp-application-crypto 36.0.0",
- "sp-consensus-slots",
- "sp-inherents",
- "sp-runtime 37.0.0",
- "sp-timestamp",
-]
-
-[[package]]
-name = "sp-consensus-grandpa"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7deefa0a09cb191c0cb7a7aa8603414283f9aaa3a0fbc94fb68ff9a858f6fab2"
-dependencies = [
- "finality-grandpa",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api",
- "sp-application-crypto 36.0.0",
- "sp-core 33.0.1",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
-]
-
-[[package]]
-name = "sp-consensus-slots"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063ccdb38545602e45205e6b186e3d47508912c9b785321f907201564697f1c0"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-timestamp",
 ]
 
 [[package]]
@@ -7069,59 +6460,12 @@ dependencies = [
  "serde",
  "sp-crypto-hashing",
  "sp-debug-derive",
- "sp-externalities 0.27.0",
- "sp-runtime-interface 26.0.0",
+ "sp-externalities",
+ "sp-runtime-interface",
  "sp-std",
- "sp-storage 20.0.0",
+ "sp-storage",
  "ss58-registry",
- "substrate-bip39 0.5.0",
- "thiserror",
- "tracing",
- "w3f-bls",
- "zeroize",
-]
-
-[[package]]
-name = "sp-core"
-version = "33.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3368e32f6fda6e20b8af51f94308d033ab70a021e87f6abbd3fed5aca942b745"
-dependencies = [
- "array-bytes",
- "bitflags 1.3.2",
- "blake2",
- "bounded-collections",
- "bs58",
- "dyn-clonable",
- "ed25519-zebra 4.0.3",
- "futures",
- "hash-db",
- "hash256-std-hasher",
- "impl-serde",
- "itertools 0.11.0",
- "k256",
- "libsecp256k1",
- "log",
- "merlin",
- "parity-bip39",
- "parity-scale-codec",
- "parking_lot",
- "paste",
- "primitive-types",
- "rand",
- "scale-info",
- "schnorrkel",
- "secp256k1",
- "secrecy",
- "serde",
- "sp-crypto-hashing",
- "sp-debug-derive",
- "sp-externalities 0.28.0",
- "sp-runtime-interface 27.0.0",
- "sp-std",
- "sp-storage 21.0.0",
- "ss58-registry",
- "substrate-bip39 0.6.0",
+ "substrate-bip39",
  "thiserror",
  "tracing",
  "w3f-bls",
@@ -7140,17 +6484,6 @@ dependencies = [
  "sha2 0.10.8",
  "sha3",
  "twox-hash",
-]
-
-[[package]]
-name = "sp-crypto-hashing-proc-macro"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85d0f1f1e44bd8617eb2a48203ee854981229e3e79e6f468c7175d5fd37489b"
-dependencies = [
- "quote",
- "sp-crypto-hashing",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -7173,45 +6506,7 @@ dependencies = [
  "environmental",
  "parity-scale-codec",
  "sp-std",
- "sp-storage 20.0.0",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33abaec4be69b1613796bbf430decbbcaaf978756379e2016e683a4d6379cd02"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-storage 21.0.0",
-]
-
-[[package]]
-name = "sp-genesis-builder"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb26e3653f6a2feac2bcb2749b5fb080e4211b882cafbdba86e4304c03c72c8"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde_json",
- "sp-api",
- "sp-runtime 37.0.0",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6766db70e0c371d43bfbf7a8950d2cb10cff6b76c8a2c5bd1336e7566b46a0cf"
-dependencies = [
- "async-trait",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 37.0.0",
- "thiserror",
+ "sp-storage",
 ]
 
 [[package]]
@@ -7228,42 +6523,15 @@ dependencies = [
  "polkavm-derive 0.9.1",
  "rustversion",
  "secp256k1",
- "sp-core 31.0.0",
+ "sp-core",
  "sp-crypto-hashing",
- "sp-externalities 0.27.0",
- "sp-keystore 0.37.0",
- "sp-runtime-interface 26.0.0",
- "sp-state-machine 0.38.0",
+ "sp-externalities",
+ "sp-keystore",
+ "sp-runtime-interface",
+ "sp-state-machine",
  "sp-std",
- "sp-tracing 16.0.0",
- "sp-trie 32.0.0",
- "tracing",
- "tracing-core",
-]
-
-[[package]]
-name = "sp-io"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a31ce27358b73656a09b4933f09a700019d63afa15ede966f7c9893c1d4db5"
-dependencies = [
- "bytes",
- "ed25519-dalek",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "polkavm-derive 0.9.1",
- "rustversion",
- "secp256k1",
- "sp-core 33.0.1",
- "sp-crypto-hashing",
- "sp-externalities 0.28.0",
- "sp-keystore 0.39.0",
- "sp-runtime-interface 27.0.0",
- "sp-state-machine 0.41.0",
- "sp-std",
- "sp-tracing 17.0.0",
- "sp-trie 35.0.0",
+ "sp-tracing",
+ "sp-trie",
  "tracing",
  "tracing-core",
 ]
@@ -7276,42 +6544,8 @@ checksum = "bdbab8b61bd61d5f8625a0c75753b5d5a23be55d3445419acd42caf59cf6236b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
-]
-
-[[package]]
-name = "sp-keystore"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a909528663a80829b95d582a20dd4c9acd6e575650dee2bcaf56f4740b305e"
-dependencies = [
- "parity-scale-codec",
- "parking_lot",
- "sp-core 33.0.1",
- "sp-externalities 0.28.0",
-]
-
-[[package]]
-name = "sp-metadata-ir"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a616fa51350b35326682a472ee8e6ba742fdacb18babac38ecd46b3e05ead869"
-dependencies = [
- "frame-metadata 16.0.0",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
-name = "sp-offchain"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e7bdda614cb69c087d89d598ac4850e567be09f3de8d510b57147c111d5ce1"
-dependencies = [
- "sp-api",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-externalities",
 ]
 
 [[package]]
@@ -7342,38 +6576,12 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 33.0.0",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
  "sp-std",
- "sp-weights 30.0.0",
-]
-
-[[package]]
-name = "sp-runtime"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2a6148bf0ba74999ecfea9b4c1ade544f0663e0baba19630bb7761b2142b19"
-dependencies = [
- "docify",
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "num-traits",
- "parity-scale-codec",
- "paste",
- "rand",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 36.0.0",
- "sp-arithmetic 26.0.0",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-std",
- "sp-weights 31.0.0",
+ "sp-weights",
 ]
 
 [[package]]
@@ -7387,32 +6595,12 @@ dependencies = [
  "parity-scale-codec",
  "polkavm-derive 0.8.0",
  "primitive-types",
- "sp-externalities 0.27.0",
+ "sp-externalities",
  "sp-runtime-interface-proc-macro",
  "sp-std",
- "sp-storage 20.0.0",
- "sp-tracing 16.0.0",
- "sp-wasm-interface 20.0.0",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647db5e1dc481686628b41554e832df6ab400c4b43a6a54e54d3b0a71ca404aa"
-dependencies = [
- "bytes",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "polkavm-derive 0.9.1",
- "primitive-types",
- "sp-externalities 0.28.0",
- "sp-runtime-interface-proc-macro",
- "sp-std",
- "sp-storage 21.0.0",
- "sp-tracing 17.0.0",
- "sp-wasm-interface 21.0.0",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
 ]
 
@@ -7431,35 +6619,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-session"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601e0203c52ac7c1122ad316ae4e5cc355fdf1d69ef5b6c4aa30f7a17921fad9"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-api",
- "sp-core 33.0.1",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
- "sp-staking",
-]
-
-[[package]]
-name = "sp-staking"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817c02b55a84c0fac32fdd8b3f0b959888bad0726009ed62433f4046f4b4b752"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
-]
-
-[[package]]
 name = "sp-state-machine"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7471,35 +6630,14 @@ dependencies = [
  "parking_lot",
  "rand",
  "smallvec",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
+ "sp-core",
+ "sp-externalities",
  "sp-panic-handler",
  "sp-std",
- "sp-trie 32.0.0",
+ "sp-trie",
  "thiserror",
  "tracing",
- "trie-db 0.28.0",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6ac196ea92c4d0613c071e1a050765dbfa30107a990224a4aba02c7dbcd063"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "parking_lot",
- "rand",
- "smallvec",
- "sp-core 33.0.1",
- "sp-externalities 0.28.0",
- "sp-panic-handler",
- "sp-trie 35.0.0",
- "thiserror",
- "tracing",
- "trie-db 0.29.1",
+ "trie-db",
 ]
 
 [[package]]
@@ -7523,32 +6661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-storage"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c82989b3a4979a7e1ad848aad9f5d0b4388f1f454cc131766526601ab9e8f8"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive",
-]
-
-[[package]]
-name = "sp-timestamp"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d48d9246310340b11dc4f4c119fe93975c7c0c325637693da8c755d028fce19"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "sp-inherents",
- "sp-runtime 37.0.0",
- "thiserror",
-]
-
-[[package]]
 name = "sp-tracing"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7559,28 +6671,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b3decf116db9f1dfaf1f1597096b043d0e12c952d3bcdc018c6d6b77deec7e"
-dependencies = [
- "parity-scale-codec",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "sp-transaction-pool"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14de2a91e5a2bebaf47993644643c92564cafc55d55e1c854f6637ee62c90b4b"
-dependencies = [
- "sp-api",
- "sp-runtime 37.0.0",
 ]
 
 [[package]]
@@ -7599,67 +6689,13 @@ dependencies = [
  "rand",
  "scale-info",
  "schnellru",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
+ "sp-core",
+ "sp-externalities",
  "sp-std",
  "thiserror",
  "tracing",
- "trie-db 0.28.0",
+ "trie-db",
  "trie-root",
-]
-
-[[package]]
-name = "sp-trie"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61ab0c3e003f457203702e4753aa5fe9e762380543fada44650b1217e4aa5a5"
-dependencies = [
- "ahash 0.8.11",
- "hash-db",
- "lazy_static",
- "memory-db",
- "nohash-hasher",
- "parity-scale-codec",
- "parking_lot",
- "rand",
- "scale-info",
- "schnellru",
- "sp-core 33.0.1",
- "sp-externalities 0.28.0",
- "thiserror",
- "tracing",
- "trie-db 0.29.1",
- "trie-root",
-]
-
-[[package]]
-name = "sp-version"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff74bf12b4f7d29387eb1caeec5553209a505f90a2511d2831143b970f89659"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "parity-wasm",
- "scale-info",
- "serde",
- "sp-crypto-hashing-proc-macro",
- "sp-runtime 37.0.0",
- "sp-std",
- "sp-version-proc-macro",
- "thiserror",
-]
-
-[[package]]
-name = "sp-version-proc-macro"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aee8f6730641a65fcf0c8f9b1e448af4b3bb083d08058b47528188bccc7b7a7"
-dependencies = [
- "parity-scale-codec",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -7677,17 +6713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-wasm-interface"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b04b919e150b4736d85089d49327eab65507deb1485eec929af69daa2278eb3"
-dependencies = [
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
-]
-
-[[package]]
 name = "sp-weights"
 version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7698,24 +6723,9 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic 25.0.0",
+ "sp-arithmetic",
  "sp-debug-derive",
  "sp-std",
-]
-
-[[package]]
-name = "sp-weights"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93cdaf72a1dad537bbb130ba4d47307ebe5170405280ed1aa31fa712718a400e"
-dependencies = [
- "bounded-collections",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "smallvec",
- "sp-arithmetic 26.0.0",
- "sp-debug-derive",
 ]
 
 [[package]]
@@ -7819,19 +6829,6 @@ name = "substrate-bip39"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b564c293e6194e8b222e52436bcb99f60de72043c7f845cf6c4406db4df121"
-dependencies = [
- "hmac 0.12.1",
- "pbkdf2",
- "schnorrkel",
- "sha2 0.10.8",
- "zeroize",
-]
-
-[[package]]
-name = "substrate-bip39"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca58ffd742f693dc13d69bdbb2e642ae239e0053f6aab3b104252892f856700a"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -7982,9 +6979,9 @@ dependencies = [
  "scale-value 0.16.1",
  "serde",
  "serde_json",
- "sp-core 31.0.0",
+ "sp-core",
  "sp-crypto-hashing",
- "sp-runtime 34.0.0",
+ "sp-runtime",
  "subxt-metadata 0.37.0",
  "tracing",
 ]
@@ -8328,15 +7325,6 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -8697,18 +7685,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trie-db"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c992b4f40c234a074d48a757efeabb1a6be88af84c0c23f7ca158950cb0ae7f"
-dependencies = [
- "hash-db",
- "log",
- "rustc-hex",
- "smallvec",
-]
-
-[[package]]
 name = "trie-root"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8722,12 +7698,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tt-call"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f195fd851901624eee5a58c4bb2b4f06399148fcd0ed336e6f1cb60a9881df"
 
 [[package]]
 name = "tungstenite"
@@ -9305,16 +8275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wide"
-version = "0.7.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901e8597c777fa042e9e245bd56c0dc4418c5db3f845b6ff94fbac732c6a0692"
-dependencies = [
- "bytemuck",
- "safe_arch",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9735,7 +8695,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sp-core 31.0.0",
+ "sp-core",
  "subxt 0.37.0",
  "subxt-signer 0.37.0",
  "thiserror",

--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -12,8 +12,8 @@ pub struct BuildContractCommand {
 	/// Path for the contract project [default: current directory]
 	#[arg(long)]
 	pub(crate) path: Option<PathBuf>,
-	/// The default compilation includes debug functionality, increasing contract size and gas usage.
-	/// For production, always build in release mode to exclude debug features.
+	/// The default compilation includes debug functionality, increasing contract size and gas
+	/// usage. For production, always build in release mode to exclude debug features.
 	#[clap(short, long)]
 	pub(crate) release: bool,
 	// Deprecation flag, used to specify whether the deprecation warning is shown.

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -44,7 +44,8 @@ pub(crate) enum Command {
 	#[cfg(feature = "parachain")]
 	#[clap(alias = "p")]
 	Parachain(BuildParachainCommand),
-	/// [DEPRECATED] Build a contract, generate metadata, bundle together in a `<name>.contract` file
+	/// [DEPRECATED] Build a contract, generate metadata, bundle together in a `<name>.contract`
+	/// file
 	#[cfg(feature = "contract")]
 	#[clap(alias = "c")]
 	Contract(BuildContractCommand),

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -83,7 +83,7 @@ mod tests {
 	use duct::cmd;
 	use std::{fs, io::Write, path::Path};
 
-	// Function that generates a Cargo.toml inside node folder for testing.
+	// Function that generates a Cargo.toml inside node directory for testing.
 	fn generate_mock_node(temp_dir: &Path) -> anyhow::Result<()> {
 		// Create a node directory
 		let target_dir = temp_dir.join("node");

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::{cli, cli::traits::Cli as _, cli::Cli, style::style};
+use crate::{
+	cli,
+	cli::{traits::Cli as _, Cli},
+	style::style,
+};
 use clap::{Args, ValueEnum};
 use cliclack::{confirm, input};
 use pop_common::Profile;
@@ -221,7 +225,7 @@ impl BuildSpecCommand {
 		// Locate binary, if it doesn't exist trigger build.
 		let mode: Profile = self.release.into();
 		let cwd = current_dir().unwrap_or(PathBuf::from("./"));
-		let binary_path = match binary_path(&mode.target_folder(&cwd), &cwd.join("node")) {
+		let binary_path = match binary_path(&mode.target_directory(&cwd), &cwd.join("node")) {
 			Ok(binary_path) => binary_path,
 			_ => {
 				cli.info("Node was not found. The project will be built locally.".to_string())?;

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 
 #[derive(Args)]
 pub struct CallContractCommand {
-	/// Path to the contract build folder.
+	/// Path to the contract build directory.
 	#[arg(short = 'p', long)]
 	path: Option<PathBuf>,
 	/// The address of the contract to call.

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -73,12 +73,14 @@ impl Command {
 				},
 				#[cfg(feature = "parachain")]
 				new::Command::Pallet(cmd) => {
-					// When more contract selections are added the tel data will likely need to go deeper in the stack
+					// When more contract selections are added the tel data will likely need to go
+					// deeper in the stack
 					cmd.execute().await.map(|_| json!("template"))
 				},
 				#[cfg(feature = "contract")]
 				new::Command::Contract(cmd) => {
-					// When more contract selections are added, the tel data will likely need to go deeper in the stack
+					// When more contract selections are added, the tel data will likely need to go
+					// deeper in the stack
 					cmd.execute().await.map(|_| json!("default"))
 				},
 			},

--- a/crates/pop-cli/src/commands/new/contract.rs
+++ b/crates/pop-cli/src/commands/new/contract.rs
@@ -72,7 +72,7 @@ impl NewContractCommand {
 		let contract_type = &contract_config.contract_type.clone().unwrap_or_default();
 		let template = match &contract_config.template {
 			Some(template) => template.clone(),
-			None => contract_type.default_template().expect("contract types have defaults; qed."), // Default contract type
+			None => contract_type.default_template().expect("contract types have defaults; qed."), /* Default contract type */
 		};
 
 		is_template_supported(contract_type, &template)?;

--- a/crates/pop-cli/src/commands/new/parachain.rs
+++ b/crates/pop-cli/src/commands/new/parachain.rs
@@ -313,7 +313,6 @@ async fn choose_release(template: &Parachain) -> Result<Option<String>> {
 async fn get_latest_3_releases(repo: &GitHub) -> Result<Vec<Release>> {
 	let mut latest_3_releases: Vec<Release> =
 		repo.releases().await?.into_iter().filter(|r| !r.prerelease).take(3).collect();
-	repo.get_repo_license().await?;
 	// Get the commit sha for the releases
 	for release in latest_3_releases.iter_mut() {
 		let commit = repo.get_commit_sha_from_release(&release.tag_name).await?;

--- a/crates/pop-cli/src/commands/new/parachain.rs
+++ b/crates/pop-cli/src/commands/new/parachain.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::cli::{traits::Cli as _, Cli};
-use crate::style::style;
+use crate::{
+	cli::{traits::Cli as _, Cli},
+	style::style,
+};
 use anyhow::Result;
 use clap::{
 	builder::{PossibleValue, PossibleValuesParser, TypedValueParser},
@@ -78,7 +80,7 @@ impl NewParachainCommand {
 		let provider = &parachain_config.provider.clone().unwrap_or_default();
 		let template = match &parachain_config.template {
 			Some(template) => template.clone(),
-			None => provider.default_template().expect("parachain templates have defaults; qed."), // Each provider has a template by default
+			None => provider.default_template().expect("parachain templates have defaults; qed."), /* Each provider has a template by default */
 		};
 
 		is_template_supported(provider, &template)?;

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -16,10 +16,9 @@ use pop_contracts::{
 };
 use sp_core::Bytes;
 use sp_weights::Weight;
-use std::process::Child;
 use std::{
 	path::{Path, PathBuf},
-	process::Command,
+	process::{Child, Command},
 };
 use tempfile::NamedTempFile;
 use url::Url;
@@ -30,7 +29,7 @@ const FAILED: &str = "🚫 Deployment failed.";
 
 #[derive(Args, Clone)]
 pub struct UpContractCommand {
-	/// Path to the contract build folder.
+	/// Path to the contract build directory.
 	#[arg(short = 'p', long)]
 	path: Option<PathBuf>,
 	/// The name of the contract constructor to call.
@@ -71,7 +70,8 @@ pub struct UpContractCommand {
 	/// Uploads the contract only, without instantiation.
 	#[clap(short('u'), long)]
 	upload_only: bool,
-	/// Automatically source or update the needed binary required without prompting for confirmation.
+	/// Automatically source or update the needed binary required without prompting for
+	/// confirmation.
 	#[clap(short('y'), long)]
 	skip_confirm: bool,
 }
@@ -81,7 +81,7 @@ impl UpContractCommand {
 	pub(crate) async fn execute(mut self) -> anyhow::Result<()> {
 		Cli.intro("Deploy a smart contract")?;
 
-		// Check if build exists in the specified "Contract build folder"
+		// Check if build exists in the specified "Contract build directory"
 		if !has_contract_been_built(self.path.as_deref()) {
 			// Build the contract in release mode
 			Cli.warning("NOTE: contract has not yet been built.")?;
@@ -313,10 +313,12 @@ impl From<UpContractCommand> for UpOpts {
 	}
 }
 
-/// Checks if a contract has been built by verifying the existence of the build directory and the <name>.contract file.
+/// Checks if a contract has been built by verifying the existence of the build directory and the
+/// <name>.contract file.
 ///
 /// # Arguments
-/// * `path` - An optional path to the project directory. If no path is provided, the current directory is used.
+/// * `path` - An optional path to the project directory. If no path is provided, the current
+///   directory is used.
 pub fn has_contract_been_built(path: Option<&Path>) -> bool {
 	let project_path = path.unwrap_or_else(|| Path::new("./"));
 	let manifest = match from_path(Some(project_path)) {

--- a/crates/pop-cli/src/commands/up/parachain.rs
+++ b/crates/pop-cli/src/commands/up/parachain.rs
@@ -18,21 +18,21 @@ pub(crate) struct ZombienetCommand {
 	/// The Zombienet network configuration file to be used.
 	#[arg(short, long)]
 	file: String,
-	/// The version of the binary to be used for the relay chain, as per the release tag (e.g. "v1.13.0").
-	/// See https://github.com/paritytech/polkadot-sdk/releases for more details.
+	/// The version of the binary to be used for the relay chain, as per the release tag (e.g.
+	/// "v1.13.0"). See https://github.com/paritytech/polkadot-sdk/releases for more details.
 	#[arg(short, long)]
 	relay_chain: Option<String>,
-	/// The version of the runtime to be used for the relay chain, as per the release tag (e.g. "v1.2.7").
-	/// See https://github.com/polkadot-fellows/runtimes/releases for more details.
+	/// The version of the runtime to be used for the relay chain, as per the release tag (e.g.
+	/// "v1.2.7"). See https://github.com/polkadot-fellows/runtimes/releases for more details.
 	#[arg(short = 'R', long)]
 	relay_chain_runtime: Option<String>,
-	/// The version of the binary to be used for system parachains, as per the release tag (e.g. "v1.13.0").
-	/// Defaults to the relay chain version if not specified.
+	/// The version of the binary to be used for system parachains, as per the release tag (e.g.
+	/// "v1.13.0"). Defaults to the relay chain version if not specified.
 	/// See https://github.com/paritytech/polkadot-sdk/releases for more details.
 	#[arg(short, long)]
 	system_parachain: Option<String>,
-	/// The version of the runtime to be used for system parachains, as per the release tag (e.g. "v1.2.7").
-	/// See https://github.com/polkadot-fellows/runtimes/releases for more details.
+	/// The version of the runtime to be used for system parachains, as per the release tag (e.g.
+	/// "v1.2.7"). See https://github.com/polkadot-fellows/runtimes/releases for more details.
 	#[arg(short = 'S', long)]
 	system_parachain_runtime: Option<String>,
 	/// The url of the git repository of a parachain to be used, with branch/release tag/commit specified as #fragment (e.g. 'https://github.com/org/repository#ref').

--- a/crates/pop-cli/src/common/contracts.rs
+++ b/crates/pop-cli/src/common/contracts.rs
@@ -4,7 +4,8 @@ use cliclack::{confirm, log::warning, spinner};
 use pop_contracts::contracts_node_generator;
 use std::path::PathBuf;
 
-///  Checks the status of the `substrate-contracts-node` binary, sources it if necessary, and prompts the user to update it if the existing binary is not the latest version.
+///  Checks the status of the `substrate-contracts-node` binary, sources it if necessary, and
+/// prompts the user to update it if the existing binary is not the latest version.
 ///
 /// # Arguments
 /// * `skip_confirm`: A boolean indicating whether to skip confirmation prompts.

--- a/crates/pop-cli/src/main.rs
+++ b/crates/pop-cli/src/main.rs
@@ -30,7 +30,8 @@ async fn main() -> Result<()> {
 
 	#[cfg(feature = "telemetry")]
 	if let Some(tel) = maybe_tel.clone() {
-		// `args` is guaranteed to have at least 3 elements as clap will display help message if not set.
+		// `args` is guaranteed to have at least 3 elements as clap will display help message if not
+		// set.
 		let (command, subcommand) = parse_args(args().collect());
 
 		if let Ok(sub_data) = &res {

--- a/crates/pop-cli/tests/contract.rs
+++ b/crates/pop-cli/tests/contract.rs
@@ -35,7 +35,7 @@ async fn contract_lifecycle() -> Result<()> {
 		.args(&["build", "--path", "./test_contract", "--release"])
 		.assert()
 		.success();
-	// Verify that the folder target has been created
+	// Verify that the directory target has been created
 	assert!(temp_dir.join("test_contract/target").exists());
 	// Verify that all the artifacts has been generated
 	assert!(temp_dir.join("test_contract/target/ink/test_contract.contract").exists());
@@ -71,7 +71,8 @@ async fn contract_lifecycle() -> Result<()> {
 		])
 		.assert()
 		.success();
-	// Using methods from the pop_contracts crate to instantiate it to get the Contract Address for the call
+	// Using methods from the pop_contracts crate to instantiate it to get the Contract Address for
+	// the call
 	let instantiate_exec = set_up_deployment(UpOpts {
 		path: Some(temp_dir.join("test_contract")),
 		constructor: "new".to_string(),

--- a/crates/pop-cli/tests/parachain.rs
+++ b/crates/pop-cli/tests/parachain.rs
@@ -46,7 +46,8 @@ async fn parachain_lifecycle() -> Result<()> {
 	assert!(temp_dir.join("test_parachain/target").exists());
 
 	let temp_parachain_dir = temp_dir.join("test_parachain");
-	// pop build spec --output ./target/pop/test-spec.json --id 2222 --type development --relay paseo-local --protocol-id pop-protocol"
+	// pop build spec --output ./target/pop/test-spec.json --id 2222 --type development --relay
+	// paseo-local --protocol-id pop-protocol"
 	Command::cargo_bin("pop")
 		.unwrap()
 		.current_dir(&temp_parachain_dir)

--- a/crates/pop-common/src/build.rs
+++ b/crates/pop-common/src/build.rs
@@ -13,8 +13,8 @@ pub enum Profile {
 }
 
 impl Profile {
-	/// Returns the corresponding path to the target folder.
-	pub fn target_folder(&self, path: &Path) -> PathBuf {
+	/// Returns the corresponding path to the target directory.
+	pub fn target_directory(&self, path: &Path) -> PathBuf {
 		match self {
 			Profile::Release => path.join("target/release"),
 			Profile::Debug => path.join("target/debug"),

--- a/crates/pop-common/src/helpers.rs
+++ b/crates/pop-common/src/helpers.rs
@@ -13,9 +13,8 @@ use std::{
 /// # Arguments
 ///
 /// * `file_path` - A `PathBuf` specifying the path to the file to be modified.
-/// * `replacements` - A `HashMap` where each key-value pair represents
-///   a target string and its corresponding replacement string.
-///
+/// * `replacements` - A `HashMap` where each key-value pair represents a target string and its
+///   corresponding replacement string.
 pub fn replace_in_file(file_path: PathBuf, replacements: HashMap<&str, &str>) -> Result<(), Error> {
 	// Read the file content
 	let mut file_content = String::new();
@@ -31,7 +30,8 @@ pub fn replace_in_file(file_path: PathBuf, replacements: HashMap<&str, &str>) ->
 	Ok(())
 }
 
-/// Gets the last component (name of a project) of a path or returns a default value if the path has no valid last component.
+/// Gets the last component (name of a project) of a path or returns a default value if the path has
+/// no valid last component.
 ///
 /// # Arguments
 /// * `path` - Location path of the project.

--- a/crates/pop-common/src/lib.rs
+++ b/crates/pop-common/src/lib.rs
@@ -10,6 +10,7 @@ pub use build::Profile;
 pub use errors::Error;
 pub use git::{Git, GitHub, Release};
 pub use helpers::{get_project_name_from_path, replace_in_file};
+pub use templates::extractor::extract_template_files;
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 

--- a/crates/pop-common/src/manifest.rs
+++ b/crates/pop-common/src/manifest.rs
@@ -12,7 +12,8 @@ use toml_edit::{value, DocumentMut, Item, Value};
 /// Parses the contents of a `Cargo.toml` manifest.
 ///
 /// # Arguments
-/// * `path` - The optional path to the manifest, defaulting to the current directory if not specified.
+/// * `path` - The optional path to the manifest, defaulting to the current directory if not
+///   specified.
 pub fn from_path(path: Option<&Path>) -> Result<Manifest, Error> {
 	// Resolve manifest path
 	let path = match path {
@@ -28,7 +29,8 @@ pub fn from_path(path: Option<&Path>) -> Result<Manifest, Error> {
 	Ok(Manifest::from_path(path.canonicalize()?)?)
 }
 
-/// This function is used to determine if a Path is contained inside a workspace, and returns a PathBuf to the workspace Cargo.toml if found
+/// This function is used to determine if a Path is contained inside a workspace, and returns a
+/// PathBuf to the workspace Cargo.toml if found
 ///
 /// # Arguments
 /// * `target_dir` - A directory that may be contained inside a workspace

--- a/crates/pop-common/src/sourcing/binary.rs
+++ b/crates/pop-common/src/sourcing/binary.rs
@@ -2,8 +2,10 @@
 
 use crate::{
 	sourcing::{
-		from_local_package, Error, GitHub::ReleaseArchive, GitHub::SourceCodeArchive, Source,
-		Source::Archive, Source::Git, Source::GitHub,
+		from_local_package, Error,
+		GitHub::{ReleaseArchive, SourceCodeArchive},
+		Source,
+		Source::{Archive, Git, GitHub},
 	},
 	Status,
 };
@@ -85,13 +87,14 @@ impl Binary {
 		}
 	}
 
-	/// Attempts to resolve a version of a binary based on whether one is specified, an existing version
-	/// can be found cached locally, or uses the latest version.
+	/// Attempts to resolve a version of a binary based on whether one is specified, an existing
+	/// version can be found cached locally, or uses the latest version.
 	///
 	/// # Arguments
 	/// * `name` - The name of the binary.
 	/// * `specified` - If available, a version explicitly specified.
-	/// * `available` - The available versions, used to check for those cached locally or the latest otherwise.
+	/// * `available` - The available versions, used to check for those cached locally or the latest
+	///   otherwise.
 	/// * `cache` - The location used for caching binaries.
 	pub fn resolve_version(
 		name: &str,
@@ -120,7 +123,8 @@ impl Binary {
 	/// Sources the binary.
 	///
 	/// # Arguments
-	/// * `release` - Whether any binaries needing to be built should be done so using the release profile.
+	/// * `release` - Whether any binaries needing to be built should be done so using the release
+	///   profile.
 	/// * `status` - Used to observe status updates.
 	/// * `verbose` - Whether verbose output is required.
 	pub async fn source(

--- a/crates/pop-common/src/sourcing/mod.rs
+++ b/crates/pop-common/src/sourcing/mod.rs
@@ -7,12 +7,12 @@ use crate::{Git, Status, APP_USER_AGENT};
 use duct::cmd;
 use flate2::read::GzDecoder;
 use reqwest::StatusCode;
-use std::time::Duration;
 use std::{
 	fs::{copy, metadata, read_dir, rename, File},
 	io::{BufRead, Seek, SeekFrom, Write},
 	os::unix::fs::PermissionsExt,
 	path::{Path, PathBuf},
+	time::Duration,
 };
 use tar::Archive;
 use tempfile::{tempdir, tempfile};
@@ -77,7 +77,8 @@ impl Source {
 	/// # Arguments
 	///
 	/// * `cache` - the cache to be used.
-	/// * `release` - whether any binaries needing to be built should be done so using the release profile.
+	/// * `release` - whether any binaries needing to be built should be done so using the release
+	///   profile.
 	/// * `status` - used to observe status updates.
 	/// * `verbose` - whether verbose output is required.
 	pub(super) async fn source(
@@ -164,7 +165,8 @@ impl GitHub {
 	/// # Arguments
 	///
 	/// * `cache` - the cache to be used.
-	/// * `release` - whether any binaries needing to be built should be done so using the release profile.
+	/// * `release` - whether any binaries needing to be built should be done so using the release
+	///   profile.
 	/// * `status` - used to observe status updates.
 	/// * `verbose` - whether verbose output is required.
 	async fn source(
@@ -383,7 +385,8 @@ async fn from_github_archive(
 			))
 		},
 		1 => working_dir = entries[0].path(), // Automatically switch to top level directory
-		_ => {}, // Assume that downloaded archive does not have a top level directory
+		_ => {},                              /* Assume that downloaded archive does not have a
+		                                        * top level directory */
 	}
 	// Build binaries
 	status.update("Starting build of binary...");

--- a/crates/pop-common/src/templates/extractor.rs
+++ b/crates/pop-common/src/templates/extractor.rs
@@ -3,23 +3,27 @@
 use anyhow::Result;
 use std::{fs, io, path::Path};
 
-/// Extracts the specified template files from the repository folder to the target folder.
+/// Extracts the specified template files from the repository directory to the target directory.
 ///
 /// # Arguments
 /// * `template_name` - The name of the template to extract.
-/// * `repo_folder` - The path to the repository folder containing the template.
-/// * `target_folder` - The destination path where the template files should be copied.
-/// * `ignore_folders` - A vector of folder names to ignore during the extraction. If empty, no folders are ignored.
-///
+/// * `repo_directory` - The path to the repository directory containing the template.
+/// * `target_directory` - The destination path where the template files should be copied.
+/// * `ignore_directories` - A vector of directory names to ignore during the extraction. If empty,
+///   no directories are ignored.
 pub fn extract_template_files(
 	template_name: String,
-	repo_folder: &Path,
-	target_folder: &Path,
-	ignore_folders: Option<Vec<String>>,
+	repo_directory: &Path,
+	target_directory: &Path,
+	ignore_directories: Option<Vec<String>>,
 ) -> Result<()> {
-	let template_folder = repo_folder.join(template_name);
-	// Recursively copy all folders and files within. Ignores the specified ones.
-	copy_dir_all(&template_folder, target_folder, &ignore_folders.unwrap_or_else(|| vec![]))?;
+	let template_directory = repo_directory.join(template_name);
+	// Recursively copy all directories and files within. Ignores the specified ones.
+	copy_dir_all(
+		&template_directory,
+		target_directory,
+		&ignore_directories.unwrap_or_else(|| vec![]),
+	)?;
 	Ok(())
 }
 
@@ -28,22 +32,22 @@ pub fn extract_template_files(
 /// # Arguments
 /// * `src`: - The source path of the directory to be copied.
 /// * `dst`: - The destination path where the directory and its contents will be copied.
-/// * `ignore_folders` - Folders to ignore during the copy process.
-///
+/// * `ignore_directories` - directories to ignore during the copy process.
 fn copy_dir_all(
 	src: impl AsRef<Path>,
 	dst: impl AsRef<Path>,
-	ignore_folders: &Vec<String>,
+	ignore_directories: &Vec<String>,
 ) -> io::Result<()> {
 	fs::create_dir_all(&dst)?;
 	for entry in fs::read_dir(src)? {
 		let entry = entry?;
 		let ty = entry.file_type()?;
-		if ty.is_dir() && ignore_folders.contains(&entry.file_name().to_string_lossy().to_string())
+		if ty.is_dir()
+			&& ignore_directories.contains(&entry.file_name().to_string_lossy().to_string())
 		{
 			continue;
 		} else if ty.is_dir() {
-			copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()), ignore_folders)?;
+			copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()), ignore_directories)?;
 		} else {
 			fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
 		}
@@ -59,12 +63,12 @@ mod tests {
 
 	fn generate_testing_contract(template: &str) -> Result<tempfile::TempDir, Error> {
 		let temp_dir = tempfile::tempdir()?;
-		let template_folder = temp_dir.path().join(template.to_string());
-		fs::create_dir(&template_folder)?;
-		fs::File::create(&template_folder.join("lib.rs"))?;
-		fs::File::create(&template_folder.join("Cargo.toml"))?;
-		fs::create_dir(&temp_dir.path().join("noise_folder"))?;
-		fs::create_dir(&template_folder.join("frontend"))?;
+		let template_directory = temp_dir.path().join(template.to_string());
+		fs::create_dir(&template_directory)?;
+		fs::File::create(&template_directory.join("lib.rs"))?;
+		fs::File::create(&template_directory.join("Cargo.toml"))?;
+		fs::create_dir(&temp_dir.path().join("noise_directory"))?;
+		fs::create_dir(&template_directory.join("frontend"))?;
 		Ok(temp_dir)
 	}
 	#[test]
@@ -76,8 +80,8 @@ mod tests {
 		assert!(output_dir.path().join("lib.rs").exists());
 		assert!(output_dir.path().join("Cargo.toml").exists());
 		assert!(output_dir.path().join("frontend").exists());
-		assert!(!output_dir.path().join("noise_folder").exists());
-		// ignore the frontend folder
+		assert!(!output_dir.path().join("noise_directory").exists());
+		// ignore the frontend directory
 		temp_dir = generate_testing_contract("erc721")?;
 		output_dir = tempfile::tempdir()?;
 		extract_template_files(
@@ -89,7 +93,7 @@ mod tests {
 		assert!(output_dir.path().join("lib.rs").exists());
 		assert!(output_dir.path().join("Cargo.toml").exists());
 		assert!(!output_dir.path().join("frontend").exists());
-		assert!(!output_dir.path().join("noise_folder").exists());
+		assert!(!output_dir.path().join("noise_directory").exists());
 
 		Ok(())
 	}

--- a/crates/pop-common/src/templates/extractor.rs
+++ b/crates/pop-common/src/templates/extractor.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0
+
+use anyhow::Result;
+use std::{fs, io, path::Path};
+
+/// Extracts the specified template files from the repository folder to the target folder.
+///
+/// # Arguments
+/// * `template_name` - The name of the template to extract.
+/// * `repo_folder` - The path to the repository folder containing the template.
+/// * `target_folder` - The destination path where the template files should be copied.
+/// * `ignore_folders` - A vector of folder names to ignore during the extraction. If empty, no folders are ignored.
+///
+pub fn extract_template_files(
+	template_name: String,
+	repo_folder: &Path,
+	target_folder: &Path,
+	ignore_folders: Option<Vec<String>>,
+) -> Result<()> {
+	let template_folder = repo_folder.join(template_name);
+	// Recursively copy all folders and files within. Ignores the specified ones.
+	copy_dir_all(&template_folder, target_folder, &ignore_folders.unwrap_or_else(|| vec![]))?;
+	Ok(())
+}
+
+/// Recursively copy a directory and its files.
+///
+/// # Arguments
+/// * `src`: - The source path of the directory to be copied.
+/// * `dst`: - The destination path where the directory and its contents will be copied.
+/// * `ignore_folders` - Folders to ignore during the copy process.
+///
+fn copy_dir_all(
+	src: impl AsRef<Path>,
+	dst: impl AsRef<Path>,
+	ignore_folders: &Vec<String>,
+) -> io::Result<()> {
+	fs::create_dir_all(&dst)?;
+	for entry in fs::read_dir(src)? {
+		let entry = entry?;
+		let ty = entry.file_type()?;
+		if ty.is_dir() && ignore_folders.contains(&entry.file_name().to_string_lossy().to_string())
+		{
+			continue;
+		} else if ty.is_dir() {
+			copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()), ignore_folders)?;
+		} else {
+			fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+		}
+	}
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::{Error, Result};
+	use std::fs;
+
+	fn generate_testing_contract(template: &str) -> Result<tempfile::TempDir, Error> {
+		let temp_dir = tempfile::tempdir()?;
+		let template_folder = temp_dir.path().join(template.to_string());
+		fs::create_dir(&template_folder)?;
+		fs::File::create(&template_folder.join("lib.rs"))?;
+		fs::File::create(&template_folder.join("Cargo.toml"))?;
+		fs::create_dir(&temp_dir.path().join("noise_folder"))?;
+		fs::create_dir(&template_folder.join("frontend"))?;
+		Ok(temp_dir)
+	}
+	#[test]
+	fn extract_template_files_works() -> Result<(), Error> {
+		// Contract
+		let mut temp_dir = generate_testing_contract("erc20")?;
+		let mut output_dir = tempfile::tempdir()?;
+		extract_template_files("erc20".to_string(), temp_dir.path(), output_dir.path(), None)?;
+		assert!(output_dir.path().join("lib.rs").exists());
+		assert!(output_dir.path().join("Cargo.toml").exists());
+		assert!(output_dir.path().join("frontend").exists());
+		assert!(!output_dir.path().join("noise_folder").exists());
+		// ignore the frontend folder
+		temp_dir = generate_testing_contract("erc721")?;
+		output_dir = tempfile::tempdir()?;
+		extract_template_files(
+			"erc721".to_string(),
+			temp_dir.path(),
+			output_dir.path(),
+			Some(vec!["frontend".to_string()]),
+		)?;
+		assert!(output_dir.path().join("lib.rs").exists());
+		assert!(output_dir.path().join("Cargo.toml").exists());
+		assert!(!output_dir.path().join("frontend").exists());
+		assert!(!output_dir.path().join("noise_folder").exists());
+
+		Ok(())
+	}
+}

--- a/crates/pop-common/src/templates/mod.rs
+++ b/crates/pop-common/src/templates/mod.rs
@@ -3,6 +3,8 @@
 use strum::{EnumMessage, EnumProperty, VariantArray};
 pub use thiserror::Error;
 
+pub mod extractor;
+
 #[derive(Error, Debug)]
 pub enum Error {
 	#[error("The `Repository` property is missing from the template variant")]

--- a/crates/pop-contracts/src/build.rs
+++ b/crates/pop-contracts/src/build.rs
@@ -8,7 +8,8 @@ use std::path::Path;
 /// Build the smart contract located at the specified `path` in `build_release` mode.
 ///
 /// # Arguments
-/// * `path` - The optional path to the smart contract manifest, defaulting to the current directory if not specified.
+/// * `path` - The optional path to the smart contract manifest, defaulting to the current directory
+///   if not specified.
 /// * `release` - Whether the smart contract should be built without any debugging functionality.
 /// * `verbosity` - The build output verbosity.
 pub fn build_smart_contract(
@@ -33,7 +34,8 @@ pub fn build_smart_contract(
 /// Determines whether the manifest at the supplied path is a supported smart contract project.
 ///
 /// # Arguments
-/// * `path` - The optional path to the manifest, defaulting to the current directory if not specified.
+/// * `path` - The optional path to the manifest, defaulting to the current directory if not
+///   specified.
 pub fn is_supported(path: Option<&Path>) -> Result<bool, Error> {
 	Ok(pop_common::manifest::from_path(path)?.dependencies.contains_key("ink"))
 }

--- a/crates/pop-contracts/src/call.rs
+++ b/crates/pop-contracts/src/call.rs
@@ -22,7 +22,7 @@ use url::Url;
 
 /// Attributes for the `call` command.
 pub struct CallOpts {
-	/// Path to the contract build folder.
+	/// Path to the contract build directory.
 	pub path: Option<PathBuf>,
 	/// The address of the contract to call.
 	pub contract: String,
@@ -49,7 +49,6 @@ pub struct CallOpts {
 /// # Arguments
 ///
 /// * `call_opts` - options for the `call` command.
-///
 pub async fn set_up_call(
 	call_opts: CallOpts,
 ) -> anyhow::Result<CallExec<DefaultConfig, DefaultEnvironment, Keypair>> {
@@ -83,7 +82,6 @@ pub async fn set_up_call(
 /// # Arguments
 ///
 /// * `call_exec` - struct with the call to be executed.
-///
 pub async fn dry_run_call(
 	call_exec: &CallExec<DefaultConfig, DefaultEnvironment, Keypair>,
 ) -> Result<String, Error> {
@@ -109,7 +107,6 @@ pub async fn dry_run_call(
 /// # Arguments
 ///
 /// * `call_exec` - the preprocessed data to call a contract.
-///
 pub async fn dry_run_gas_estimate_call(
 	call_exec: &CallExec<DefaultConfig, DefaultEnvironment, Keypair>,
 ) -> Result<Weight, Error> {
@@ -138,7 +135,6 @@ pub async fn dry_run_gas_estimate_call(
 /// * `call_exec` - struct with the call to be executed.
 /// * `gas_limit` - maximum amount of gas to be used for this call.
 /// * `url` - endpoint of the node which to send the call to.
-///
 pub async fn call_smart_contract(
 	call_exec: CallExec<DefaultConfig, DefaultEnvironment, Keypair>,
 	gas_limit: Weight,
@@ -237,7 +233,7 @@ mod tests {
 		Ok(())
 	}
 	#[tokio::test]
-	async fn test_set_up_call_fails_no_smart_contract_folder() -> Result<()> {
+	async fn test_set_up_call_fails_no_smart_contract_directory() -> Result<()> {
 		let call_opts = CallOpts {
 			path: None,
 			contract: "5CLPm1CeUvJhZ8GCDZCR7nWZ2m3XXe4X5MtAQK69zEjut36A".to_string(),

--- a/crates/pop-contracts/src/new.rs
+++ b/crates/pop-contracts/src/new.rs
@@ -5,8 +5,10 @@ use anyhow::Result;
 use contract_build::new_contract_project;
 use heck::ToUpperCamelCase;
 use pop_common::{extract_template_files, replace_in_file, templates::Template, Git};
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::{
+	collections::HashMap,
+	path::{Path, PathBuf},
+};
 use url::Url;
 
 /// Create a new smart contract.
@@ -161,7 +163,7 @@ mod tests {
 		Ok(())
 	}
 
-	fn generate_contract_folder() -> Result<tempfile::TempDir, Error> {
+	fn generate_contract_directory() -> Result<tempfile::TempDir, Error> {
 		let temp_dir = tempfile::tempdir()?;
 		let config = temp_dir.path().join("Cargo.toml");
 		let mut config_file = fs::File::create(config.clone())?;
@@ -189,7 +191,7 @@ mod tests {
 	}
 	#[test]
 	fn test_rename_contract() -> Result<(), Error> {
-		let temp_dir = generate_contract_folder()?;
+		let temp_dir = generate_contract_directory()?;
 		rename_contract("my_contract", temp_dir.path().to_owned(), &Contract::ERC20)?;
 		let generated_cargo =
 			fs::read_to_string(temp_dir.path().join("Cargo.toml")).expect("Could not read file");

--- a/crates/pop-contracts/src/new.rs
+++ b/crates/pop-contracts/src/new.rs
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::{
-	errors::Error,
-	utils::helpers::{canonicalized_path, copy_dir_all},
-	Contract,
-};
+use crate::{errors::Error, utils::helpers::canonicalized_path, Contract};
 use anyhow::Result;
 use contract_build::new_contract_project;
 use heck::ToUpperCamelCase;
-use pop_common::{replace_in_file, templates::Template, Git};
+use pop_common::{extract_template_files, replace_in_file, templates::Template, Git};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use url::Url;
@@ -67,28 +63,23 @@ fn create_template_contract(
 	// Retrieve only the template contract files.
 	if template == &Contract::PSP22 || template == &Contract::PSP34 {
 		// Different template structure requires extracting different path
-		extract_contract_files(String::from(""), temp_dir.path(), canonicalized_path.as_path())?;
+		extract_template_files(
+			String::from(""),
+			temp_dir.path(),
+			canonicalized_path.as_path(),
+			None,
+		)?;
 	} else {
-		extract_contract_files(
+		extract_template_files(
 			template.to_string(),
 			temp_dir.path(),
 			canonicalized_path.as_path(),
+			Some(vec!["frontend".to_string()]),
 		)?;
 	}
 
 	// Replace name of the contract.
 	rename_contract(name, canonicalized_path, template)?;
-	Ok(())
-}
-
-fn extract_contract_files(
-	contract_name: String,
-	repo_folder: &Path,
-	target_folder: &Path,
-) -> Result<()> {
-	let contract_folder = repo_folder.join(contract_name);
-	// Recursively copy all folders and files within. Ignores frontend folders.
-	copy_dir_all(&contract_folder, target_folder)?;
 	Ok(())
 }
 
@@ -167,85 +158,6 @@ mod tests {
 		assert!(is_valid_contract_name("123").is_err());
 		assert!(is_valid_contract_name("my-contract").is_err());
 		assert!(is_valid_contract_name("contract**").is_err());
-		Ok(())
-	}
-
-	fn generate_testing_files_and_folders(template: Contract) -> Result<tempfile::TempDir, Error> {
-		let temp_dir = tempfile::tempdir()?;
-		let contract_folder = temp_dir.path().join(template.to_string());
-		fs::create_dir(&contract_folder)?;
-		fs::File::create(&contract_folder.join("lib.rs"))?;
-		fs::File::create(&contract_folder.join("Cargo.toml"))?;
-		fs::create_dir(&temp_dir.path().join("noise_folder"))?;
-		Ok(temp_dir)
-	}
-
-	#[test]
-	fn test_extract_contract_files() -> Result<(), Error> {
-		// ERC-20
-		let mut temp_dir = generate_testing_files_and_folders(Contract::ERC20)?;
-		let mut output_dir = tempfile::tempdir()?;
-		extract_contract_files(Contract::ERC20.to_string(), temp_dir.path(), output_dir.path())?;
-		assert!(output_dir.path().join("lib.rs").exists());
-		assert!(output_dir.path().join("Cargo.toml").exists());
-		assert!(!output_dir.path().join("noise_folder").exists());
-		assert!(!output_dir.path().join("frontend").exists());
-		// ERC-721
-		temp_dir = generate_testing_files_and_folders(Contract::ERC721)?;
-		output_dir = tempfile::tempdir()?;
-		extract_contract_files(Contract::ERC721.to_string(), temp_dir.path(), output_dir.path())?;
-		assert!(output_dir.path().join("lib.rs").exists());
-		assert!(output_dir.path().join("Cargo.toml").exists());
-		assert!(!output_dir.path().join("noise_folder").exists());
-		assert!(!output_dir.path().join("frontend").exists());
-		// ERC-1155
-		temp_dir = generate_testing_files_and_folders(Contract::ERC1155)?;
-		output_dir = tempfile::tempdir()?;
-		extract_contract_files(Contract::ERC1155.to_string(), temp_dir.path(), output_dir.path())?;
-		assert!(output_dir.path().join("lib.rs").exists());
-		assert!(output_dir.path().join("Cargo.toml").exists());
-		assert!(!output_dir.path().join("noise_folder").exists());
-		assert!(!output_dir.path().join("frontend").exists());
-		// PSP22
-		temp_dir = generate_testing_files_and_folders(Contract::PSP22)?;
-		output_dir = tempfile::tempdir()?;
-		extract_contract_files(Contract::PSP22.to_string(), temp_dir.path(), output_dir.path())?;
-		assert!(output_dir.path().join("lib.rs").exists());
-		assert!(output_dir.path().join("Cargo.toml").exists());
-		assert!(!output_dir.path().join("noise_folder").exists());
-		// PSP34
-		temp_dir = generate_testing_files_and_folders(Contract::PSP34)?;
-		output_dir = tempfile::tempdir()?;
-		extract_contract_files(Contract::PSP34.to_string(), temp_dir.path(), output_dir.path())?;
-		assert!(output_dir.path().join("lib.rs").exists());
-		assert!(output_dir.path().join("Cargo.toml").exists());
-		assert!(!output_dir.path().join("noise_folder").exists());
-		// DNS
-		temp_dir = generate_testing_files_and_folders(Contract::DNS)?;
-		output_dir = tempfile::tempdir()?;
-		extract_contract_files(Contract::DNS.to_string(), temp_dir.path(), output_dir.path())?;
-		assert!(output_dir.path().join("lib.rs").exists());
-		assert!(output_dir.path().join("Cargo.toml").exists());
-		assert!(!output_dir.path().join("noise_folder").exists());
-		// CrossContract
-		temp_dir = generate_testing_files_and_folders(Contract::CrossContract)?;
-		output_dir = tempfile::tempdir()?;
-		extract_contract_files(
-			Contract::CrossContract.to_string(),
-			temp_dir.path(),
-			output_dir.path(),
-		)?;
-		assert!(output_dir.path().join("lib.rs").exists());
-		assert!(output_dir.path().join("Cargo.toml").exists());
-		assert!(!output_dir.path().join("noise_folder").exists());
-		// Multisig
-		temp_dir = generate_testing_files_and_folders(Contract::Multisig)?;
-		output_dir = tempfile::tempdir()?;
-		extract_contract_files(Contract::Multisig.to_string(), temp_dir.path(), output_dir.path())?;
-		assert!(output_dir.path().join("lib.rs").exists());
-		assert!(output_dir.path().join("Cargo.toml").exists());
-		assert!(!output_dir.path().join("noise_folder").exists());
-
 		Ok(())
 	}
 

--- a/crates/pop-contracts/src/node/mod.rs
+++ b/crates/pop-contracts/src/node/mod.rs
@@ -28,7 +28,6 @@ const BIN_NAME: &str = "substrate-contracts-node";
 /// # Arguments
 ///
 /// * `url` - Endpoint of the node.
-///
 pub async fn is_chain_alive(url: url::Url) -> Result<bool, Error> {
 	let request = RpcRequest::new(&url).await;
 	match request {
@@ -65,7 +64,7 @@ impl TryInto for Chain {
 	/// * `latest` - If applicable, some specifier used to determine the latest source.
 	fn try_into(&self, tag: Option<String>, latest: Option<String>) -> Result<Source, Error> {
 		let archive = archive_name_by_target()?;
-		let archive_bin_path = release_folder_by_target()?;
+		let archive_bin_path = release_directory_by_target()?;
 		Ok(match self {
 			&Chain::ContractsNode => {
 				// Source from GitHub release asset
@@ -86,12 +85,13 @@ impl TryInto for Chain {
 
 impl pop_common::sourcing::traits::Source for Chain {}
 
-/// Retrieves the latest release of the contracts node binary, resolves its version, and constructs a `Binary::Source`
-/// with the specified cache path.
+/// Retrieves the latest release of the contracts node binary, resolves its version, and constructs
+/// a `Binary::Source` with the specified cache path.
 ///
 /// # Arguments
 /// * `cache` -  The cache directory path.
-/// * `version` - The specific version used for the substrate-contracts-node (`None` will use the latest available version).
+/// * `version` - The specific version used for the substrate-contracts-node (`None` will use the
+///   latest available version).
 pub async fn contracts_node_generator(
 	cache: PathBuf,
 	version: Option<&str>,
@@ -118,7 +118,6 @@ pub async fn contracts_node_generator(
 ///
 /// * `binary_path` - The path where the binary is stored. Can be the binary name itself if in PATH.
 /// * `output` - The optional log file for node output.
-///
 pub async fn run_contracts_node(
 	binary_path: PathBuf,
 	output: Option<&File>,
@@ -145,7 +144,7 @@ fn archive_name_by_target() -> Result<String, Error> {
 	}
 }
 
-fn release_folder_by_target() -> Result<&'static str, Error> {
+fn release_directory_by_target() -> Result<&'static str, Error> {
 	match OS {
 		"macos" => Ok("artifacts/substrate-contracts-node-mac/substrate-contracts-node"),
 		"linux" => Ok("artifacts/substrate-contracts-node-linux/substrate-contracts-node"),
@@ -160,7 +159,7 @@ mod tests {
 	use std::process::Command;
 
 	#[tokio::test]
-	async fn folder_path_by_target() -> Result<()> {
+	async fn directory_path_by_target() -> Result<()> {
 		let archive = archive_name_by_target();
 		if cfg!(target_os = "macos") {
 			assert_eq!(archive?, "substrate-contracts-node-mac-universal.tar.gz");
@@ -189,7 +188,7 @@ mod tests {
 		let version = "v0.40.0";
 		let binary = contracts_node_generator(cache.clone(), Some(version)).await?;
 		let archive = archive_name_by_target()?;
-		let archive_bin_path = release_folder_by_target()?;
+		let archive_bin_path = release_directory_by_target()?;
 		assert!(matches!(binary, Binary::Source { name, source, cache}
 			if name == expected.binary()  &&
 				source == Source::GitHub(ReleaseArchive {

--- a/crates/pop-contracts/src/test.rs
+++ b/crates/pop-contracts/src/test.rs
@@ -52,7 +52,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_smart_contract_wrong_folder() -> Result<(), Error> {
+	fn test_smart_contract_wrong_directory() -> Result<(), Error> {
 		let temp_dir = tempfile::tempdir()?;
 		assert!(matches!(
 			test_smart_contract(Some(&temp_dir.path().join(""))),
@@ -65,7 +65,8 @@ mod tests {
 	fn test_e2e_smart_contract_set_env_variable() -> Result<(), Error> {
 		let temp_dir = tempfile::tempdir()?;
 		cmd("cargo", ["new", "test_contract", "--bin"]).dir(temp_dir.path()).run()?;
-		// Ignore 2e2 testing in this scenario, will fail. Only test if the environment variable CONTRACTS_NODE is set.
+		// Ignore 2e2 testing in this scenario, will fail. Only test if the environment variable
+		// CONTRACTS_NODE is set.
 		let err = test_e2e_smart_contract(Some(&temp_dir.path().join("test_contract")), None);
 		assert!(err.is_err());
 		// The environment variable `CONTRACTS_NODE` should not be set.

--- a/crates/pop-contracts/src/up.rs
+++ b/crates/pop-contracts/src/up.rs
@@ -20,7 +20,7 @@ use subxt_signer::sr25519::Keypair;
 /// Attributes for the `up` command
 #[derive(Debug, PartialEq)]
 pub struct UpOpts {
-	/// Path to the contract build folder.
+	/// Path to the contract build directory.
 	pub path: Option<PathBuf>,
 	/// The name of the contract constructor to call.
 	pub constructor: String,
@@ -96,7 +96,8 @@ pub async fn set_up_upload(
 	return Ok(upload_exec);
 }
 
-/// Estimate the gas required for instantiating a contract without modifying the state of the blockchain.
+/// Estimate the gas required for instantiating a contract without modifying the state of the
+/// blockchain.
 ///
 /// # Arguments
 ///

--- a/crates/pop-contracts/src/utils/helpers.rs
+++ b/crates/pop-contracts/src/utils/helpers.rs
@@ -37,7 +37,6 @@ pub fn parse_account(account: &str) -> Result<<DefaultConfig as Config>::Account
 /// # Arguments
 ///
 /// * `target` - A reference to the `Path` to be canonicalized.
-///
 pub fn canonicalized_path(target: &Path) -> Result<PathBuf, Error> {
 	// Canonicalize the target path to ensure consistency and resolve any symbolic links.
 	target
@@ -75,8 +74,8 @@ mod tests {
 	fn test_canonicalized_path() -> Result<(), Error> {
 		let temp_dir = tempfile::tempdir()?;
 		// Error case
-		let error_folder = canonicalized_path(&temp_dir.path().join("my_folder"));
-		assert!(error_folder.is_err());
+		let error_directory = canonicalized_path(&temp_dir.path().join("my_directory"));
+		assert!(error_directory.is_err());
 		// Success case
 		canonicalized_path(temp_dir.path())?;
 		Ok(())

--- a/crates/pop-contracts/src/utils/helpers.rs
+++ b/crates/pop-contracts/src/utils/helpers.rs
@@ -5,7 +5,6 @@ use contract_build::ManifestPath;
 use contract_extrinsics::BalanceVariant;
 use ink_env::{DefaultEnvironment, Environment};
 use std::{
-	fs, io,
 	path::{Path, PathBuf},
 	str::FromStr,
 };
@@ -45,29 +44,6 @@ pub fn canonicalized_path(target: &Path) -> Result<PathBuf, Error> {
 		.canonicalize()
 		// If an I/O error occurs during canonicalization, convert it into an Error enum variant.
 		.map_err(|e| Error::IO(e))
-}
-/// Recursively copy a directory and its files.
-///
-/// # Arguments
-///
-/// * `src`: - Path to copy from
-/// * `dst`: - Path to copy to
-///
-pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
-	fs::create_dir_all(&dst)?;
-	for entry in fs::read_dir(src)? {
-		let entry = entry?;
-		let ty = entry.file_type()?;
-		// Ignore frontend folder in templates
-		if ty.is_dir() && entry.file_name() == "frontend" {
-			continue;
-		} else if ty.is_dir() {
-			copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
-		} else {
-			fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
-		}
-	}
-	Ok(())
 }
 
 #[cfg(test)]

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -14,10 +14,12 @@ use std::{
 /// Build the parachain and returns the path to the binary.
 ///
 /// # Arguments
-/// * `path` - The optional path to the parachain manifest, defaulting to the current directory if not specified.
+/// * `path` - The optional path to the parachain manifest, defaulting to the current directory if
+///   not specified.
 /// * `package` - The optional package to be built.
 /// * `release` - Whether the parachain should be built without any debugging functionality.
-/// * `node_path` - An optional path to the node directory. Defaults to the `node` subdirectory of the project path if not provided.
+/// * `node_path` - An optional path to the node directory. Defaults to the `node` subdirectory of
+///   the project path if not provided.
 pub fn build_parachain(
 	path: &Path,
 	package: Option<String>,
@@ -33,13 +35,14 @@ pub fn build_parachain(
 		args.push("--release");
 	}
 	cmd("cargo", args).dir(path).run()?;
-	binary_path(&profile.target_folder(path), node_path.unwrap_or(&path.join("node")))
+	binary_path(&profile.target_directory(path), node_path.unwrap_or(&path.join("node")))
 }
 
 /// Determines whether the manifest at the supplied path is a supported parachain project.
 ///
 /// # Arguments
-/// * `path` - The optional path to the manifest, defaulting to the current directory if not specified.
+/// * `path` - The optional path to the manifest, defaulting to the current directory if not
+///   specified.
 pub fn is_supported(path: Option<&Path>) -> Result<bool, Error> {
 	let manifest = from_path(path)?;
 	// Simply check for a parachain dependency
@@ -51,7 +54,7 @@ pub fn is_supported(path: Option<&Path>) -> Result<bool, Error> {
 	}))
 }
 
-/// Constructs the node binary path based on the target path and the node folder path.
+/// Constructs the node binary path based on the target path and the node directory path.
 ///
 /// # Arguments
 /// * `target_path` - The path where the binaries are expected to be found.
@@ -121,7 +124,8 @@ pub fn generate_raw_chain_spec(
 /// Export the WebAssembly runtime for the parachain.
 ///
 /// # Arguments
-/// * `binary_path` - The path to the node binary executable that contains the `export-genesis-wasm` command.
+/// * `binary_path` - The path to the node binary executable that contains the `export-genesis-wasm`
+///   command.
 /// * `chain_spec` - Location of the raw chain specification file.
 /// * `wasm_file_name` - The name of the wasm runtime file to be generated.
 pub fn export_wasm_file(
@@ -152,7 +156,8 @@ pub fn export_wasm_file(
 /// Generate the parachain genesis state.
 ///
 /// # Arguments
-/// * `binary_path` - The path to the node binary executable that contains the `export-genesis-state` command.
+/// * `binary_path` - The path to the node binary executable that contains the
+///   `export-genesis-state` command.
 /// * `chain_spec` - Location of the raw chain specification file.
 /// * `genesis_file_name` - The name of the genesis state file to be generated.
 pub fn generate_genesis_state_file(
@@ -348,7 +353,7 @@ mod tests {
 		Ok(())
 	}
 
-	// Function that generates a Cargo.toml inside node folder for testing.
+	// Function that generates a Cargo.toml inside node directory for testing.
 	fn generate_mock_node(temp_dir: &Path) -> Result<(), Error> {
 		// Create a node directory
 		let target_dir = temp_dir.join("node");
@@ -414,12 +419,12 @@ default_command = "pop-node"
 		cmd("cargo", ["new", name, "--bin"]).dir(temp_dir.path()).run()?;
 		generate_mock_node(&temp_dir.path().join(name))?;
 		let binary = build_parachain(&temp_dir.path().join(name), None, &Profile::Release, None)?;
-		let target_folder = temp_dir.path().join(name).join("target/release");
-		assert!(target_folder.exists());
-		assert!(target_folder.join("parachain_template_node").exists());
+		let target_directory = temp_dir.path().join(name).join("target/release");
+		assert!(target_directory.exists());
+		assert!(target_directory.join("parachain_template_node").exists());
 		assert_eq!(
 			binary.display().to_string(),
-			target_folder.join("parachain_template_node").display().to_string()
+			target_directory.join("parachain_template_node").display().to_string()
 		);
 		Ok(())
 	}

--- a/crates/pop-parachains/src/errors.rs
+++ b/crates/pop-parachains/src/errors.rs
@@ -5,7 +5,7 @@ use zombienet_sdk::OrchestratorError;
 
 #[derive(Error, Debug)]
 pub enum Error {
-	#[error("User aborted due to existing target folder.")]
+	#[error("User aborted due to existing target directory.")]
 	Aborted,
 	#[error("Anyhow error: {0}")]
 	AnyhowError(#[from] anyhow::Error),

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -20,7 +20,6 @@ pub use new_pallet::{create_pallet_template, TemplatePalletConfig};
 pub use new_parachain::instantiate_template_dir;
 pub use templates::{Config, Parachain, Provider};
 pub use up::Zombienet;
-pub use utils::helpers::is_initial_endowment_valid;
-pub use utils::pallet_helpers::resolve_pallet_path;
+pub use utils::{helpers::is_initial_endowment_valid, pallet_helpers::resolve_pallet_path};
 /// Information about the Node. External export from Zombienet-SDK.
 pub use zombienet_sdk::NetworkNode;

--- a/crates/pop-parachains/src/new_pallet.rs
+++ b/crates/pop-parachains/src/new_pallet.rs
@@ -2,8 +2,8 @@
 
 use std::{fs, path::PathBuf};
 
-use crate::errors::Error;
 use crate::{
+	errors::Error,
 	generator::pallet::{
 		PalletBenchmarking, PalletCargoToml, PalletItem, PalletLib, PalletMock, PalletTests,
 		PalletWeights,
@@ -39,7 +39,7 @@ pub fn create_pallet_template(
 	Ok(())
 }
 
-/// Generate a pallet folder and file structure
+/// Generate a pallet directory and file structure
 fn generate_pallet_structure(target: &PathBuf, pallet_name: &str) -> Result<(), Error> {
 	use fs::{create_dir, File};
 	let (pallet, src) = (target.join(pallet_name), target.join(pallet_name.to_string() + "/src"));
@@ -100,8 +100,8 @@ mod tests {
 
 		// Assert that the pallet structure is generated
 		let pallet_path = temp_dir.path().join(pallet_name);
-		assert!(pallet_path.exists(), "Pallet folder should be created");
-		assert!(pallet_path.join("src").exists(), "src folder should be created");
+		assert!(pallet_path.exists(), "Pallet directory should be created");
+		assert!(pallet_path.join("src").exists(), "src directory should be created");
 		assert!(pallet_path.join("Cargo.toml").exists(), "Cargo.toml should be created");
 		assert!(pallet_path.join("src").join("lib.rs").exists(), "lib.rs should be created");
 		assert!(

--- a/crates/pop-parachains/src/templates.rs
+++ b/crates/pop-parachains/src/templates.rs
@@ -104,7 +104,8 @@ pub enum Parachain {
 		)
 	)]
 	Contracts,
-	/// Parachain configured with Frontier, enabling compatibility with the Ethereum Virtual Machine (EVM).
+	/// Parachain configured with Frontier, enabling compatibility with the Ethereum Virtual
+	/// Machine (EVM).
 	#[strum(
 		serialize = "evm",
 		message = "EVM",
@@ -195,7 +196,8 @@ impl Parachain {
 	}
 
 	pub fn is_supported_version(&self, version: &str) -> bool {
-		// if `SupportedVersion` is None, then all versions are supported. Otherwise, ensure version is present.
+		// if `SupportedVersion` is None, then all versions are supported. Otherwise, ensure version
+		// is present.
 		self.supported_versions().map_or(true, |versions| versions.contains(&version))
 	}
 

--- a/crates/pop-parachains/src/up/mod.rs
+++ b/crates/pop-parachains/src/up/mod.rs
@@ -39,10 +39,14 @@ impl Zombienet {
 	/// # Arguments
 	/// * `cache` - The location used for caching binaries.
 	/// * `network_config` - The configuration file to be used to launch a network.
-	/// * `relay_chain_version` - The specific binary version used for the relay chain (`None` will use the latest available version).
-	/// * `relay_chain_runtime_version` - The specific runtime version used for the relay chain runtime (`None` will use the latest available version).
-	/// * `system_parachain_version` - The specific binary version used for system parachains (`None` will use the latest available version).
-	/// * `system_parachain_runtime_version` - The specific runtime version used for system parachains (`None` will use the latest available version).
+	/// * `relay_chain_version` - The specific binary version used for the relay chain (`None` will
+	///   use the latest available version).
+	/// * `relay_chain_runtime_version` - The specific runtime version used for the relay chain
+	///   runtime (`None` will use the latest available version).
+	/// * `system_parachain_version` - The specific binary version used for system parachains
+	///   (`None` will use the latest available version).
+	/// * `system_parachain_runtime_version` - The specific runtime version used for system
+	///   parachains (`None` will use the latest available version).
 	/// * `parachains` - The parachain(s) specified.
 	pub async fn new(
 		cache: &Path,
@@ -100,8 +104,10 @@ impl Zombienet {
 	///
 	/// # Arguments
 	/// * `relay_chain` - The configuration required to launch the relay chain.
-	/// * `system_parachain_version` - The specific binary version used for system parachains (`None` will use the latest available version).
-	/// * `system_parachain_runtime_version` - The specific runtime version used for system parachains (`None` will use the latest available version).
+	/// * `system_parachain_version` - The specific binary version used for system parachains
+	///   (`None` will use the latest available version).
+	/// * `system_parachain_runtime_version` - The specific runtime version used for system
+	///   parachains (`None` will use the latest available version).
 	/// * `parachains` - The parachain repositories specified.
 	/// * `network_config` - The network configuration to be used to launch a network.
 	/// * `cache` - The location used for caching binaries.
@@ -203,8 +209,10 @@ impl Zombienet {
 	/// Determines relay chain configuration based on specified version and network configuration.
 	///
 	/// # Arguments
-	/// * `version` - The specific binary version used for the relay chain (`None` will use the latest available version).
-	/// * `runtime_version` - The specific runtime version used for the relay chain runtime (`None` will use the latest available version).
+	/// * `version` - The specific binary version used for the relay chain (`None` will use the
+	///   latest available version).
+	/// * `runtime_version` - The specific runtime version used for the relay chain runtime (`None`
+	///   will use the latest available version).
 	/// * `network_config` - The network configuration to be used to launch a network.
 	/// * `cache` - The location used for caching binaries.
 	async fn relay_chain(
@@ -524,7 +532,8 @@ impl Parachain {
 		})
 	}
 
-	/// Initializes the configuration required to launch a parachain using a binary sourced from the specified repository.
+	/// Initializes the configuration required to launch a parachain using a binary sourced from the
+	/// specified repository.
 	///
 	/// # Arguments
 	/// * `id` - The parachain identifier on the local network.
@@ -644,8 +653,7 @@ fn resolve_manifest(package: &str, path: &Path) -> Result<Option<PathBuf>, Error
 mod tests {
 	use super::*;
 	use anyhow::Result;
-	use std::env::current_dir;
-	use std::{fs::File, io::Write};
+	use std::{env::current_dir, fs::File, io::Write};
 	use tempfile::tempdir;
 
 	mod zombienet {
@@ -1434,10 +1442,9 @@ validator = true
 
 	mod network_config {
 		use super::*;
-		use std::io::Read;
 		use std::{
 			fs::{create_dir_all, File},
-			io::Write,
+			io::{Read, Write},
 			path::PathBuf,
 		};
 		use tempfile::{tempdir, Builder};

--- a/crates/pop-parachains/src/utils/helpers.rs
+++ b/crates/pop-parachains/src/utils/helpers.rs
@@ -9,7 +9,7 @@ use std::{
 
 pub(crate) fn sanitize(target: &Path) -> Result<(), Error> {
 	if target.exists() {
-		print!("\"{}\" folder exists. Do you want to clean it? [y/n]: ", target.display());
+		print!("\"{}\" directory exists. Do you want to clean it? [y/n]: ", target.display());
 		stdout().flush()?;
 
 		let mut input = String::new();


### PR DESCRIPTION
Refactor the `extract_contract_files` function, currently used for generating new contract templates in a monorepo with multiple templates, and move it into the `pop_common` crate. 
This will allow us to reuse the function for parachains with the upcoming integrations.