### PR TITLE
fix: templates errors

### DIFF
--- a/crates/pop-contracts/src/new.rs
+++ b/crates/pop-contracts/src/new.rs
@@ -95,18 +95,18 @@ pub fn rename_contract(name: &str, path: PathBuf, template: &Contract) -> Result
 	// Replace name in the lib.rs file.
 	file_path = path.join("lib.rs");
 	let name_in_camel_case = name.to_upper_camel_case();
-	let mut replacements_in_contract = HashMap::new();
-	replacements_in_contract.insert(template_name.as_str(), name);
-	replacements_in_contract.insert(template.name(), &name_in_camel_case);
-	replace_in_file(file_path, replacements_in_contract)?;
+	replace_in_file(
+		file_path,
+		HashMap::from([(template_name.as_str(), name), (template.name(), &name_in_camel_case)]),
+	)?;
 	// Replace name in the e2e_tests.rs file if exists.
-	if path.join("e2e_tests.rs").exists() {
-		file_path = path.join("e2e_tests.rs");
-		let name_in_camel_case = name.to_upper_camel_case();
-		let mut replacements_in_contract = HashMap::new();
-		replacements_in_contract.insert(template_name.as_str(), name);
-		replacements_in_contract.insert(template.name(), &name_in_camel_case);
-		replace_in_file(file_path, replacements_in_contract)?;
+	let e2e_tests = path.join("e2e_tests.rs");
+	if e2e_tests.exists() {
+		let name_in_camel_case = format!("\"{}\"", name.to_upper_camel_case());
+		replace_in_file(
+			e2e_tests,
+			HashMap::from([(template_name.as_str(), name), (template.name(), &name_in_camel_case)]),
+		)?;
 	}
 	Ok(())
 }

--- a/crates/pop-contracts/src/templates.rs
+++ b/crates/pop-contracts/src/templates.rs
@@ -104,7 +104,7 @@ pub enum Contract {
 		serialize = "PSP34",
 		message = "Psp34",
 		detailed_message = "The implementation of the PSP34 standard in ink!",
-		props(Type = "PSP", Repository = "https://github.com/Cardinal-Cryptography/PSP34")
+		props(Type = "PSP", Repository = "https://github.com/r0gue-io/PSP34")
 	)]
 	PSP34,
 	/// Domain name service example implemented in ink!
@@ -162,7 +162,7 @@ mod tests {
 			("erc721".to_string(), "https://github.com/use-ink/ink-examples"),
 			("erc1155".to_string(), "https://github.com/use-ink/ink-examples"),
 			("PSP22".to_string(), "https://github.com/Cardinal-Cryptography/PSP22"),
-			("PSP34".to_string(), "https://github.com/Cardinal-Cryptography/PSP34"),
+			("PSP34".to_string(), "https://github.com/r0gue-io/PSP34"),
 			("dns".to_string(), "https://github.com/use-ink/ink-examples"),
 			("cross-contract-calls".to_string(), "https://github.com/use-ink/ink-examples"),
 			("multisig".to_string(), "https://github.com/use-ink/ink-examples"),


### PR DESCRIPTION
Closes https://github.com/r0gue-io/pop-cli/issues/323. For the contract_template's `cross-contract-calls`, it was necessary to rename `e2e_tests.rs` to match the user-defined input name. Without this adjustment, the e2e tests would fail due to the file not being correctly recognized.

Closes https://github.com/r0gue-io/pop-cli/issues/321 using the PSP34 managed by R0gue:  https://github.com/r0gue-io/PSP34