### PR TITLE
fix: improve contract experience

### DIFF
--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -224,12 +224,36 @@ impl UpContractCommand {
 		if !self.dry_run {
 			let spinner = spinner();
 			spinner.start("Uploading and instantiating the contract...");
-			let contract_address =
-				instantiate_smart_contract(instantiate_exec, weight_limit).await?;
+			let contract_info = instantiate_smart_contract(instantiate_exec, weight_limit).await?;
 			spinner.stop(format!(
-				"Contract deployed and instantiated: The Contract Address is {:?}",
-				contract_address
+				"Contract deployed and instantiated:\n{}",
+				style(format!(
+					"{}\n{}",
+					style(format!(
+						"{} The Contract Address is {:?}",
+						console::Emoji("●", ">"),
+						contract_info.address
+					))
+					.dim()
+					.to_string(),
+					contract_info
+						.code_hash
+						.map(|hash| style(format!(
+							"{} The Contract Code Hash is {:?}",
+							console::Emoji("●", ">"),
+							hash
+						))
+						.dim()
+						.to_string())
+						.unwrap_or_default(),
+				))
+				.dim()
 			));
+			// spinner.stop(format!(
+			// 	"Contract deployed and instantiated:\nThe Contract Address is {:?}\nThe Contract
+			// Code Hash is {:?}", 	contract_info.address,
+			// 	contract_info.code_hash
+			// ));
 			Self::terminate_node(process)?;
 			Cli.outro(COMPLETE)?;
 		}

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -230,16 +230,15 @@ impl UpContractCommand {
 				style(format!(
 					"{}\n{}",
 					style(format!(
-						"{} The Contract Address is {:?}",
+						"{} The contract address is {:?}",
 						console::Emoji("●", ">"),
 						contract_info.address
 					))
-					.dim()
-					.to_string(),
+					.dim(),
 					contract_info
 						.code_hash
 						.map(|hash| style(format!(
-							"{} The Contract Code Hash is {:?}",
+							"{} The contract code hash is {:?}",
 							console::Emoji("●", ">"),
 							hash
 						))

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -249,11 +249,6 @@ impl UpContractCommand {
 				))
 				.dim()
 			));
-			// spinner.stop(format!(
-			// 	"Contract deployed and instantiated:\nThe Contract Address is {:?}\nThe Contract
-			// Code Hash is {:?}", 	contract_info.address,
-			// 	contract_info.code_hash
-			// ));
 			Self::terminate_node(process)?;
 			Cli.outro(COMPLETE)?;
 		}
@@ -349,8 +344,8 @@ pub fn has_contract_been_built(path: Option<&Path>) -> bool {
 		Err(_) => return false,
 	};
 	let contract_name = manifest.package().name();
-	project_path.join("target/ink").exists() &&
-		project_path.join(format!("target/ink/{}.contract", contract_name)).exists()
+	project_path.join("target/ink").exists()
+		&& project_path.join(format!("target/ink/{}.contract", contract_name)).exists()
 }
 
 #[cfg(test)]

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -344,8 +344,8 @@ pub fn has_contract_been_built(path: Option<&Path>) -> bool {
 		Err(_) => return false,
 	};
 	let contract_name = manifest.package().name();
-	project_path.join("target/ink").exists()
-		&& project_path.join(format!("target/ink/{}.contract", contract_name)).exists()
+	project_path.join("target/ink").exists() &&
+		project_path.join(format!("target/ink/{}.contract", contract_name)).exists()
 }
 
 #[cfg(test)]

--- a/crates/pop-cli/tests/contract.rs
+++ b/crates/pop-cli/tests/contract.rs
@@ -86,7 +86,7 @@ async fn contract_lifecycle() -> Result<()> {
 	})
 	.await?;
 	let weight_limit = dry_run_gas_estimate_instantiate(&instantiate_exec).await?;
-	let contract_address = instantiate_smart_contract(instantiate_exec, weight_limit).await?;
+	let contract_info = instantiate_smart_contract(instantiate_exec, weight_limit).await?;
 	// Call contract (only query)
 	// pop call contract --contract $INSTANTIATED_CONTRACT_ADDRESS --message get --suri //Alice
 	Command::cargo_bin("pop")
