### PR TITLE
fix: fetch stable version

### DIFF
--- a/crates/pop-common/src/git.rs
+++ b/crates/pop-common/src/git.rs
@@ -60,9 +60,8 @@ impl Git {
 	) -> Result<Option<String>> {
 		let repo = match GitRepository::clone(url, target) {
 			Ok(repo) => repo,
-			Err(_e) => {
-				Self::ssh_clone_and_degit(url::Url::parse(url).map_err(Error::from)?, target)?
-			},
+			Err(_e) =>
+				Self::ssh_clone_and_degit(url::Url::parse(url).map_err(Error::from)?, target)?,
 		};
 
 		if let Some(tag_version) = tag_version {

--- a/crates/pop-common/src/git.rs
+++ b/crates/pop-common/src/git.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::{errors::Error, APP_USER_AGENT};
+use crate::{errors::Error, helpers::parse_latest_tag, APP_USER_AGENT};
 use anyhow::Result;
 use git2::{
 	build::RepoBuilder, FetchOptions, IndexAddOption, RemoteCallbacks, Repository as GitRepository,
 	ResetType,
 };
 use git2_credentials::CredentialHandler;
-use regex::Regex;
 use std::{fs, path::Path};
 use url::Url;
 
@@ -119,71 +118,7 @@ impl Git {
 	/// Fetch the latest release from a repository
 	fn fetch_latest_tag(repo: &GitRepository) -> Option<String> {
 		let tags = repo.tag_names(None).ok()?;
-		Self::parse_latest_tag(tags.iter().flatten().collect::<Vec<_>>())
-	}
-
-	/// Parses a list of tags to identify the latest one, prioritizing tags in the stable format
-	/// first.
-	fn parse_latest_tag(tags: Vec<&str>) -> Option<String> {
-		match Self::parse_stable_format(tags.clone()) {
-			Some(last_stable_tag) => Some(last_stable_tag),
-			None => Self::parse_version_format(tags),
-		}
-	}
-
-	/// Parse the stable release tags.
-	fn parse_stable_format(tags: Vec<&str>) -> Option<String> {
-		// Regex for polkadot-stableYYMM and polkadot-stableYYMM-X
-		let stable_reg = Regex::new(
-			r"polkadot-stable(?P<year>\d{2})(?P<month>\d{2})(-(?P<patch>\d+))?(-rc\d+)?",
-		)
-		.expect("Valid regex");
-		tags.into_iter()
-			.filter_map(|tag| {
-				// Skip the pre-release label
-				if tag.contains("-rc") {
-					return None;
-				}
-				stable_reg.captures(tag).and_then(|v| {
-					let year = v.name("year")?.as_str().parse::<u32>().ok()?;
-					let month = v.name("month")?.as_str().parse::<u32>().ok()?;
-					let patch =
-						v.name("patch").and_then(|m| m.as_str().parse::<u32>().ok()).unwrap_or(0);
-					Some((tag, (year, month, patch)))
-				})
-			})
-			.max_by(|a, b| {
-				let (_, (year_a, month_a, patch_a)) = a;
-				let (_, (year_b, month_b, patch_b)) = b;
-				// Compare by year, then by month, then by patch number
-				year_a
-					.cmp(year_b)
-					.then_with(|| month_a.cmp(month_b))
-					.then_with(|| patch_a.cmp(patch_b))
-			})
-			.map(|(tag_str, _)| tag_str.to_string())
-	}
-
-	/// Parse the versioning release tags.
-	fn parse_version_format(tags: Vec<&str>) -> Option<String> {
-		// Regex for polkadot-vmajor.minor.patch format
-		let version_reg = Regex::new(r"v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-rc\d+)?")
-			.expect("Valid regex");
-		tags.into_iter()
-			.filter_map(|tag| {
-				// Skip the pre-release label
-				if tag.contains("-rc") {
-					return None;
-				}
-				version_reg.captures(tag).and_then(|v| {
-					let major = v.name("major")?.as_str().parse::<u32>().ok()?;
-					let minor = v.name("minor")?.as_str().parse::<u32>().ok()?;
-					let patch = v.name("patch")?.as_str().parse::<u32>().ok()?;
-					Some((tag, (major, minor, patch)))
-				})
-			})
-			.max_by_key(|&(_, version)| version)
-			.map(|(tag_str, _)| tag_str.to_string())
+		parse_latest_tag(tags.iter().flatten().collect::<Vec<_>>())
 	}
 
 	/// Init a new git repository.
@@ -542,57 +477,6 @@ mod tests {
 			),
 			"git@github.com:paritytech/frontier-parachain-template.git"
 		);
-	}
-
-	#[test]
-	fn parse_latest_tag_works() {
-		let mut tags = vec![];
-		assert_eq!(Git::parse_latest_tag(tags), None);
-		tags = vec![
-			"polkadot-stable2407",
-			"polkadot-stable2407-1",
-			"polkadot-v1.10.0",
-			"polkadot-v1.11.0",
-			"polkadot-v1.12.0",
-			"polkadot-v1.7.0",
-			"polkadot-v1.8.0",
-			"polkadot-v1.9.0",
-			"v1.15.1-rc2",
-		];
-		assert_eq!(Git::parse_latest_tag(tags), Some("polkadot-stable2407-1".to_string()));
-	}
-
-	#[test]
-	fn parse_stable_format_works() {
-		let mut tags = vec![];
-		assert_eq!(Git::parse_stable_format(tags), None);
-		tags = vec!["polkadot-stable2407", "polkadot-stable2408"];
-		assert_eq!(Git::parse_stable_format(tags), Some("polkadot-stable2408".to_string()));
-		tags = vec!["polkadot-stable2407", "polkadot-stable2501"];
-		assert_eq!(Git::parse_stable_format(tags), Some("polkadot-stable2501".to_string()));
-		// Skip the pre-release label
-		tags = vec!["polkadot-stable2407", "polkadot-stable2407-1", "polkadot-stable2407-1-rc1"];
-		assert_eq!(Git::parse_stable_format(tags), Some("polkadot-stable2407-1".to_string()));
-	}
-
-	#[test]
-	fn parse_version_format_works() {
-		let mut tags: Vec<&str> = vec![];
-		assert_eq!(Git::parse_version_format(tags), None);
-		tags = vec![
-			"polkadot-v1.10.0",
-			"polkadot-v1.11.0",
-			"polkadot-v1.12.0",
-			"polkadot-v1.7.0",
-			"polkadot-v1.8.0",
-			"polkadot-v1.9.0",
-		];
-		assert_eq!(Git::parse_version_format(tags), Some("polkadot-v1.12.0".to_string()));
-		tags = vec!["v1.0.0", "v2.0.0", "v3.0.0"];
-		assert_eq!(Git::parse_version_format(tags), Some("v3.0.0".to_string()));
-		// Skip the pre-release label
-		tags = vec!["polkadot-v1.12.0", "v1.15.1-rc2"];
-		assert_eq!(Git::parse_version_format(tags), Some("polkadot-v1.12.0".to_string()));
 	}
 
 	mod repository {

--- a/crates/pop-common/src/git.rs
+++ b/crates/pop-common/src/git.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::{errors::Error, helpers::parse_latest_tag, APP_USER_AGENT};
+use crate::{errors::Error, polkadot_sdk::parse_latest_tag, APP_USER_AGENT};
 use anyhow::Result;
 use git2::{
 	build::RepoBuilder, FetchOptions, IndexAddOption, RemoteCallbacks, Repository as GitRepository,
@@ -60,8 +60,9 @@ impl Git {
 	) -> Result<Option<String>> {
 		let repo = match GitRepository::clone(url, target) {
 			Ok(repo) => repo,
-			Err(_e) =>
-				Self::ssh_clone_and_degit(url::Url::parse(url).map_err(Error::from)?, target)?,
+			Err(_e) => {
+				Self::ssh_clone_and_degit(url::Url::parse(url).map_err(Error::from)?, target)?
+			},
 		};
 
 		if let Some(tag_version) = tag_version {

--- a/crates/pop-common/src/helpers.rs
+++ b/crates/pop-common/src/helpers.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use crate::Error;
+use regex::Regex;
 use std::{
 	collections::HashMap,
 	fs,
@@ -53,6 +54,70 @@ pub fn prefix_with_current_dir_if_needed(path: PathBuf) -> PathBuf {
 		}
 	}
 	path
+}
+
+/// Parses a list of tags to identify the latest one, prioritizing tags in the stable format
+/// first.
+pub fn parse_latest_tag(tags: Vec<&str>) -> Option<String> {
+	match parse_stable_format(tags.clone()) {
+		Some(last_stable_tag) => Some(last_stable_tag),
+		None => parse_version_format(tags),
+	}
+}
+
+/// Parse the stable release tags.
+fn parse_stable_format(tags: Vec<&str>) -> Option<String> {
+	// Regex for polkadot-stableYYMM and polkadot-stableYYMM-X
+	let stable_reg = Regex::new(
+		r"(polkadot-(parachain-)?)?stable(?P<year>\d{2})(?P<month>\d{2})(-(?P<patch>\d+))?(-rc\d+)?",
+	)
+	.expect("Valid regex");
+	tags.into_iter()
+		.filter_map(|tag| {
+			// Skip the pre-release label
+			if tag.contains("-rc") {
+				return None;
+			}
+			stable_reg.captures(tag).and_then(|v| {
+				let year = v.name("year")?.as_str().parse::<u32>().ok()?;
+				let month = v.name("month")?.as_str().parse::<u32>().ok()?;
+				let patch =
+					v.name("patch").and_then(|m| m.as_str().parse::<u32>().ok()).unwrap_or(0);
+				Some((tag, (year, month, patch)))
+			})
+		})
+		.max_by(|a, b| {
+			let (_, (year_a, month_a, patch_a)) = a;
+			let (_, (year_b, month_b, patch_b)) = b;
+			// Compare by year, then by month, then by patch number
+			year_a
+				.cmp(year_b)
+				.then_with(|| month_a.cmp(month_b))
+				.then_with(|| patch_a.cmp(patch_b))
+		})
+		.map(|(tag_str, _)| tag_str.to_string())
+}
+
+/// Parse the versioning release tags.
+fn parse_version_format(tags: Vec<&str>) -> Option<String> {
+	// Regex for polkadot-vmajor.minor.patch format
+	let version_reg = Regex::new(r"v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-rc\d+)?")
+		.expect("Valid regex");
+	tags.into_iter()
+		.filter_map(|tag| {
+			// Skip the pre-release label
+			if tag.contains("-rc") {
+				return None;
+			}
+			version_reg.captures(tag).and_then(|v| {
+				let major = v.name("major")?.as_str().parse::<u32>().ok()?;
+				let minor = v.name("minor")?.as_str().parse::<u32>().ok()?;
+				let patch = v.name("patch")?.as_str().parse::<u32>().ok()?;
+				Some((tag, (major, minor, patch)))
+			})
+		})
+		.max_by_key(|&(_, version)| version)
+		.map(|(tag_str, _)| tag_str.to_string())
 }
 
 #[cfg(test)]
@@ -115,5 +180,57 @@ mod tests {
 			PathBuf::from("/my/path/".to_string())
 		);
 		assert_eq!(prefix_with_current_dir_if_needed(empty_path), PathBuf::from("".to_string()));
+	}
+
+	#[test]
+	fn parse_latest_tag_works() {
+		let mut tags = vec![];
+		assert_eq!(parse_latest_tag(tags), None);
+		tags = vec![
+			"polkadot-stable2409",
+			"polkadot-stable2409-1",
+			"polkadot-stable2407",
+			"polkadot-v1.10.0",
+			"polkadot-v1.11.0",
+			"polkadot-v1.12.0",
+			"polkadot-v1.7.0",
+			"polkadot-v1.8.0",
+			"polkadot-v1.9.0",
+			"v1.15.1-rc2",
+		];
+		assert_eq!(parse_latest_tag(tags), Some("polkadot-stable2409-1".to_string()));
+	}
+
+	#[test]
+	fn parse_stable_format_works() {
+		let mut tags = vec![];
+		assert_eq!(parse_stable_format(tags), None);
+		tags = vec!["polkadot-stable2407", "polkadot-stable2408"];
+		assert_eq!(parse_stable_format(tags), Some("polkadot-stable2408".to_string()));
+		tags = vec!["polkadot-stable2407", "polkadot-stable2501"];
+		assert_eq!(parse_stable_format(tags), Some("polkadot-stable2501".to_string()));
+		// Skip the pre-release label
+		tags = vec!["polkadot-stable2407", "polkadot-stable2407-1", "polkadot-stable2407-1-rc1"];
+		assert_eq!(parse_stable_format(tags), Some("polkadot-stable2407-1".to_string()));
+	}
+
+	#[test]
+	fn parse_version_format_works() {
+		let mut tags: Vec<&str> = vec![];
+		assert_eq!(parse_version_format(tags), None);
+		tags = vec![
+			"polkadot-v1.10.0",
+			"polkadot-v1.11.0",
+			"polkadot-v1.12.0",
+			"polkadot-v1.7.0",
+			"polkadot-v1.8.0",
+			"polkadot-v1.9.0",
+		];
+		assert_eq!(parse_version_format(tags), Some("polkadot-v1.12.0".to_string()));
+		tags = vec!["v1.0.0", "v2.0.0", "v3.0.0"];
+		assert_eq!(parse_version_format(tags), Some("v3.0.0".to_string()));
+		// Skip the pre-release label
+		tags = vec!["polkadot-v1.12.0", "v1.15.1-rc2"];
+		assert_eq!(parse_version_format(tags), Some("polkadot-v1.12.0".to_string()));
 	}
 }

--- a/crates/pop-common/src/helpers.rs
+++ b/crates/pop-common/src/helpers.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use crate::Error;
-use regex::Regex;
 use std::{
 	collections::HashMap,
 	fs,
@@ -54,70 +53,6 @@ pub fn prefix_with_current_dir_if_needed(path: PathBuf) -> PathBuf {
 		}
 	}
 	path
-}
-
-/// Parses a list of tags to identify the latest one, prioritizing tags in the stable format
-/// first.
-pub fn parse_latest_tag(tags: Vec<&str>) -> Option<String> {
-	match parse_stable_format(tags.clone()) {
-		Some(last_stable_tag) => Some(last_stable_tag),
-		None => parse_version_format(tags),
-	}
-}
-
-/// Parse the stable release tags.
-fn parse_stable_format(tags: Vec<&str>) -> Option<String> {
-	// Regex for polkadot-stableYYMM and polkadot-stableYYMM-X
-	let stable_reg = Regex::new(
-		r"(polkadot-(parachain-)?)?stable(?P<year>\d{2})(?P<month>\d{2})(-(?P<patch>\d+))?(-rc\d+)?",
-	)
-	.expect("Valid regex");
-	tags.into_iter()
-		.filter_map(|tag| {
-			// Skip the pre-release label
-			if tag.contains("-rc") {
-				return None;
-			}
-			stable_reg.captures(tag).and_then(|v| {
-				let year = v.name("year")?.as_str().parse::<u32>().ok()?;
-				let month = v.name("month")?.as_str().parse::<u32>().ok()?;
-				let patch =
-					v.name("patch").and_then(|m| m.as_str().parse::<u32>().ok()).unwrap_or(0);
-				Some((tag, (year, month, patch)))
-			})
-		})
-		.max_by(|a, b| {
-			let (_, (year_a, month_a, patch_a)) = a;
-			let (_, (year_b, month_b, patch_b)) = b;
-			// Compare by year, then by month, then by patch number
-			year_a
-				.cmp(year_b)
-				.then_with(|| month_a.cmp(month_b))
-				.then_with(|| patch_a.cmp(patch_b))
-		})
-		.map(|(tag_str, _)| tag_str.to_string())
-}
-
-/// Parse the versioning release tags.
-fn parse_version_format(tags: Vec<&str>) -> Option<String> {
-	// Regex for polkadot-vmajor.minor.patch format
-	let version_reg = Regex::new(r"v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-rc\d+)?")
-		.expect("Valid regex");
-	tags.into_iter()
-		.filter_map(|tag| {
-			// Skip the pre-release label
-			if tag.contains("-rc") {
-				return None;
-			}
-			version_reg.captures(tag).and_then(|v| {
-				let major = v.name("major")?.as_str().parse::<u32>().ok()?;
-				let minor = v.name("minor")?.as_str().parse::<u32>().ok()?;
-				let patch = v.name("patch")?.as_str().parse::<u32>().ok()?;
-				Some((tag, (major, minor, patch)))
-			})
-		})
-		.max_by_key(|&(_, version)| version)
-		.map(|(tag_str, _)| tag_str.to_string())
 }
 
 #[cfg(test)]
@@ -180,57 +115,5 @@ mod tests {
 			PathBuf::from("/my/path/".to_string())
 		);
 		assert_eq!(prefix_with_current_dir_if_needed(empty_path), PathBuf::from("".to_string()));
-	}
-
-	#[test]
-	fn parse_latest_tag_works() {
-		let mut tags = vec![];
-		assert_eq!(parse_latest_tag(tags), None);
-		tags = vec![
-			"polkadot-stable2409",
-			"polkadot-stable2409-1",
-			"polkadot-stable2407",
-			"polkadot-v1.10.0",
-			"polkadot-v1.11.0",
-			"polkadot-v1.12.0",
-			"polkadot-v1.7.0",
-			"polkadot-v1.8.0",
-			"polkadot-v1.9.0",
-			"v1.15.1-rc2",
-		];
-		assert_eq!(parse_latest_tag(tags), Some("polkadot-stable2409-1".to_string()));
-	}
-
-	#[test]
-	fn parse_stable_format_works() {
-		let mut tags = vec![];
-		assert_eq!(parse_stable_format(tags), None);
-		tags = vec!["polkadot-stable2407", "polkadot-stable2408"];
-		assert_eq!(parse_stable_format(tags), Some("polkadot-stable2408".to_string()));
-		tags = vec!["polkadot-stable2407", "polkadot-stable2501"];
-		assert_eq!(parse_stable_format(tags), Some("polkadot-stable2501".to_string()));
-		// Skip the pre-release label
-		tags = vec!["polkadot-stable2407", "polkadot-stable2407-1", "polkadot-stable2407-1-rc1"];
-		assert_eq!(parse_stable_format(tags), Some("polkadot-stable2407-1".to_string()));
-	}
-
-	#[test]
-	fn parse_version_format_works() {
-		let mut tags: Vec<&str> = vec![];
-		assert_eq!(parse_version_format(tags), None);
-		tags = vec![
-			"polkadot-v1.10.0",
-			"polkadot-v1.11.0",
-			"polkadot-v1.12.0",
-			"polkadot-v1.7.0",
-			"polkadot-v1.8.0",
-			"polkadot-v1.9.0",
-		];
-		assert_eq!(parse_version_format(tags), Some("polkadot-v1.12.0".to_string()));
-		tags = vec!["v1.0.0", "v2.0.0", "v3.0.0"];
-		assert_eq!(parse_version_format(tags), Some("v3.0.0".to_string()));
-		// Skip the pre-release label
-		tags = vec!["polkadot-v1.12.0", "v1.15.1-rc2"];
-		assert_eq!(parse_version_format(tags), Some("polkadot-v1.12.0".to_string()));
 	}
 }

