### PR TITLE
fix: limit API calls when generating parachain

### DIFF
--- a/crates/pop-cli/src/commands/new/parachain.rs
+++ b/crates/pop-cli/src/commands/new/parachain.rs
@@ -197,8 +197,8 @@ async fn generate_parachain_from_template(
 	if verify && tag.is_some() {
 		let url = url::Url::parse(&template.repository_url()?).expect("valid repository url");
 		let repo = GitHub::parse(url.as_str())?;
-		let commit = repo.get_commit_sha_from_release(&tag.clone().unwrap()).await?;
-		verify_note = format!(" ✅ Fetched the latest release of the template along with its license based on the commit SHA for the release ({}).", commit);
+		let commit = repo.get_commit_sha_from_release(&tag.clone().unwrap()).await;
+		verify_note = format!(" ✅ Fetched the latest release of the template along with its license based on the commit SHA for the release ({}).", commit.unwrap_or_default());
 	}
 	success(format!(
 		"Generation complete{}",

--- a/crates/pop-cli/src/commands/new/parachain.rs
+++ b/crates/pop-cli/src/commands/new/parachain.rs
@@ -61,6 +61,12 @@ pub struct NewParachainCommand {
 		default_value = DEFAULT_INITIAL_ENDOWMENT
 	)]
 	pub(crate) initial_endowment: Option<String>,
+	#[arg(
+		short = 'v',
+		long,
+		help = "Fetches the latest license, release, and commit SHA data from GitHub."
+	)]
+	pub(crate) verify: bool,
 }
 
 impl NewParachainCommand {
@@ -68,7 +74,7 @@ impl NewParachainCommand {
 	pub(crate) async fn execute(self) -> Result<Parachain> {
 		// If user doesn't select the name guide them to generate a parachain.
 		let parachain_config = if self.name.is_none() {
-			guide_user_to_generate_parachain().await?
+			guide_user_to_generate_parachain(self.verify).await?
 		} else {
 			self.clone()
 		};
@@ -99,7 +105,7 @@ impl NewParachainCommand {
 }
 
 /// Guide the user to generate a parachain from available templates.
-async fn guide_user_to_generate_parachain() -> Result<NewParachainCommand> {
+async fn guide_user_to_generate_parachain(verify: bool) -> Result<NewParachainCommand> {
 	Cli.intro("Generate a parachain")?;
 
 	// Prompt for template selection.
@@ -121,7 +127,7 @@ async fn guide_user_to_generate_parachain() -> Result<NewParachainCommand> {
 	}
 	let provider = prompt.interact()?;
 	let template = display_select_options(provider)?;
-	let release_name = choose_release(template).await?;
+	let release_name = choose_release(template, verify).await?;
 
 	// Prompt for location.
 	let name: String = input("Where should your project be created?")
@@ -147,6 +153,7 @@ async fn guide_user_to_generate_parachain() -> Result<NewParachainCommand> {
 		symbol: Some(customizable_options.symbol),
 		decimals: Some(customizable_options.decimals),
 		initial_endowment: Some(customizable_options.initial_endowment),
+		verify,
 	})
 }
 
@@ -281,15 +288,19 @@ fn check_destination_path(name_template: &String) -> Result<&Path> {
 /// Otherwise, the default release is used.
 ///
 /// return: `Option<String>` - The release name selected by the user or None if no releases found.
-async fn choose_release(template: &Parachain) -> Result<Option<String>> {
+async fn choose_release(template: &Parachain, verify: bool) -> Result<Option<String>> {
 	let url = url::Url::parse(&template.repository_url()?).expect("valid repository url");
 	let repo = GitHub::parse(url.as_str())?;
 
-	let license = repo.get_repo_license().await?;
+	let license = if verify || template.license().is_none() {
+		repo.get_repo_license().await?
+	} else {
+		template.license().unwrap().to_string() // unwrap is safe as it is checked above
+	};
 	log::info(format!("Template {}: {}", style("License").bold(), license))?;
 
 	// Get only the latest 3 releases that are supported by the template (default is all)
-	let latest_3_releases: Vec<Release> = get_latest_3_releases(&repo)
+	let latest_3_releases: Vec<Release> = get_latest_3_releases(&repo, verify)
 		.await?
 		.into_iter()
 		.filter(|r| template.is_supported_version(&r.tag_name))
@@ -312,13 +323,15 @@ async fn choose_release(template: &Parachain) -> Result<Option<String>> {
 	Ok(release_name)
 }
 
-async fn get_latest_3_releases(repo: &GitHub) -> Result<Vec<Release>> {
+async fn get_latest_3_releases(repo: &GitHub, verify: bool) -> Result<Vec<Release>> {
 	let mut latest_3_releases: Vec<Release> =
 		repo.releases().await?.into_iter().filter(|r| !r.prerelease).take(3).collect();
-	// Get the commit sha for the releases
-	for release in latest_3_releases.iter_mut() {
-		let commit = repo.get_commit_sha_from_release(&release.tag_name).await?;
-		release.commit = Some(commit);
+	if verify {
+		// Get the commit sha for the releases
+		for release in latest_3_releases.iter_mut() {
+			let commit = repo.get_commit_sha_from_release(&release.tag_name).await?;
+			release.commit = Some(commit);
+		}
 	}
 	Ok(latest_3_releases)
 }
@@ -422,6 +435,7 @@ mod tests {
 			symbol: Some("UNIT".to_string()),
 			decimals: Some(12),
 			initial_endowment: Some("1u64 << 60".to_string()),
+			verify: false,
 		};
 		command.execute().await?;
 

--- a/crates/pop-cli/tests/parachain.rs
+++ b/crates/pop-cli/tests/parachain.rs
@@ -16,7 +16,7 @@ async fn parachain_lifecycle() -> Result<()> {
 	// let temp_dir = Path::new("./"); //For testing locally
 	// Test that all templates are generated correctly
 	generate_all_the_templates(&temp_dir)?;
-	// pop new parachain test_parachain (default)
+	// pop new parachain test_parachain --verify (default)
 	Command::cargo_bin("pop")
 		.unwrap()
 		.current_dir(&temp_dir)
@@ -30,6 +30,7 @@ async fn parachain_lifecycle() -> Result<()> {
 			"6",
 			"--endowment",
 			"1u64 << 60",
+			"--verify",
 		])
 		.assert()
 		.success();
@@ -106,7 +107,7 @@ fn generate_all_the_templates(temp_dir: &Path) -> Result<()> {
 	for template in Parachain::VARIANTS {
 		let parachain_name = format!("test_parachain_{}", template);
 		let provider = template.template_type()?.to_lowercase();
-		// pop new parachain test_parachain
+		// pop new parachain test_parachain --verify
 		Command::cargo_bin("pop")
 			.unwrap()
 			.current_dir(&temp_dir)
@@ -117,6 +118,7 @@ fn generate_all_the_templates(temp_dir: &Path) -> Result<()> {
 				&provider,
 				"--template",
 				&template.to_string(),
+				"--verify",
 			])
 			.assert()
 			.success();

--- a/crates/pop-parachains/src/templates.rs
+++ b/crates/pop-parachains/src/templates.rs
@@ -76,7 +76,8 @@ pub enum Parachain {
 		props(
 			Provider = "Pop",
 			Repository = "https://github.com/r0gue-io/base-parachain",
-			Network = "./network.toml"
+			Network = "./network.toml",
+			License = "Unlicense"
 		)
 	)]
 	Standard,
@@ -88,7 +89,8 @@ pub enum Parachain {
 		props(
 			Provider = "Pop",
 			Repository = "https://github.com/r0gue-io/assets-parachain",
-			Network = "./network.toml"
+			Network = "./network.toml",
+			License = "Unlicense"
 		)
 	)]
 	Assets,
@@ -100,7 +102,8 @@ pub enum Parachain {
 		props(
 			Provider = "Pop",
 			Repository = "https://github.com/r0gue-io/contracts-parachain",
-			Network = "./network.toml"
+			Network = "./network.toml",
+			License = "Unlicense"
 		)
 	)]
 	Contracts,
@@ -113,7 +116,8 @@ pub enum Parachain {
 		props(
 			Provider = "Pop",
 			Repository = "https://github.com/r0gue-io/evm-parachain",
-			Network = "./network.toml"
+			Network = "./network.toml",
+			License = "Unlicense"
 		)
 	)]
 	EVM,
@@ -127,7 +131,8 @@ pub enum Parachain {
 			Repository = "https://github.com/OpenZeppelin/polkadot-runtime-templates",
 			Network = "./zombienet-config/devnet.toml",
 			SupportedVersions = "v1.0.0",
-			IsAudited = "true"
+			IsAudited = "true",
+			License = "GPL-3.0"
 		)
 	)]
 	OpenZeppelinGeneric,
@@ -139,7 +144,8 @@ pub enum Parachain {
 		props(
 			Provider = "Parity",
 			Repository = "https://github.com/paritytech/substrate-contracts-node",
-			Network = "./zombienet.toml"
+			Network = "./zombienet.toml",
+			License = "Unlicense"
 		)
 	)]
 	ParityContracts,
@@ -151,7 +157,8 @@ pub enum Parachain {
 		props(
 			Provider = "Parity",
 			Repository = "https://github.com/paritytech/frontier-parachain-template",
-			Network = "./zombienet-config.toml"
+			Network = "./zombienet-config.toml",
+			License = "Unlicense"
 		)
 	)]
 	ParityFPT,
@@ -167,7 +174,8 @@ pub enum Parachain {
 			Repository = "",
 			Network = "",
 			SupportedVersions = "v1.0.0,v2.0.0",
-			IsAudited = "true"
+			IsAudited = "true",
+			License = "Unlicense"
 		)
 	)]
 	TestTemplate01,