@@ -96,7 +96,7 @@ async fn contract_lifecycle() -> Result<()> {
 			"call",
 			"contract",
 			"--contract",
-			&contract_address,
+			&contract_info.address,
 			"--message",
 			"get",
 			"--suri",
@@ -114,7 +114,7 @@ async fn contract_lifecycle() -> Result<()> {
 			"call",
 			"contract",
 			"--contract",
-			&contract_address,
+			&contract_info.address,
 			"--message",
 			"flip",
 			"--suri",

--- a/crates/pop-contracts/src/call.rs
+++ b/crates/pop-contracts/src/call.rs
@@ -326,11 +326,11 @@ mod tests {
 		})
 		.await?;
 		let weight = dry_run_gas_estimate_instantiate(&instantiate_exec).await?;
-		let address = instantiate_smart_contract(instantiate_exec, weight).await?;
+		let contract_info = instantiate_smart_contract(instantiate_exec, weight).await?;
 		// Test querying a value.
 		let query_exec = set_up_call(CallOpts {
 			path: Some(temp_dir.path().join("testing")),
-			contract: address.clone(),
+			contract: contract_info.address.clone(),
 			message: "get".to_string(),
 			args: [].to_vec(),
 			value: "0".to_string(),
@@ -346,7 +346,7 @@ mod tests {
 		// Test extrinsic execution by flipping the value.
 		let call_exec = set_up_call(CallOpts {
 			path: Some(temp_dir.path().join("testing")),
-			contract: address,
+			contract: contract_info.address,
 			message: "flip".to_string(),
 			args: [].to_vec(),
 			value: "0".to_string(),

--- a/crates/pop-contracts/src/node/mod.rs
+++ b/crates/pop-contracts/src/node/mod.rs
@@ -120,7 +120,7 @@ pub async fn run_contracts_node(
 	output: Option<&File>,
 ) -> Result<Child, Error> {
 	let mut command = Command::new(binary_path);
-
+	command.arg("-lerror,runtime::contracts=debug");
 	if let Some(output) = output {
 		command.stdout(Stdio::from(output.try_clone()?));
 		command.stderr(Stdio::from(output.try_clone()?));

--- a/crates/pop-contracts/src/node/mod.rs
+++ b/crates/pop-contracts/src/node/mod.rs
@@ -120,7 +120,7 @@ pub async fn run_contracts_node(
 	output: Option<&File>,
 ) -> Result<Child, Error> {
 	let mut command = Command::new(binary_path);
-	command.arg("-lerror,runtime::contracts=debug");
+	command.arg("-linfo,runtime::contracts=debug");
 	if let Some(output) = output {
 		command.stdout(Stdio::from(output.try_clone()?));
 		command.stderr(Stdio::from(output.try_clone()?));

--- a/crates/pop-contracts/src/up.rs
+++ b/crates/pop-contracts/src/up.rs
@@ -157,8 +157,11 @@ pub async fn dry_run_upload(
 	}
 }
 
+///Type to represent information about a deployed smart contract.
 pub struct ContractInfo {
+	/// The on-chain address of the deployed contract.
 	pub address: String,
+	/// The hash of the contract's code
 	pub code_hash: Option<String>,
 }
 
@@ -177,11 +180,8 @@ pub async fn instantiate_smart_contract(
 		.await
 		.map_err(|error_variant| Error::InstantiateContractError(format!("{:?}", error_variant)))?;
 	// If is upload + instantiate, return the code hash.
-	let hash = if let Some(code_hash) = instantiate_result.code_hash {
-		Some(format!("{:?}", code_hash))
-	} else {
-		None
-	};
+	let hash = instantiate_result.code_hash.map(|code_hash| format!("{:?}", code_hash));
+
 	Ok(ContractInfo { address: instantiate_result.contract_address.to_string(), code_hash: hash })
 }
 

--- a/crates/pop-contracts/src/up.rs
+++ b/crates/pop-contracts/src/up.rs
@@ -157,7 +157,7 @@ pub async fn dry_run_upload(
 	}
 }
 
-///Type to represent information about a deployed smart contract.
+/// Type to represent information about a deployed smart contract.
 pub struct ContractInfo {
 	/// The on-chain address of the deployed contract.
 	pub address: String,

--- a/crates/pop-contracts/src/up.rs
+++ b/crates/pop-contracts/src/up.rs
@@ -157,6 +157,11 @@ pub async fn dry_run_upload(
 	}
 }
 
+pub struct ContractInfo {
+	pub address: String,
+	pub code_hash: Option<String>,
+}
+
 /// Instantiate a contract.
 ///
 /// # Arguments
@@ -166,12 +171,18 @@ pub async fn dry_run_upload(
 pub async fn instantiate_smart_contract(
 	instantiate_exec: InstantiateExec<DefaultConfig, DefaultEnvironment, Keypair>,
 	gas_limit: Weight,
-) -> anyhow::Result<String, Error> {
+) -> anyhow::Result<ContractInfo, Error> {
 	let instantiate_result = instantiate_exec
 		.instantiate(Some(gas_limit))
 		.await
 		.map_err(|error_variant| Error::InstantiateContractError(format!("{:?}", error_variant)))?;
-	Ok(instantiate_result.contract_address.to_string())
+	// If is upload + instantiate, return the code hash.
+	let hash = if let Some(code_hash) = instantiate_result.code_hash {
+		Some(format!("{:?}", code_hash))
+	} else {
+		None
+	};
+	Ok(ContractInfo { address: instantiate_result.contract_address.to_string(), code_hash: hash })
 }
 
 /// Upload a contract.
@@ -391,8 +402,9 @@ mod tests {
 		assert!(weight.ref_time() > 0);
 		assert!(weight.proof_size() > 0);
 		// Instantiate smart contract
-		let address = instantiate_smart_contract(instantiate_exec, weight).await?;
-		assert!(address.starts_with("5"));
+		let contract_info = instantiate_smart_contract(instantiate_exec, weight).await?;
+		assert!(contract_info.address.starts_with("5"));
+		assert!(contract_info.code_hash.is_none());
 		// Stop the process contracts-node
 		Command::new("kill")
 			.args(["-s", "TERM", &process.id().to_string()])


### PR DESCRIPTION
- [x] Partially addresses https://github.com/r0gue-io/pop-cli/issues/290. The `code_hash` is now displayed when running `pop up contract` for both upload only (`-u`) and upload + instantiate scenarios.

For instantiating an already uploaded contract, `code_hash` is currently not displayed, as retrieving it would require parsing events or querying the value on-chain.

- [X] Additionally, this PR closes https://github.com/r0gue-io/pop-cli/issues/291

It adds `-lerror,runtime::contracts=debug` when running `substrate-contracts-node` to allow debugging messages (the contract has to be build without --release flag).