--- a/crates/pop-common/src/lib.rs
+++ b/crates/pop-common/src/lib.rs
@@ -36,18 +36,16 @@ pub fn target() -> Result<&'static str, Error> {
 	}
 
 	match ARCH {
-		"aarch64" => {
+		"aarch64" =>
 			return match OS {
 				"macos" => Ok("aarch64-apple-darwin"),
 				_ => Ok("aarch64-unknown-linux-gnu"),
-			}
-		},
-		"x86_64" | "x86" => {
+			},
+		"x86_64" | "x86" =>
 			return match OS {
 				"macos" => Ok("x86_64-apple-darwin"),
 				_ => Ok("x86_64-unknown-linux-gnu"),
-			}
-		},
+			},
 		&_ => {},
 	}
 	Err(Error::UnsupportedPlatform { arch: ARCH, os: OS })

--- a/crates/pop-common/src/lib.rs
+++ b/crates/pop-common/src/lib.rs
@@ -3,6 +3,7 @@ pub mod errors;
 pub mod git;
 pub mod helpers;
 pub mod manifest;
+pub mod polkadot_sdk;
 pub mod sourcing;
 pub mod templates;
 
@@ -35,16 +36,18 @@ pub fn target() -> Result<&'static str, Error> {
 	}
 
 	match ARCH {
-		"aarch64" =>
+		"aarch64" => {
 			return match OS {
 				"macos" => Ok("aarch64-apple-darwin"),
 				_ => Ok("aarch64-unknown-linux-gnu"),
-			},
-		"x86_64" | "x86" =>
+			}
+		},
+		"x86_64" | "x86" => {
 			return match OS {
 				"macos" => Ok("x86_64-apple-darwin"),
 				_ => Ok("x86_64-unknown-linux-gnu"),
-			},
+			}
+		},
 		&_ => {},
 	}
 	Err(Error::UnsupportedPlatform { arch: ARCH, os: OS })