@@ -176,7 +184,7 @@ pub enum Parachain {
 		serialize = "test_02",
 		message = "Test_02",
 		detailed_message = "Test template only compiled in test mode.",
-		props(Provider = "Test", Repository = "", Network = "",)
+		props(Provider = "Test", Repository = "", Network = "", License = "GPL-3.0")
 	)]
 	TestTemplate02,
 }
@@ -203,6 +211,10 @@ impl Parachain {
 
 	pub fn is_audited(&self) -> bool {
 		self.get_str("IsAudited").map_or(false, |s| s == "true")
+	}
+
+	pub fn license(&self) -> Option<&str> {
+		self.get_str("License")
 	}
 }
 
@@ -261,6 +273,21 @@ mod tests {
 		.into()
 	}
 
+	fn template_license() -> HashMap<Parachain, Option<&'static str>> {
+		[
+			(Standard, Some("Unlicense")),
+			(Assets, Some("Unlicense")),
+			(Contracts, Some("Unlicense")),
+			(EVM, Some("Unlicense")),
+			(OpenZeppelinGeneric, Some("GPL-3.0")),
+			(ParityContracts, Some("Unlicense")),
+			(ParityFPT, Some("Unlicense")),
+			(TestTemplate01, Some("Unlicense")),
+			(TestTemplate02, Some("GPL-3.0")),
+		]
+		.into()
+	}
+
 	#[test]
 	fn test_is_template_correct() {
 		for template in Parachain::VARIANTS {
@@ -305,6 +332,14 @@ mod tests {
 		let network_configs = template_network_configs();
 		for template in Parachain::VARIANTS {
 			assert_eq!(template.network_config(), network_configs[template]);
+		}
+	}
+
+	#[test]
+	fn test_license() {
+		let licenses = template_license();
+		for template in Parachain::VARIANTS {
+			assert_eq!(template.license(), licenses[template]);
 		}
 	}
 


### PR DESCRIPTION
In the `pop new parachain` command, we perform several sequential operations to gather repository information based on the user's selection:
1. Fetch the template license.
2. Retrieve latest releases to display the user the last 3.
3. Fetch commit hashes: For each of these three releases, we retrieve the commit hash associated with the specified tag in the GitHub repository.
```
◇  Select a template provider: 
│  Pop 
│
◇  Select the type of parachain:
│  Standard 
│
⚙  Template License: Unlicense
│  
◆  Select a specific release:
│  ● Polkadot v1.14 (polkadot-v.1.14.0 / 4a6e8ef)
│  ○ Polkadot v1.13 
│  ○ Polkadot v1.12 
└  
```
This process results in a total of five API calls before we even generate the parachain. If the user performs this operation twice in a short period, it results in 10 API calls, which could quickly hit rate limits on the API:
```
Error: HTTP status client error (403 Forbidden) for url (https://api.github.com/repos/org/project/license)
```
The limit per hour seems high enough [60 requests per hour](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28), but it seems it also restricts the call per minute.
I reached the limit while working on an integration which means I got stuck and can generate more parachains for a certain period of time. Same happened to another user: https://github.com/r0gue-io/pop-cli/issues/237#issuecomment-2291114617

**Solution**
By default, the command won't fetch the `license` (since it's unlikely to change and can be hardcoded) or the `commit hashes`, cutting the API queries down to just one. If users still want to verify this info, they can use the `--verify` flag. This approach keeps the _"Don't Trust, Verify"_ principle intact while reducing API calls for most users, making parachain generation smoother and avoiding rate limit issues.
I couldn’t find a way to fetch all the information in a single call, which would be ideal, so I think this is the best approach for now. However, I’m open to other ideas if you have any suggestions.

Closes: https://github.com/r0gue-io/pop-cli/issues/237