### PR TITLE
refactor(contracts): default to riscv release build

### DIFF
--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -62,8 +62,7 @@ impl Command {
 		#[cfg(feature = "contract")]
 		if pop_contracts::is_supported(args.path.as_deref())? {
 			// All commands originating from root command are valid
-			BuildContractCommand { path: args.path, release: args.release, valid: true }
-				.execute()?;
+			BuildContractCommand { path: args.path, release: true, valid: true }.execute()?;
 			return Ok("contract");
 		}
 

--- a/crates/pop-contracts/src/build.rs
+++ b/crates/pop-contracts/src/build.rs
@@ -2,7 +2,7 @@
 
 use crate::{errors::Error, utils::helpers::get_manifest_path};
 pub use contract_build::Verbosity;
-use contract_build::{execute, BuildMode, BuildResult, ExecuteArgs};
+use contract_build::{execute, BuildMode, BuildResult, ExecuteArgs, Target};
 use std::path::Path;
 
 /// Build the smart contract located at the specified `path` in `build_release` mode.
@@ -25,7 +25,13 @@ pub fn build_smart_contract(
 	};
 
 	// Default values
-	let args = ExecuteArgs { manifest_path, build_mode, verbosity, ..Default::default() };
+	let args = ExecuteArgs {
+		manifest_path,
+		build_mode,
+		verbosity,
+		target: Target::RiscV,
+		..Default::default()
+	};
 
 	// Execute the build and log the output of the build
 	execute(args)


### PR DESCRIPTION
Should enable riscv contract building.

Note that I have not been able to test due to struggling to get the `rve-nightly` toolchain installed on my system.