--- a/crates/pop-common/src/polkadot_sdk.rs
+++ b/crates/pop-common/src/polkadot_sdk.rs
@@ -22,7 +22,7 @@ fn parse_latest_stable(tags: &[&str]) -> Option<String> {
 		r"(polkadot-(parachain-)?)?stable(?P<year>\d{2})(?P<month>\d{2})(-(?P<patch>\d+))?(-rc\d+)?",
 	)
 	.expect("Valid regex");
-	tags.into_iter()
+	tags.iter()
 		.filter_map(|tag| {
 			// Skip the pre-release label
 			if tag.contains("-rc") {
@@ -53,7 +53,7 @@ fn parse_version_format(tags: &[&str]) -> Option<String> {
 	// Regex for polkadot-vmajor.minor.patch format
 	let version_reg = Regex::new(r"v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-rc\d+)?")
 		.expect("Valid regex");
-	tags.into_iter()
+	tags.iter()
 		.filter_map(|tag| {
 			// Skip the pre-release label
 			if tag.contains("-rc") {

--- a/crates/pop-common/src/polkadot_sdk.rs
+++ b/crates/pop-common/src/polkadot_sdk.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-3.0
+
+//! Parses and identifies the latest version tags for Polkadot SDK releases.
+
+use regex::Regex;
+
+/// Identifies the latest tag from a list of tags, prioritizing tags in a stable format.
+///
+/// # Arguments
+/// * `tags` - A vector of tags to parse and evaluate.
+pub fn parse_latest_tag(tags: Vec<&str>) -> Option<String> {
+	match parse_latest_stable(&tags) {
+		Some(last_stable_tag) => Some(last_stable_tag),
+		None => parse_version_format(&tags),
+	}
+}
+
+/// Retrieves the latest stable release ta
+fn parse_latest_stable(tags: &[&str]) -> Option<String> {
+	// Regex for polkadot-stableYYMM and polkadot-stableYYMM-X
+	let stable_reg = Regex::new(
+		r"(polkadot-(parachain-)?)?stable(?P<year>\d{2})(?P<month>\d{2})(-(?P<patch>\d+))?(-rc\d+)?",
+	)
+	.expect("Valid regex");
+	tags.into_iter()
+		.filter_map(|tag| {
+			// Skip the pre-release label
+			if tag.contains("-rc") {
+				return None;
+			}
+			stable_reg.captures(tag).and_then(|v| {
+				let year = v.name("year")?.as_str().parse::<u32>().ok()?;
+				let month = v.name("month")?.as_str().parse::<u32>().ok()?;
+				let patch =
+					v.name("patch").and_then(|m| m.as_str().parse::<u32>().ok()).unwrap_or(0);
+				Some((tag, (year, month, patch)))
+			})
+		})
+		.max_by(|a, b| {
+			let (_, (year_a, month_a, patch_a)) = a;
+			let (_, (year_b, month_b, patch_b)) = b;
+			// Compare by year, then by month, then by patch number
+			year_a
+				.cmp(year_b)
+				.then_with(|| month_a.cmp(month_b))
+				.then_with(|| patch_a.cmp(patch_b))
+		})
+		.map(|(tag_str, _)| tag_str.to_string())
+}
+
+/// Parse the versioning release tags.
+fn parse_version_format(tags: &[&str]) -> Option<String> {
+	// Regex for polkadot-vmajor.minor.patch format
+	let version_reg = Regex::new(r"v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-rc\d+)?")
+		.expect("Valid regex");
+	tags.into_iter()
+		.filter_map(|tag| {
+			// Skip the pre-release label
+			if tag.contains("-rc") {
+				return None;
+			}
+			version_reg.captures(tag).and_then(|v| {
+				let major = v.name("major")?.as_str().parse::<u32>().ok()?;
+				let minor = v.name("minor")?.as_str().parse::<u32>().ok()?;
+				let patch = v.name("patch")?.as_str().parse::<u32>().ok()?;
+				Some((tag, (major, minor, patch)))
+			})
+		})
+		.max_by_key(|&(_, version)| version)
+		.map(|(tag_str, _)| tag_str.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parse_latest_tag_works() {
+		let mut tags = vec![];
+		assert_eq!(parse_latest_tag(tags), None);
+		tags = vec![
+			"polkadot-stable2409",
+			"polkadot-stable2409-1",
+			"polkadot-stable2407",
+			"polkadot-v1.10.0",
+			"polkadot-v1.11.0",
+			"polkadot-v1.12.0",
+			"polkadot-v1.7.0",
+			"polkadot-v1.8.0",
+			"polkadot-v1.9.0",
+			"v1.15.1-rc2",
+		];
+		assert_eq!(parse_latest_tag(tags), Some("polkadot-stable2409-1".to_string()));
+	}
+
+	#[test]
+	fn parse_stable_format_works() {
+		let mut tags = vec![];
+		assert_eq!(parse_latest_stable(&tags), None);
+		tags = vec!["polkadot-stable2407", "polkadot-stable2408"];
+		assert_eq!(parse_latest_stable(&tags), Some("polkadot-stable2408".to_string()));
+		tags = vec!["polkadot-stable2407", "polkadot-stable2501"];
+		assert_eq!(parse_latest_stable(&tags), Some("polkadot-stable2501".to_string()));
+		// Skip the pre-release label
+		tags = vec!["polkadot-stable2407", "polkadot-stable2407-1", "polkadot-stable2407-1-rc1"];
+		assert_eq!(parse_latest_stable(&tags), Some("polkadot-stable2407-1".to_string()));
+	}
+
+	#[test]
+	fn parse_version_format_works() {
+		let mut tags: Vec<&str> = vec![];
+		assert_eq!(parse_version_format(&tags), None);
+		tags = vec![
+			"polkadot-v1.10.0",
+			"polkadot-v1.11.0",
+			"polkadot-v1.12.0",
+			"polkadot-v1.7.0",
+			"polkadot-v1.8.0",
+			"polkadot-v1.9.0",
+		];
+		assert_eq!(parse_version_format(&tags), Some("polkadot-v1.12.0".to_string()));
+		tags = vec!["v1.0.0", "v2.0.0", "v3.0.0"];
+		assert_eq!(parse_version_format(&tags), Some("v3.0.0".to_string()));
+		// Skip the pre-release label
+		tags = vec!["polkadot-v1.12.0", "v1.15.1-rc2"];
+		assert_eq!(parse_version_format(&tags), Some("polkadot-v1.12.0".to_string()));
+	}
+}

--- a/crates/pop-common/src/sourcing/binary.rs
+++ b/crates/pop-common/src/sourcing/binary.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use crate::{
-	helpers::parse_latest_tag,
+	polkadot_sdk::parse_latest_tag,
 	sourcing::{
 		from_local_package, Error,
 		GitHub::{ReleaseArchive, SourceCodeArchive},
@@ -45,12 +45,13 @@ impl Binary {
 	pub fn latest(&self) -> Option<&str> {
 		match self {
 			Self::Local { .. } => None,
-			Self::Source { source, .. } =>
+			Self::Source { source, .. } => {
 				if let GitHub(ReleaseArchive { latest, .. }) = source {
 					latest.as_deref()
 				} else {
 					None
-				},
+				}
+			},
 		}
 	}
 
@@ -115,8 +116,7 @@ impl Binary {
 				.unwrap_or_else(|| {
 					// Default to latest version
 					let versions = available.iter().map(|v| v.as_ref()).collect::<Vec<&str>>();
-					let latest = parse_latest_tag(versions);
-					latest
+					parse_latest_tag(versions)
 				}),
 		}
 	}
@@ -139,11 +139,13 @@ impl Binary {
 				None => Err(Error::MissingBinary(format!(
 					"The {path:?} binary cannot be sourced automatically."
 				))),
-				Some(manifest) =>
-					from_local_package(manifest, name, release, status, verbose).await,
+				Some(manifest) => {
+					from_local_package(manifest, name, release, status, verbose).await
+				},
 			},
-			Self::Source { source, cache, .. } =>
-				source.source(cache, release, status, verbose).await,
+			Self::Source { source, cache, .. } => {
+				source.source(cache, release, status, verbose).await
+			},
 		}
 	}
 

--- a/crates/pop-common/src/sourcing/binary.rs
+++ b/crates/pop-common/src/sourcing/binary.rs
@@ -45,13 +45,12 @@ impl Binary {
 	pub fn latest(&self) -> Option<&str> {
 		match self {
 			Self::Local { .. } => None,
-			Self::Source { source, .. } => {
+			Self::Source { source, .. } =>
 				if let GitHub(ReleaseArchive { latest, .. }) = source {
 					latest.as_deref()
 				} else {
 					None
-				}
-			},
+				},
 		}
 	}
 
@@ -139,13 +138,11 @@ impl Binary {
 				None => Err(Error::MissingBinary(format!(
 					"The {path:?} binary cannot be sourced automatically."
 				))),
-				Some(manifest) => {
-					from_local_package(manifest, name, release, status, verbose).await
-				},
+				Some(manifest) =>
+					from_local_package(manifest, name, release, status, verbose).await,
 			},
-			Self::Source { source, cache, .. } => {
-				source.source(cache, release, status, verbose).await
-			},
+			Self::Source { source, cache, .. } =>
+				source.source(cache, release, status, verbose).await,
 		}
 	}
 

--- a/crates/pop-parachains/src/up/chain_specs.rs
+++ b/crates/pop-parachains/src/up/chain_specs.rs
@@ -30,7 +30,7 @@ pub(super) enum Runtime {
 		Repository = "https://github.com/r0gue-io/paseo-runtimes",
 		Binary = "chain-spec-generator",
 		Chain = "paseo-local",
-		Fallback = "v1.2.4"
+		Fallback = "v1.2.6"
 	))]
 	Paseo,
 	/// Polkadot.

--- a/crates/pop-parachains/src/up/parachains.rs
+++ b/crates/pop-parachains/src/up/parachains.rs
@@ -30,7 +30,7 @@ pub(super) enum Parachain {
 		Repository = "https://github.com/r0gue-io/pop-node",
 		Binary = "pop-node",
 		Prerelease = "true",
-		Fallback = "v0.1.0-mainnet"
+		Fallback = "testnet-v0.4.1"
 	))]
 	Pop,
 }

