### PR TITLE
chore: bump cargo-contract and subxt versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "ark-bls12-377"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,9 +1208,9 @@ checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
 
 [[package]]
 name = "contract-build"
-version = "4.1.1"
+version = "5.0.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30f629d8cb26692c4e5f4155e8ab37649f1b2fd0abab64a4c1b3c95c9bcf3df"
+checksum = "d12277cde43657b5a7a36c9bb6e9ecf12b757234a867f9f38ce78d386a328281"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1216,7 +1225,6 @@ dependencies = [
  "hex",
  "impl-serde",
  "parity-scale-codec",
- "parity-wasm",
  "regex",
  "rustc_version",
  "semver",
@@ -1232,16 +1240,18 @@ dependencies = [
  "url",
  "uzers",
  "walkdir",
+ "wasm-encoder",
  "wasm-opt",
+ "wasmparser 0.207.0",
  "which",
  "zip",
 ]
 
 [[package]]
 name = "contract-extrinsics"
-version = "4.1.1"
+version = "5.0.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b1840f7218ce4c7b7ba6e97f23e9e9a814710ff1cfe44e69215b42651539cd"
+checksum = "bf7cd6c946b411dc175da09825bc0b041503eabca8347cefbf40eb346e035efc"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1264,7 +1274,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-weights",
- "subxt 0.35.3",
+ "subxt",
  "tokio",
  "tracing",
  "url",
@@ -1272,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "contract-metadata"
-version = "4.1.1"
+version = "5.0.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd54ed69476dc2076d6ebda17351babe1c2f33751170877f66719e8129078d3a"
+checksum = "4fc0718fc46a399688c032f2141a3abafa0eb42041e3d6880390069ca4700fca"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -1286,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "4.1.1"
+version = "5.0.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7e979c22d15a6b0615b039bf69427bc0f96c6a984943fa4f4e91149ac2712e"
+checksum = "671e0dff122f02fff592b7f32aa59b1886352939945cba487ee10f6367f13a75"
 dependencies = [
  "anyhow",
  "base58",
@@ -1692,6 +1702,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +1783,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3516,6 +3548,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
 name = "libc"
 version = "0.2.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4324,12 +4362,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-wasm"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
-
-[[package]]
 name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4707,8 +4739,8 @@ dependencies = [
  "sp-weights",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "subxt 0.35.3",
- "subxt-signer 0.35.3",
+ "subxt",
+ "subxt-signer",
  "tar",
  "tempfile",
  "thiserror",
@@ -5494,25 +5526,13 @@ dependencies = [
 
 [[package]]
 name = "scale-bits"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662d10dcd57b1c2a3c41c9cf68f71fb09747ada1ea932ad961aca7e2ca28315f"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "scale-type-resolver 0.1.1",
- "serde",
-]
-
-[[package]]
-name = "scale-bits"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "scale-type-resolver 0.2.0",
+ "scale-type-resolver",
  "serde",
 ]
 
@@ -5532,21 +5552,6 @@ dependencies = [
 
 [[package]]
 name = "scale-decode"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc79ba56a1c742f5aeeed1f1801f3edf51f7e818f0a54582cac6f131364ea7b"
-dependencies = [
- "derive_more",
- "parity-scale-codec",
- "primitive-types",
- "scale-bits 0.5.0",
- "scale-decode-derive 0.11.1",
- "scale-type-resolver 0.1.1",
- "smallvec",
-]
-
-[[package]]
-name = "scale-decode"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
@@ -5556,7 +5561,7 @@ dependencies = [
  "primitive-types",
  "scale-bits 0.6.0",
  "scale-decode-derive 0.13.1",
- "scale-type-resolver 0.2.0",
+ "scale-type-resolver",
  "smallvec",
 ]
 
@@ -5568,18 +5573,6 @@ checksum = "d3475108a1b62c7efd1b5c65974f30109a598b2f45f23c9ae030acb9686966db"
 dependencies = [
  "darling 0.14.4",
  "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "scale-decode-derive"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5398fdb3c7bea3cb419bac4983aadacae93fe1a7b5f693f4ebd98c3821aad7a5"
-dependencies = [
- "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -5612,21 +5605,6 @@ dependencies = [
 
 [[package]]
 name = "scale-encode"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628800925a33794fb5387781b883b5e14d130fece9af5a63613867b8de07c5c7"
-dependencies = [
- "derive_more",
- "parity-scale-codec",
- "primitive-types",
- "scale-bits 0.5.0",
- "scale-encode-derive 0.6.0",
- "scale-type-resolver 0.1.1",
- "smallvec",
-]
-
-[[package]]
-name = "scale-encode"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ba0b9c48dc0eb20c60b083c29447c0c4617cb7c4a4c9fef72aa5c5bc539e15e"
@@ -5636,7 +5614,7 @@ dependencies = [
  "primitive-types",
  "scale-bits 0.6.0",
  "scale-encode-derive 0.7.1",
- "scale-type-resolver 0.2.0",
+ "scale-type-resolver",
  "smallvec",
 ]
 
@@ -5645,19 +5623,6 @@ name = "scale-encode-derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "995491f110efdc6bea96d6a746140e32bfceb4ea47510750a5467295a4707a25"
-dependencies = [
- "darling 0.14.4",
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "scale-encode-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a304e1af7cdfbe7a24e08b012721456cc8cecdedadc14b3d10513eada63233c"
 dependencies = [
  "darling 0.14.4",
  "proc-macro-crate 1.3.1",
@@ -5708,35 +5673,12 @@ dependencies = [
 
 [[package]]
 name = "scale-type-resolver"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b800069bfd43374e0f96f653e0d46882a2cb16d6d961ac43bea80f26c76843"
-dependencies = [
- "scale-info",
- "smallvec",
-]
-
-[[package]]
-name = "scale-type-resolver"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
 dependencies = [
  "scale-info",
  "smallvec",
-]
-
-[[package]]
-name = "scale-typegen"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d470fa75e71b12b3244a4113adc4bc49891f3daba2054703cacd06256066397e"
-dependencies = [
- "proc-macro2",
- "quote",
- "scale-info",
- "syn 2.0.74",
- "thiserror",
 ]
 
 [[package]]
@@ -5750,27 +5692,6 @@ dependencies = [
  "scale-info",
  "syn 2.0.74",
  "thiserror",
-]
-
-[[package]]
-name = "scale-value"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07ccfee963104335c971aaf8b7b0e749be8569116322df23f1f75c4ca9e4a28"
-dependencies = [
- "base58",
- "blake2",
- "derive_more",
- "either",
- "frame-metadata 15.1.0",
- "parity-scale-codec",
- "scale-bits 0.5.0",
- "scale-decode 0.11.1",
- "scale-encode 0.6.0",
- "scale-info",
- "scale-type-resolver 0.1.1",
- "serde",
- "yap",
 ]
 
 [[package]]
@@ -5789,7 +5710,7 @@ dependencies = [
  "scale-decode 0.13.1",
  "scale-encode 0.7.1",
  "scale-info",
- "scale-type-resolver 0.2.0",
+ "scale-type-resolver",
  "serde",
  "yap",
 ]
@@ -6867,42 +6788,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.35.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd68bef23f4de5e513ab4c29af69053e232b098f9c87ab552d7ea153b4a1fbc5"
-dependencies = [
- "async-trait",
- "base58",
- "blake2",
- "derivative",
- "either",
- "frame-metadata 16.0.0",
- "futures",
- "hex",
- "impl-serde",
- "instant",
- "jsonrpsee 0.22.5",
- "parity-scale-codec",
- "primitive-types",
- "scale-bits 0.5.0",
- "scale-decode 0.11.1",
- "scale-encode 0.6.0",
- "scale-info",
- "scale-value 0.14.1",
- "serde",
- "serde_json",
- "sp-crypto-hashing",
- "subxt-lightclient 0.35.3",
- "subxt-macro 0.35.3",
- "subxt-metadata 0.35.3",
- "thiserror",
- "tokio-util",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "subxt"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a160cba1edbf3ec4fbbeaea3f1a185f70448116a6bccc8276bb39adb3b3053bd"
@@ -6923,39 +6808,18 @@ dependencies = [
  "scale-decode 0.13.1",
  "scale-encode 0.7.1",
  "scale-info",
- "scale-value 0.16.2",
+ "scale-value",
  "serde",
  "serde_json",
  "sp-crypto-hashing",
  "subxt-core",
- "subxt-lightclient 0.37.0",
- "subxt-macro 0.37.0",
- "subxt-metadata 0.37.0",
+ "subxt-lightclient",
+ "subxt-macro",
+ "subxt-metadata",
  "thiserror",
  "tokio-util",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "subxt-codegen"
-version = "0.35.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9e2b256b71d31a2629e44eb9cbfd944eb7d577c9e0c8e9802cc3c3943af2d9"
-dependencies = [
- "frame-metadata 16.0.0",
- "heck 0.4.1",
- "hex",
- "jsonrpsee 0.22.5",
- "parity-scale-codec",
- "proc-macro2",
- "quote",
- "scale-info",
- "scale-typegen 0.2.1",
- "subxt-metadata 0.35.3",
- "syn 2.0.74",
- "thiserror",
- "tokio",
 ]
 
 [[package]]
@@ -6972,8 +6836,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
- "scale-typegen 0.8.0",
- "subxt-metadata 0.37.0",
+ "scale-typegen",
+ "subxt-metadata",
  "syn 2.0.74",
  "thiserror",
  "tokio",
@@ -6998,30 +6862,13 @@ dependencies = [
  "scale-decode 0.13.1",
  "scale-encode 0.7.1",
  "scale-info",
- "scale-value 0.16.2",
+ "scale-value",
  "serde",
  "serde_json",
  "sp-core",
  "sp-crypto-hashing",
  "sp-runtime",
- "subxt-metadata 0.37.0",
- "tracing",
-]
-
-[[package]]
-name = "subxt-lightclient"
-version = "0.35.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d51f1ac12e3be7aafea4d037730a57da4f22f2e9c73955666081ffa2697c6f1"
-dependencies = [
- "futures",
- "futures-util",
- "serde",
- "serde_json",
- "smoldot-light",
- "thiserror",
- "tokio",
- "tokio-stream",
+ "subxt-metadata",
  "tracing",
 ]
 
@@ -7044,21 +6891,6 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.35.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98dc84d7e6a0abd7ed407cce0bf60d7d58004f699460cffb979640717d1ab506"
-dependencies = [
- "darling 0.20.10",
- "parity-scale-codec",
- "proc-macro-error",
- "quote",
- "scale-typegen 0.2.1",
- "subxt-codegen 0.35.3",
- "syn 2.0.74",
-]
-
-[[package]]
-name = "subxt-macro"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c195f803d70687e409aba9be6c87115b5da8952cd83c4d13f2e043239818fcd"
@@ -7067,23 +6899,9 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro-error",
  "quote",
- "scale-typegen 0.8.0",
- "subxt-codegen 0.37.0",
+ "scale-typegen",
+ "subxt-codegen",
  "syn 2.0.74",
-]
-
-[[package]]
-name = "subxt-metadata"
-version = "0.35.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc10c54028d079a9f1be65188707cd29e5ffd8d0031a2b1346a0941d57b7ab7e"
-dependencies = [
- "derive_more",
- "frame-metadata 16.0.0",
- "hashbrown 0.14.5",
- "parity-scale-codec",
- "scale-info",
- "sp-crypto-hashing",
 ]
 
 [[package]]
@@ -7097,29 +6915,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-crypto-hashing",
-]
-
-[[package]]
-name = "subxt-signer"
-version = "0.35.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ccb59a38fe357fab55247756174435e8626b93929864e8a498635a15e779df8"
-dependencies = [
- "bip39",
- "cfg-if",
- "derive_more",
- "hex",
- "hmac 0.12.1",
- "parity-scale-codec",
- "pbkdf2",
- "regex",
- "schnorrkel",
- "secp256k1",
- "secrecy",
- "sha2 0.10.8",
- "sp-crypto-hashing",
- "subxt 0.35.3",
- "zeroize",
 ]
 
 [[package]]
@@ -7887,9 +7682,9 @@ dependencies = [
 
 [[package]]
 name = "uzers"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d283dc7e8c901e79e32d077866eaf599156cbf427fffa8289aecc52c5c3f63"
+checksum = "4df81ff504e7d82ad53e95ed1ad5b72103c11253f39238bcc0235b90768a97dd"
 dependencies = [
  "libc",
  "log",
@@ -8045,6 +7840,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.207.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d996306fb3aeaee0d9157adbe2f670df0236caf19f6728b221e92d0f27b3fe17"
+dependencies = [
+ "leb128",
+ "wasmparser 0.207.0",
+]
+
+[[package]]
 name = "wasm-opt"
 version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8126,6 +7931,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.207.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19bb9f8ab07616da582ef8adb24c54f1424c7ec876720b7da9db8ec0626c92c"
+dependencies = [
+ "ahash 0.8.11",
+ "bitflags 2.6.0",
+ "hashbrown 0.14.5",
+ "indexmap 2.4.0",
+ "semver",
+]
+
+[[package]]
 name = "wasmparser-nostd"
 version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8152,7 +7970,7 @@ dependencies = [
  "psm",
  "serde",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.102.0",
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-runtime",
@@ -8183,7 +8001,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.102.0",
  "wasmtime-types",
 ]
 
@@ -8263,7 +8081,7 @@ dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.102.0",
 ]
 
 [[package]]
@@ -8682,13 +8500,17 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "dc5e4288ea4057ae23afc69a4472434a87a2495cafce6632fd1c4ec9f5cf3494"
 dependencies = [
- "byteorder",
+ "arbitrary",
  "crc32fast",
  "crossbeam-utils",
+ "displaydoc",
+ "indexmap 2.4.0",
+ "memchr",
+ "thiserror",
 ]
 
 [[package]]
@@ -8729,8 +8551,8 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "sp-core",
- "subxt 0.37.0",
- "subxt-signer 0.37.0",
+ "subxt",
+ "subxt-signer",
  "thiserror",
  "tokio",
  "tracing",
@@ -8792,7 +8614,7 @@ dependencies = [
  "async-trait",
  "futures",
  "lazy_static",
- "subxt 0.37.0",
+ "subxt",
  "tokio",
  "zombienet-configuration",
  "zombienet-orchestrator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,13 +42,13 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 url = "2.5"
 
 # contracts
-subxt-signer = { version = "0.35", features = ["subxt", "sr25519"] }
-subxt = "0.35"
+subxt-signer = { version = "0.37.0", features = ["subxt", "sr25519"] }
+subxt = "0.37.0"
 ink_env = "5.0.0"
 sp-core = "31"
 sp-weights = "30"
-contract-build = "4.1"
-contract-extrinsics = "4.1"
+contract-build = "5.0.0-alpha"
+contract-extrinsics = "5.0.0-alpha"
 heck = "0.5.0"
 
 # parachains


### PR DESCRIPTION
This PR upgrades the `subxt` and `subxt-signer` library from version 0.35.3 to 0.37.0 and `contract-build` and `contract-extrinsic` to 5.0.0-alpha where `subxt` has been updated.
This upgrade is necessary because version 0.37 of subxt includes support for the signed extension CheckMetadataHash.

Closes the bug reported https://github.com/r0gue-io/pop-cli/issues/270

To test it you can use contract template in this branch https://github.com/r0gue-io/contracts-parachain/pull/8 or Pop Network testnet.