--- a/crates/pop-parachains/src/up/parachains.rs
+++ b/crates/pop-parachains/src/up/parachains.rs
@@ -2,7 +2,7 @@
 
 use super::{chain_specs::chain_spec_generator, Binary};
 use pop_common::{
-	helpers::parse_latest_tag,
+	polkadot_sdk::parse_latest_tag,
 	sourcing::{
 		traits::{Source as _, *},
 		GitHub::ReleaseArchive,

--- a/crates/pop-parachains/src/up/parachains.rs
+++ b/crates/pop-parachains/src/up/parachains.rs
@@ -29,7 +29,7 @@ pub(super) enum Parachain {
 	#[strum(props(
 		Repository = "https://github.com/r0gue-io/pop-node",
 		Binary = "pop-node",
-		Prerelease = "true",
+		Prerelease = "false",
 		Fallback = "testnet-v0.4.1"
 	))]
 	Pop,
@@ -130,10 +130,7 @@ pub(super) async fn from(
 		let releases = para.releases().await?;
 		let tag = Binary::resolve_version(command, version, &releases, cache);
 		// Only set latest when caller has not explicitly specified a version to use
-		let latest = version
-			.is_none()
-			.then(|| parse_latest_tag(releases.iter().map(|s| s.as_str()).collect()))
-			.flatten();
+		let latest = version.is_none().then(|| releases.first().map(|v| v.to_string())).flatten();
 		let binary = Binary::Source {
 			name: para.binary().to_string(),
 			source: TryInto::try_into(para, tag, latest)?,

--- a/crates/pop-parachains/src/up/parachains.rs
+++ b/crates/pop-parachains/src/up/parachains.rs
@@ -30,7 +30,7 @@ pub(super) enum Parachain {
 		Repository = "https://github.com/r0gue-io/pop-node",
 		Binary = "pop-node",
 		Prerelease = "true",
-		Fallback = "v0.1.0-alpha2"
+		Fallback = "v0.1.0-mainnet"
 	))]
 	Pop,
 }

--- a/crates/pop-parachains/src/up/parachains.rs
+++ b/crates/pop-parachains/src/up/parachains.rs
@@ -91,7 +91,10 @@ pub(super) async fn system(
 		None => {
 			// Default to same version as relay chain when not explicitly specified
 			// Only set latest when caller has not explicitly specified a version to use
-			(Some(relay_chain_version.to_string()), para.releases().await?.into_iter().next())
+			(
+				Some(relay_chain_version.to_string()),
+				parse_latest_tag(para.releases().await?.iter().map(|s| s.as_str()).collect()),
+			)
 		},
 	};
 	let source = TryInto::try_into(para, tag, latest)?;

--- a/crates/pop-parachains/src/up/parachains.rs
+++ b/crates/pop-parachains/src/up/parachains.rs
@@ -2,6 +2,7 @@
 
 use super::{chain_specs::chain_spec_generator, Binary};
 use pop_common::{
+	helpers::parse_latest_tag,
 	sourcing::{
 		traits::{Source as _, *},
 		GitHub::ReleaseArchive,
@@ -126,7 +127,10 @@ pub(super) async fn from(
 		let releases = para.releases().await?;
 		let tag = Binary::resolve_version(command, version, &releases, cache);
 		// Only set latest when caller has not explicitly specified a version to use
-		let latest = version.is_none().then(|| releases.first().map(|v| v.to_string())).flatten();
+		let latest = version
+			.is_none()
+			.then(|| parse_latest_tag(releases.iter().map(|s| s.as_str()).collect()))
+			.flatten();
 		let binary = Binary::Source {
 			name: para.binary().to_string(),
 			source: TryInto::try_into(para, tag, latest)?,

--- a/crates/pop-parachains/src/up/relay.rs
+++ b/crates/pop-parachains/src/up/relay.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use super::chain_specs::chain_spec_generator;
+use pop_common::helpers::parse_latest_tag;
 pub use pop_common::{
 	git::GitHub,
 	sourcing::{
@@ -104,7 +105,10 @@ pub(super) async fn from(
 		let releases = relay.releases().await?;
 		let tag = Binary::resolve_version(name, version, &releases, cache);
 		// Only set latest when caller has not explicitly specified a version to use
-		let latest = version.is_none().then(|| releases.first().map(|v| v.to_string())).flatten();
+		let latest = version
+			.is_none()
+			.then(|| parse_latest_tag(releases.iter().map(|s| s.as_str()).collect()))
+			.flatten();
 		let binary = Binary::Source {
 			name: name.to_string(),
 			source: TryInto::try_into(&relay, tag, latest)?,

--- a/crates/pop-parachains/src/up/relay.rs
+++ b/crates/pop-parachains/src/up/relay.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use super::chain_specs::chain_spec_generator;
-use pop_common::helpers::parse_latest_tag;
 pub use pop_common::{
 	git::GitHub,
+	polkadot_sdk::parse_latest_tag,
 	sourcing::{
 		traits::{Source as _, *},
 		Binary,


### PR DESCRIPTION
This PR addresses the sorting issue identified in: https://github.com/r0gue-io/pop-cli/issues/325 where versioned tags were prioritized over `stable2409` in the `pop up parachain` process.

### Changes
- Updated the logic to use this improved sorting approach for fetching both relay and parachain binaries.
- Moved the parse_latest_tag method, which identifies the latest version by prioritizing stable-format tags, into a helper module. It was used to fetch templates, now is used for fetching relay and parachain binaries too.