### PR TITLE
fix: build spec experience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4716,6 +4716,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "toml 0.5.11",
  "toml_edit 0.22.20",
  "url",
 ]
@@ -7315,6 +7316,15 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tar = "0.4.40"
 tempfile = "3.10"
 thiserror = "1.0.58"
 tokio-test = "0.4.4"
+toml = "0.5.0"
 
 # networking
 reqwest = { version = "0.12", features = ["json"] }

--- a/crates/pop-cli/src/cli.rs
+++ b/crates/pop-cli/src/cli.rs
@@ -135,6 +135,7 @@ impl traits::Cli for Cli {
 
 /// A confirmation prompt using cliclack.
 struct Confirm(cliclack::Confirm);
+
 impl traits::Confirm for Confirm {
 	/// Sets the initially selected value.
 	fn initial_value(mut self, initial_value: bool) -> Self {
@@ -145,47 +146,11 @@ impl traits::Confirm for Confirm {
 	fn interact(&mut self) -> Result<bool> {
 		self.0.interact()
 	}
-	/// Sets the initially selected value.
-	fn initial_value(mut self, initial_value: bool) -> Self {
-		self.0 = self.0.initial_value(initial_value);
-		self
-	}
 }
 
 /// A input prompt using cliclack.
 struct Input(cliclack::Input);
-impl traits::Input for Input {
-	/// Sets the default value for the input.
-	fn default_input(mut self, value: &str) -> Self {
-		self.0 = self.0.default_input(value);
-		self
-	}
-	/// Starts the prompt interaction.
-	fn interact(&mut self) -> Result<String> {
-		self.0.interact()
-	}
-	/// Sets the placeholder (hint) text for the input.
-	fn placeholder(mut self, placeholder: &str) -> Self {
-		self.0 = self.0.placeholder(placeholder);
-		self
-	}
-	/// Sets whether the input is required.
-	fn required(mut self, required: bool) -> Self {
-		self.0 = self.0.required(required);
-		self
-	}
-	/// Sets a validation callback for the input that is called when the user submits.
-	fn validate(
-		mut self,
-		validator: impl Fn(&String) -> std::result::Result<(), &'static str> + 'static,
-	) -> Self {
-		self.0 = self.0.validate(validator);
-		self
-	}
-}
 
-/// A input prompt using cliclack.
-struct Input(cliclack::Input);
 impl traits::Input for Input {
 	/// Sets the default value for the input.
 	fn default_input(mut self, value: &str) -> Self {
@@ -242,22 +207,7 @@ impl<T: Clone + Eq> traits::MultiSelect<T> for MultiSelect<T> {
 struct Select<T: Clone + Eq>(cliclack::Select<T>);
 
 impl<T: Clone + Eq> traits::Select<T> for Select<T> {
-	/// Starts the prompt interaction.
-	fn interact(&mut self) -> Result<T> {
-		self.0.interact()
-	}
-
-	/// Adds an item to the selection prompt.
-	fn item(mut self, value: T, label: impl Display, hint: impl Display) -> Self {
-		self.0 = self.0.item(value, label, hint);
-		self
-	}
-}
-
-/// A select prompt using cliclack.
-struct Select<T: Clone + Eq>(cliclack::Select<T>);
-
-impl<T: Clone + Eq> traits::Select<T> for Select<T> {
+	/// Sets the initially selected value.
 	fn initial_value(mut self, initial_value: T) -> Self {
 		self.0 = self.0.initial_value(initial_value);
 		self
@@ -352,18 +302,6 @@ pub(crate) mod tests {
 		) -> Self {
 			self.select_expectation
 				.insert(0, (prompt.to_string(), required, collect, items, item));
-			self
-		}
-
-		pub(crate) fn expect_select<T>(
-			mut self,
-			prompt: impl Display,
-			required: Option<bool>,
-			collect: bool,
-			items: Option<Vec<(String, String)>>,
-			item: usize,
-		) -> Self {
-			self.select_expectation = Some((prompt.to_string(), required, collect, items, item));
 			self
 		}
 

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -30,7 +30,7 @@ pub(crate) struct BuildArgs {
 	#[arg(short = 'p', long)]
 	pub(crate) package: Option<String>,
 	/// For production, always build in release mode to exclude debug features.
-	#[clap(short = 'r', long, conflicts_with = "profile")]
+	#[clap(short, long, conflicts_with = "profile")]
 	pub(crate) release: bool,
 	/// Build profile [default: debug].
 	#[clap(long, value_enum)]
@@ -145,7 +145,7 @@ mod tests {
 		for package in [None, Some(name.to_string())] {
 			for release in [true, false] {
 				for profile in Profile::VARIANTS {
-					let profile = if release { Profile::Release } else { Profile::Debug };
+					let profile = if release { Profile::Release } else { profile.clone() };
 					let project = if package.is_some() { "package" } else { "project" };
 					let mut cli = MockCli::new()
 						.expect_intro(format!("Building your {project}"))

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -16,9 +16,9 @@ pub struct BuildParachainCommand {
 	/// The package to be built.
 	#[arg(short = 'p', long)]
 	pub(crate) package: Option<String>,
-	/// For production, always build in release mode to exclude debug features.
-	#[clap(short, long, default_value = "true")]
-	pub(crate) release: bool,
+	/// Build profile [default: debug].
+	#[clap(long, value_enum)]
+	pub(crate) profile: Option<Profile>,
 	/// Parachain ID to be used when generating the chain spec files.
 	#[arg(short = 'i', long = "id")]
 	pub(crate) id: Option<u32>,
@@ -41,12 +41,13 @@ impl BuildParachainCommand {
 		let project = if self.package.is_some() { "package" } else { "parachain" };
 		cli.intro(format!("Building your {project}"))?;
 
+		let profile = self.profile.unwrap_or(Profile::Debug);
 		// Show warning if specified as deprecated.
 		if !self.valid {
 			cli.warning("NOTE: this command is deprecated. Please use `pop build` (or simply `pop b`) in future...")?;
 			#[cfg(not(test))]
 			sleep(Duration::from_secs(3))
-		} else if !self.release {
+		} else if profile == Profile::Debug {
 			cli.warning("NOTE: this command now defaults to DEBUG builds. Please use `--release` (or simply `-r`) for a release build...")?;
 			#[cfg(not(test))]
 			sleep(Duration::from_secs(3))
@@ -55,9 +56,8 @@ impl BuildParachainCommand {
 		// Build parachain.
 		cli.warning("NOTE: this may take some time...")?;
 		let project_path = self.path.unwrap_or_else(|| PathBuf::from("./"));
-		let mode: Profile = self.release.into();
-		let binary = build_parachain(&project_path, self.package, &mode, None)?;
-		cli.info(format!("The {project} was built in {mode} mode."))?;
+		let binary = build_parachain(&project_path, self.package, &profile, None)?;
+		cli.info(format!("The {project} was built in {} mode.", profile))?;
 		cli.outro("Build completed successfully!")?;
 		let generated_files = [format!("Binary generated at: {}", binary.display())];
 		let generated_files: Vec<_> = generated_files
@@ -80,6 +80,8 @@ mod tests {
 	use cli::MockCli;
 	use duct::cmd;
 	use std::{fs, io::Write, path::Path};
+	use std::fs::write;
+	use strum::VariantArray;
 
 	// Function that generates a Cargo.toml inside node directory for testing.
 	fn generate_mock_node(temp_dir: &Path) -> anyhow::Result<()> {
@@ -101,38 +103,55 @@ mod tests {
 		Ok(())
 	}
 
+	fn add_production_profile(project: &Path) -> anyhow::Result<()> {
+		let root_toml_path = project.join("Cargo.toml");
+		let mut root_toml_content = fs::read_to_string(&root_toml_path)?;
+		root_toml_content.push_str(
+			r#"
+			[profile.production]
+			codegen-units = 1
+			inherits = "release"
+			lto = true
+			"#,
+		);
+		// Write the updated content back to the file
+		write(&root_toml_path, root_toml_content)?;
+		Ok(())
+	}
+
 	#[test]
 	fn build_works() -> anyhow::Result<()> {
 		let name = "hello_world";
 		let temp_dir = tempfile::tempdir()?;
 		let path = temp_dir.path();
+		let project_path = path.join(name);
 		cmd("cargo", ["new", name, "--bin"]).dir(&path).run()?;
-		generate_mock_node(&temp_dir.path().join(name))?;
+		add_production_profile(&project_path)?;
+		generate_mock_node(&project_path)?;
 
 		for package in [None, Some(name.to_string())] {
-			for release in [false, true] {
+			for profile in Profile::VARIANTS {
 				for valid in [false, true] {
 					let project = if package.is_some() { "package" } else { "parachain" };
-					let mode = if release { Profile::Release } else { Profile::Debug };
 					let mut cli = MockCli::new()
 						.expect_intro(format!("Building your {project}"))
 						.expect_warning("NOTE: this may take some time...")
-						.expect_info(format!("The {project} was built in {mode} mode."))
+						.expect_info(format!("The {project} was built in {profile} mode."))
 						.expect_outro("Build completed successfully!");
 
 					if !valid {
 						cli = cli.expect_warning("NOTE: this command is deprecated. Please use `pop build` (or simply `pop b`) in future...");
 					} else {
-						if !release {
+						if profile == &Profile::Debug {
 							cli = cli.expect_warning("NOTE: this command now defaults to DEBUG builds. Please use `--release` (or simply `-r`) for a release build...");
 						}
 					}
 
 					assert_eq!(
 						BuildParachainCommand {
-							path: Some(path.join(name)),
+							path: Some(project_path.clone()),
 							package: package.clone(),
-							release,
+							profile: Some(profile.clone()),
 							id: None,
 							valid,
 						}

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -79,8 +79,8 @@ mod tests {
 	use super::*;
 	use cli::MockCli;
 	use duct::cmd;
+	use pop_common::manifest::add_production_profile;
 	use std::{fs, io::Write, path::Path};
-	use std::fs::write;
 	use strum::VariantArray;
 
 	// Function that generates a Cargo.toml inside node directory for testing.
@@ -100,22 +100,6 @@ mod tests {
 			[dependencies]
 			"#
 		)?;
-		Ok(())
-	}
-
-	fn add_production_profile(project: &Path) -> anyhow::Result<()> {
-		let root_toml_path = project.join("Cargo.toml");
-		let mut root_toml_content = fs::read_to_string(&root_toml_path)?;
-		root_toml_content.push_str(
-			r#"
-			[profile.production]
-			codegen-units = 1
-			inherits = "release"
-			lto = true
-			"#,
-		);
-		// Write the updated content back to the file
-		write(&root_toml_path, root_toml_content)?;
 		Ok(())
 	}
 

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -206,8 +206,7 @@ impl BuildSpecCommand {
 			sleep(Duration::from_secs(3))
 		}
 
-		let spinner = cliclack::spinner();
-		spinner.start("Generating chain specification...");
+		cli.info("Generating chain specification...")?;
 
 		// Create output path if needed
 		let mut output_path = self.output_file.unwrap_or_else(|| PathBuf::from("./"));
@@ -241,7 +240,7 @@ impl BuildSpecCommand {
 		};
 
 		// Generate plain spec.
-		spinner.set_message("Generating plain chain specification...");
+		cli.info("Generating plain chain specification...")?;
 		let mut generated_files = vec![];
 		generate_plain_chain_spec(
 			&binary_path,
@@ -268,7 +267,7 @@ impl BuildSpecCommand {
 		chain_spec.to_file(&plain_chain_spec)?;
 
 		// Generate raw spec.
-		spinner.set_message("Generating raw chain specification...");
+		cli.info("Generating raw chain specification...")?;
 		let spec_name = plain_chain_spec
 			.file_name()
 			.and_then(|s| s.to_str())
@@ -284,7 +283,7 @@ impl BuildSpecCommand {
 
 		// Generate genesis artifacts.
 		if self.genesis_code {
-			spinner.set_message("Generating genesis code...");
+			cli.info("Generating genesis code...")?;
 			let wasm_file_name = format!("para-{}.wasm", para_id);
 			let wasm_file = export_wasm_file(&binary_path, &raw_chain_spec, &wasm_file_name)?;
 			generated_files
@@ -292,7 +291,7 @@ impl BuildSpecCommand {
 		}
 
 		if self.genesis_state {
-			spinner.set_message("Generating genesis state...");
+			cli.info("Generating genesis state...")?;
 			let genesis_file_name = format!("para-{}-genesis-state", para_id);
 			let genesis_state_file =
 				generate_genesis_state_file(&binary_path, &raw_chain_spec, &genesis_file_name)?;

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -9,7 +9,7 @@ use crate::{
 	style::style,
 };
 use clap::{Args, ValueEnum};
-use cliclack::{spinner};
+use cliclack::spinner;
 use pop_common::Profile;
 use pop_parachains::{
 	binary_path, build_parachain, export_wasm_file, generate_genesis_state_file,
@@ -536,7 +536,6 @@ fn ensure_binary_exists(
 }
 
 // Prepare the output path provided.
-
 fn prepare_output_path(output_path: impl AsRef<Path>) -> anyhow::Result<PathBuf> {
 	let mut output_path = output_path.as_ref().to_path_buf();
 	// Convert to string to check for trailing slash.
@@ -573,8 +572,6 @@ fn prepare_output_path(output_path: impl AsRef<Path>) -> anyhow::Result<PathBuf>
 	}
 	Ok(output_path)
 }
-
-
 
 #[cfg(test)]
 mod tests {
@@ -789,8 +786,9 @@ mod tests {
 			("existing_dir/", "existing_dir/chain-spec.json"),
 			("non_existing_dir", "non_existing_dir.json"),
 			("non_existing_dir/", "non_existing_dir/chain-spec.json"),
-			("some_file	", "some_file.json"),
+			("some_file", "some_file.json"),
 			("some_dir/some_file", "some_dir/some_file.json"),
+			("existing_dir/subdir/", "existing_dir/subdir/chain-spec.json"),
 		];
 		for (input_str, expected_str) in &test_cases {
 			let input_path = temp_dir_path.join(input_str);

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -12,11 +12,7 @@ use pop_parachains::{
 	binary_path, build_parachain, export_wasm_file, generate_genesis_state_file,
 	generate_plain_chain_spec, generate_raw_chain_spec, is_supported, ChainSpec,
 };
-use std::{
-	env::current_dir,
-	fs::create_dir_all,
-	path::{Path, PathBuf},
-};
+use std::{env::current_dir, fs::create_dir_all, path::PathBuf};
 #[cfg(not(test))]
 use std::{thread::sleep, time::Duration};
 use strum::{EnumMessage, VariantArray};
@@ -127,78 +123,283 @@ pub(crate) enum RelayChain {
 	PolkadotLocal,
 }
 
-#[derive(Args)]
+/// Command for generating a chain specification.
+#[derive(Args, Clone)]
 pub struct BuildSpecCommand {
 	/// File name for the resulting spec. If a path is given,
 	/// the necessary directories will be created
-	/// [default: ./chain-spec.json].
 	#[arg(short = 'o', long = "output")]
 	pub(crate) output_file: Option<PathBuf>,
 	/// This command builds the node if it has not been built already.
 	/// For production, always build in release mode to exclude debug features.
-	#[clap(short = 'r', long, default_value = "true")]
+	#[arg(short = 'r', long)]
 	pub(crate) release: bool,
 	/// Parachain ID to be used when generating the chain spec files.
-	#[arg(short = 'i', long = "id")]
+	#[arg(short = 'i', long)]
 	pub(crate) id: Option<u32>,
 	/// Whether to keep localhost as a bootnode.
-	#[clap(long)]
+	#[arg(long)]
 	pub(crate) default_bootnode: bool,
-	/// Type of the chain [default: development].
+	/// Type of the chain.
 	#[arg(short = 't', long = "type", value_enum)]
 	pub(crate) chain_type: Option<ChainType>,
-	/// Specify the chain specification. It can be one of the predefined ones (dev, local) or a
-	/// custom one.
-	#[arg(short = 'c', long = "chain", default_value = "dev")]
+	/// Specify the chain specification. It can be one of the predefined ones (e.g. dev, local or a
+	/// custom one) or the path to an existing chain spec.
+	#[arg(short = 'c', long = "chain")]
 	pub(crate) chain: Option<String>,
-	/// Relay chain this parachain will connect to [default: paseo-local].
+	/// Relay chain this parachain will connect to.
 	#[arg(long, value_enum)]
 	pub(crate) relay: Option<RelayChain>,
 	/// Protocol-id to use in the specification.
 	#[arg(long = "protocol-id")]
 	pub(crate) protocol_id: Option<String>,
-	/// Whether the genesis state file should be generated [default: true].
-	#[clap(long = "genesis-state", default_value = "true")]
+	/// Whether the genesis state file should be generated.
+	#[arg(long = "genesis-state")]
 	pub(crate) genesis_state: bool,
-	/// Whether the genesis code file should be generated [default: true].
-	#[clap(long = "genesis-code", default_value = "true")]
+	/// Whether the genesis code file should be generated.
+	#[arg(long = "genesis-code")]
 	pub(crate) genesis_code: bool,
 }
 
 impl BuildSpecCommand {
-	/// Executes the command.
+	/// Executes the build spec command.
 	pub(crate) async fn execute(self) -> anyhow::Result<&'static str> {
+		let mut cli = Cli;
 		// Checks for appchain project in `./`.
 		if is_supported(None)? {
-			// If para id has been provided we can build the spec
-			// otherwise, we need to guide the user.
-			let _ = match self.id {
-				Some(_) => self.build(&mut Cli),
-				None => {
-					let config = guide_user_to_generate_spec(self).await?;
-					config.build(&mut Cli)
-				},
-			};
-			Ok("spec")
+			let build_spec = self.complete_build_spec(&mut cli).await?;
+			build_spec.build(&mut cli)
 		} else {
-			Cli.intro("Building your chain spec")?;
-			Cli.outro_cancel(
+			cli.intro("Generate your chain spec")?;
+			cli.outro_cancel(
 				"🚫 Can't build a specification for target. Maybe not a chain project ?",
 			)?;
 			Ok("spec")
 		}
 	}
 
-	/// Builds a parachain spec.
-	///
-	/// # Arguments
-	/// * `cli` - The CLI implementation to be used.
-	fn build(self, cli: &mut impl cli::traits::Cli) -> anyhow::Result<&'static str> {
-		cli.intro("Building your chain spec")?;
+	/// Completes chain specification requirements by prompting for missing inputs, validating
+	/// provided values, and preparing a BuildSpec for generating chain spec files.
+	async fn complete_build_spec(
+		self,
+		cli: &mut impl cli::traits::Cli,
+	) -> anyhow::Result<BuildSpec> {
+		cli.intro("Generate your chain spec")?;
 
-		// Either a para id was already provided or user has been guided to provide one.
-		let para_id = self.id.unwrap_or(DEFAULT_PARA_ID);
-		// Notify user in case we need to build the parachain project.
+		let BuildSpecCommand {
+			output_file,
+			release,
+			id,
+			default_bootnode,
+			chain_type,
+			chain,
+			relay,
+			protocol_id,
+			genesis_state,
+			genesis_code,
+		} = self;
+
+		// Prompt for chain specification.
+		let chain = match chain {
+			Some(chain) => chain,
+			_ => {
+				input("Specify the chain specification. It can be one of the predefined ones (e.g. dev, local or a custom one) or the path to an existing chain spec.")
+					.placeholder("dev")
+					.default_input("dev")
+					.interact()?
+			},
+		};
+
+		// Check if the provided chain specification is a file.
+		let maybe_chain_spec_file = PathBuf::from(&chain);
+		let output_file = if maybe_chain_spec_file.exists() && maybe_chain_spec_file.is_file() {
+			if output_file.is_some() {
+				cli.warning("NOTE: If an existing chain spec file is provided it will be used for the output path.")?;
+			}
+			// Set the provided chain specification file as output file.
+			maybe_chain_spec_file
+		} else {
+			let output_file = match output_file {
+				Some(output) => output,
+				None => {
+					// Prompt for output file if not provided.
+					let default_output = format!("./{DEFAULT_SPEC_NAME}");
+					input("Name of the plain chain spec file. If a path is given, the necessary directories will be created:")
+						.placeholder(&default_output)
+						.default_input(&default_output)
+						.interact()?
+				},
+			};
+			prepare_output_path(output_file)?
+		};
+		// If chain specification file already exists, obtain values for defaults when prompting.
+		let chain_spec = ChainSpec::from(&output_file).ok();
+
+		// Prompt for para id if not provided.
+		let id = match id {
+			Some(id) => id,
+			None => {
+				let default_id = chain_spec
+					.as_ref()
+					.and_then(|cs| cs.get_parachain_id())
+					.unwrap_or(DEFAULT_PARA_ID as u64)
+					.to_string();
+				input("What parachain ID should be used?")
+					.placeholder(&default_id)
+					.default_input(&default_id)
+					.interact()?
+			},
+		};
+
+		// Prompt for chain type if not provided.
+		let chain_type = match chain_type {
+			Some(chain_type) => chain_type,
+			None => {
+				let mut prompt = cliclack::select("Choose the chain type: ".to_string());
+				let default = chain_spec
+					.as_ref()
+					.and_then(|cs| cs.get_chain_type())
+					.and_then(|r| ChainType::from_str(r, true).ok());
+				if let Some(chain_type) = default.as_ref() {
+					prompt = prompt.initial_value(chain_type);
+				}
+				for (i, chain_type) in ChainType::VARIANTS.iter().enumerate() {
+					if default.is_none() && i == 0 {
+						prompt = prompt.initial_value(chain_type);
+					}
+					prompt = prompt.item(
+						chain_type,
+						chain_type.get_message().unwrap_or(chain_type.as_ref()),
+						chain_type.get_detailed_message().unwrap_or_default(),
+					);
+				}
+				prompt.interact()?.clone()
+			},
+		};
+
+		// Prompt for relay chain if not provided.
+		let relay = match relay {
+			Some(relay) => relay,
+			None => {
+				let mut prompt = cliclack::select(
+					"Choose the relay chain your chain will be connecting to: ".to_string(),
+				);
+				let default = chain_spec
+					.as_ref()
+					.and_then(|cs| cs.get_relay_chain())
+					.and_then(|r| RelayChain::from_str(r, true).ok());
+				if let Some(relay) = default.as_ref() {
+					prompt = prompt.initial_value(relay);
+				}
+				for relay in RelayChain::VARIANTS {
+					prompt = prompt.item(
+						relay,
+						relay.get_message().unwrap_or(relay.as_ref()),
+						relay.get_detailed_message().unwrap_or_default(),
+					);
+				}
+				prompt.interact()?.clone()
+			},
+		};
+
+		// Prompt for default bootnode if not provided and chain type is Local or Live.
+		let default_bootnode = if !default_bootnode {
+			match chain_type {
+				ChainType::Development => true,
+				_ => confirm("Would you like to use local host as a bootnode ?".to_string())
+					.interact()?,
+			}
+		} else {
+			true
+		};
+
+		// Prompt for protocol-id if not provided.
+		let protocol_id = match protocol_id {
+			Some(protocol_id) => protocol_id,
+			None => {
+				let default = chain_spec
+					.as_ref()
+					.and_then(|cs| cs.get_protocol_id())
+					.unwrap_or(DEFAULT_PROTOCOL_ID)
+					.to_string();
+				input("Enter the protocol ID that will identify your network:")
+					.placeholder(&default)
+					.default_input(&default)
+					.interact()?
+			},
+		};
+
+		// Prompt for genesis state if not provided.
+		let genesis_state = if !genesis_state {
+			confirm("Should the genesis state file be generated ?".to_string())
+				.initial_value(true)
+				.interact()?
+		} else {
+			true
+		};
+
+		// Prompt for genesis code if not provided.
+		let genesis_code = if !genesis_code {
+			confirm("Should the genesis code file be generated ?".to_string())
+				.initial_value(true)
+				.interact()?
+		} else {
+			true
+		};
+
+		// Only prompt user for build profile if a live spec is being built on debug mode.
+		let release = if !release && matches!(chain_type, ChainType::Live) {
+			confirm("Using Debug profile to build a Live specification. Should Release be used instead ?")
+				.initial_value(true)
+				.interact()?
+		} else {
+			release
+		};
+
+		Ok(BuildSpec {
+			output_file,
+			release,
+			id,
+			default_bootnode,
+			chain_type,
+			chain,
+			relay,
+			protocol_id,
+			genesis_state,
+			genesis_code,
+		})
+	}
+}
+
+// Represents the configuration for building a chain specification.
+struct BuildSpec {
+	output_file: PathBuf,
+	release: bool,
+	id: u32,
+	default_bootnode: bool,
+	chain_type: ChainType,
+	chain: String,
+	relay: RelayChain,
+	protocol_id: String,
+	genesis_state: bool,
+	genesis_code: bool,
+}
+
+impl BuildSpec {
+	// Executes the process of generating the chain specification.
+	//
+	// This function generates plain and raw chain spec files based on the provided configuration,
+	// optionally including genesis state and runtime artifacts. If the node binary is missing,
+	// it triggers a build process.
+	fn build(&self, cli: &mut impl cli::traits::Cli) -> anyhow::Result<&'static str> {
+		cli.intro("Building your chain spec")?;
+		let spinner = spinner();
+		spinner.start("Generating chain specification...");
+		let mut generated_files = vec![];
+
+		// Ensure binary is built.
+		let mode: Profile = self.release.into();
+		let binary_path = ensure_binary_exists(cli, &mode)?;
 		if !self.release {
 			cli.warning(
 				"NOTE: this command defaults to DEBUG builds for development chain types. Please use `--release` (or simply `-r` for a release build...)",
@@ -206,78 +407,32 @@ impl BuildSpecCommand {
 			#[cfg(not(test))]
 			sleep(Duration::from_secs(3))
 		}
-		let spinner = spinner();
-		spinner.start("Generating chain specification...");
 
-		// Create output path if needed
-		let mut output_path = self.output_file.unwrap_or_else(|| PathBuf::from("./"));
-		let mut plain_chain_spec;
-		if output_path.is_dir() {
-			if !output_path.exists() {
-				// Generate the output path if needed
-				create_dir_all(&output_path)?;
-			}
-			plain_chain_spec = output_path.join(DEFAULT_SPEC_NAME);
-		} else {
-			plain_chain_spec = output_path.clone();
-			output_path.pop();
-			if !output_path.exists() {
-				// Generate the output path if needed
-				create_dir_all(&output_path)?;
-			}
-		}
-		plain_chain_spec.set_extension("json");
-
-		// Locate binary, if it doesn't exist trigger build.
-		let mode: Profile = self.release.into();
-		let cwd = current_dir().unwrap_or(PathBuf::from("./"));
-		let binary_path = match binary_path(&mode.target_directory(&cwd), &cwd.join("node")) {
-			Ok(binary_path) => binary_path,
-			_ => {
-				spinner.clear();
-				cli.info("Node was not found. The project will be built locally.".to_string())?;
-				cli.warning("NOTE: this may take some time...")?;
-				build_parachain(&cwd, None, &mode, None)?
-			},
-		};
-
-		// Generate plain spec.
-		spinner.set_message("Generating plain chain specification...");
-		let mut generated_files = vec![];
+		// Generate chain spec.
 		generate_plain_chain_spec(
 			&binary_path,
-			&plain_chain_spec,
+			&self.output_file,
 			self.default_bootnode,
-			self.chain.as_deref(),
+			&self.chain,
 		)?;
+		// Customize spec based on input.
+		self.customize()?;
 		generated_files.push(format!(
 			"Plain text chain specification file generated at: {}",
-			plain_chain_spec.display()
+			self.output_file.display()
 		));
-
-		// Customize spec based on input.
-		let mut chain_spec = ChainSpec::from(&plain_chain_spec)?;
-		chain_spec.replace_para_id(para_id)?;
-		let relay = self.relay.unwrap_or(RelayChain::PaseoLocal).to_string();
-		chain_spec.replace_relay_chain(&relay)?;
-		let chain_type = self.chain_type.unwrap_or(ChainType::Development).to_string();
-		chain_spec.replace_chain_type(&chain_type)?;
-		if self.protocol_id.is_some() {
-			let protocol_id = self.protocol_id.unwrap_or(DEFAULT_PROTOCOL_ID.to_string());
-			chain_spec.replace_protocol_id(&protocol_id)?;
-		}
-		chain_spec.to_file(&plain_chain_spec)?;
 
 		// Generate raw spec.
 		spinner.set_message("Generating raw chain specification...");
-		let spec_name = plain_chain_spec
+		let spec_name = self
+			.output_file
 			.file_name()
 			.and_then(|s| s.to_str())
 			.unwrap_or(DEFAULT_SPEC_NAME)
 			.trim_end_matches(".json");
 		let raw_spec_name = format!("{spec_name}-raw.json");
 		let raw_chain_spec =
-			generate_raw_chain_spec(&binary_path, &plain_chain_spec, &raw_spec_name)?;
+			generate_raw_chain_spec(&binary_path, &self.output_file, &raw_spec_name)?;
 		generated_files.push(format!(
 			"Raw chain specification file generated at: {}",
 			raw_chain_spec.display()
@@ -286,15 +441,14 @@ impl BuildSpecCommand {
 		// Generate genesis artifacts.
 		if self.genesis_code {
 			spinner.set_message("Generating genesis code...");
-			let wasm_file_name = format!("para-{}.wasm", para_id);
+			let wasm_file_name = format!("para-{}.wasm", self.id);
 			let wasm_file = export_wasm_file(&binary_path, &raw_chain_spec, &wasm_file_name)?;
 			generated_files
 				.push(format!("WebAssembly runtime file exported at: {}", wasm_file.display()));
 		}
-
 		if self.genesis_state {
 			spinner.set_message("Generating genesis state...");
-			let genesis_file_name = format!("para-{}-genesis-state", para_id);
+			let genesis_file_name = format!("para-{}-genesis-state", self.id);
 			let genesis_state_file =
 				generate_genesis_state_file(&binary_path, &raw_chain_spec, &genesis_file_name)?;
 			generated_files
@@ -302,7 +456,6 @@ impl BuildSpecCommand {
 		}
 
 		spinner.stop("Chain specification built successfully.");
-
 		let generated_files: Vec<_> = generated_files
 			.iter()
 			.map(|s| style(format!("{} {s}", console::Emoji("●", ">"))).dim().to_string())
@@ -312,162 +465,51 @@ impl BuildSpecCommand {
 			"Need help? Learn more at {}\n",
 			style("https://learn.onpop.io").magenta().underlined()
 		))?;
-
 		Ok("spec")
+	}
+
+	// Customize a chain specification.
+	fn customize(&self) -> anyhow::Result<()> {
+		let mut chain_spec = ChainSpec::from(&self.output_file)?;
+		chain_spec.replace_para_id(self.id)?;
+		chain_spec.replace_relay_chain(&self.relay.to_string())?;
+		chain_spec.replace_chain_type(&self.chain_type.to_string())?;
+		chain_spec.replace_protocol_id(&self.protocol_id)?;
+		chain_spec.to_file(&self.output_file)?;
+		Ok(())
 	}
 }
 
-/// Guide the user to generate their chain specification.
-async fn guide_user_to_generate_spec(args: BuildSpecCommand) -> anyhow::Result<BuildSpecCommand> {
-	Cli.intro("Generate your chain spec")?;
-
-	// Confirm output path
-	let default_output = format!("./{DEFAULT_SPEC_NAME}");
-	let output_file: String = input("Name of the plain chain spec file. If a path is given, the necessary directories will be created:")
-		.placeholder(&default_output)
-		.default_input(&default_output)
-		.interact()?;
-
-	// Check if specified chain spec already exists, allowing us to default values for prompts
-	let path = Path::new(&output_file);
-	let chain_spec =
-		(path.is_file() && path.exists()).then(|| ChainSpec::from(path).ok()).flatten();
-
-	// Prompt for chain id.
-	let default = chain_spec
-		.as_ref()
-		.and_then(|cs| cs.get_parachain_id())
-		.unwrap_or(DEFAULT_PARA_ID as u64)
-		.to_string();
-	let para_id: u32 = input("What parachain ID should be used?")
-		.placeholder(&default)
-		.default_input(&default)
-		.interact()?;
-
-	// Prompt for chain type.
-	// If relay is Kusama or Polkadot, then Live type is used and user is not prompted.
-	let mut prompt = cliclack::select("Choose the chain type: ".to_string());
-	let default = chain_spec
-		.as_ref()
-		.and_then(|cs| cs.get_chain_type())
-		.and_then(|r| ChainType::from_str(r, true).ok());
-	if let Some(chain_type) = default.as_ref() {
-		prompt = prompt.initial_value(chain_type);
+// Locate binary, if it doesn't exist trigger build.
+fn ensure_binary_exists(
+	cli: &mut impl cli::traits::Cli,
+	mode: &Profile,
+) -> anyhow::Result<PathBuf> {
+	let cwd = current_dir().unwrap_or(PathBuf::from("./"));
+	match binary_path(&mode.target_directory(&cwd), &cwd.join("node")) {
+		Ok(binary_path) => Ok(binary_path),
+		_ => {
+			cli.info("Node was not found. The project will be built locally.".to_string())?;
+			cli.warning("NOTE: this may take some time...")?;
+			build_parachain(&cwd, None, mode, None).map_err(|e| e.into())
+		},
 	}
-	for (i, chain_type) in ChainType::VARIANTS.iter().enumerate() {
-		if default.is_none() && i == 0 {
-			prompt = prompt.initial_value(chain_type);
+}
+
+// Prepare the output path provided.
+fn prepare_output_path(mut output_path: PathBuf) -> anyhow::Result<PathBuf> {
+	if output_path.is_dir() {
+		if !output_path.exists() {
+			create_dir_all(&output_path)?;
 		}
-		prompt = prompt.item(
-			chain_type,
-			chain_type.get_message().unwrap_or(chain_type.as_ref()),
-			chain_type.get_detailed_message().unwrap_or_default(),
-		);
+		output_path.push(DEFAULT_SPEC_NAME);
+	} else {
+		if let Some(parent_dir) = output_path.parent() {
+			if !parent_dir.exists() {
+				create_dir_all(&output_path)?;
+			}
+		}
 	}
-	let chain_type: ChainType = prompt.interact()?.clone();
-	// Prompt for chain
-	let chain: String = input("Specify the chain specification. It can be one of the predefined ones (dev, local) or a custom one.")
-		.placeholder("dev")
-		.default_input("dev")
-		.interact()?;
-
-	// Prompt for relay chain.
-	let mut prompt =
-		cliclack::select("Choose the relay chain your chain will be connecting to: ".to_string());
-	let default = chain_spec
-		.as_ref()
-		.and_then(|cs| cs.get_relay_chain())
-		.and_then(|r| RelayChain::from_str(r, true).ok());
-	if let Some(relay) = default.as_ref() {
-		prompt = prompt.initial_value(relay);
-	}
-	// Prompt relays chains based on the chain type
-	match chain_type {
-		ChainType::Live =>
-			for relay in RelayChain::VARIANTS {
-				if !matches!(
-					relay,
-					RelayChain::Westend |
-						RelayChain::Paseo | RelayChain::Kusama |
-						RelayChain::Polkadot
-				) {
-					continue;
-				} else {
-					prompt = prompt.item(
-						relay,
-						relay.get_message().unwrap_or(relay.as_ref()),
-						relay.get_detailed_message().unwrap_or_default(),
-					);
-				}
-			},
-		_ =>
-			for relay in RelayChain::VARIANTS {
-				if matches!(
-					relay,
-					RelayChain::Westend |
-						RelayChain::Paseo | RelayChain::Kusama |
-						RelayChain::Polkadot
-				) {
-					continue;
-				} else {
-					prompt = prompt.item(
-						relay,
-						relay.get_message().unwrap_or(relay.as_ref()),
-						relay.get_detailed_message().unwrap_or_default(),
-					);
-				}
-			},
-	}
-
-	let relay_chain = prompt.interact()?.clone();
-
-	// Prompt for default bootnode if chain type is Local or Live.
-	let default_bootnode = match chain_type {
-		ChainType::Development => true,
-		_ => confirm("Would you like to use local host as a bootnode ?".to_string()).interact()?,
-	};
-
-	// Prompt for protocol-id.
-	let default = chain_spec
-		.as_ref()
-		.and_then(|cs| cs.get_protocol_id())
-		.unwrap_or(DEFAULT_PROTOCOL_ID)
-		.to_string();
-	let protocol_id: String = input("Enter the protocol ID that will identify your network:")
-		.placeholder(&default)
-		.default_input(&default)
-		.interact()?;
-
-	// Prompt for genesis state
-	let genesis_state = confirm("Should the genesis state file be generated ?".to_string())
-		.initial_value(true)
-		.interact()?;
-
-	// Prompt for genesis code
-	let genesis_code = confirm("Should the genesis code file be generated ?".to_string())
-		.initial_value(true)
-		.interact()?;
-
-	// Only check user to check their profile selection if a live spec is being built on debug mode.
-	let profile =
-		if !args.release && matches!(chain_type, ChainType::Live) {
-			confirm("Using Debug profile to build a Live specification. Should Release be used instead ?")
-    		.initial_value(true)
-    		.interact()?
-		} else {
-			args.release
-		};
-
-	Ok(BuildSpecCommand {
-		output_file: Some(PathBuf::from(output_file)),
-		release: profile,
-		id: Some(para_id),
-		default_bootnode,
-		chain_type: Some(chain_type),
-		chain: Some(chain),
-		relay: Some(relay_chain),
-		protocol_id: Some(protocol_id),
-		genesis_state,
-		genesis_code,
-	})
+	output_path.set_extension("json");
+	Ok(output_path)
 }

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -139,7 +139,7 @@ pub struct BuildSpecCommand {
 	#[arg(short = 'o', long = "output")]
 	pub(crate) output_file: Option<PathBuf>,
 	// TODO: remove at release ...
-	/// [DEPRECATED] use `profile`.
+	/// [DEPRECATED] since v0.6.0, use `profile`.
 	#[arg(short = 'r', long, conflicts_with = "profile")]
 	pub(crate) release: bool,
 	/// Build profile for the binary to generate the chain specification.
@@ -534,8 +534,8 @@ impl BuildSpec {
 	fn customize(&self) -> anyhow::Result<()> {
 		let mut chain_spec = ChainSpec::from(&self.output_file)?;
 		chain_spec.replace_para_id(self.id)?;
-		chain_spec.replace_relay_chain(&self.relay.as_ref())?;
-		chain_spec.replace_chain_type(&self.chain_type.to_string())?;
+		chain_spec.replace_relay_chain(self.relay.as_ref())?;
+		chain_spec.replace_chain_type(self.chain_type.as_ref())?;
 		chain_spec.replace_protocol_id(&self.protocol_id)?;
 		chain_spec.to_file(&self.output_file)?;
 		Ok(())

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -141,7 +141,7 @@ pub struct BuildSpecCommand {
 	#[arg(short = 'i', long = "id")]
 	pub(crate) id: Option<u32>,
 	/// Whether to keep localhost as a bootnode.
-	#[clap(long, default_value = "true")]
+	#[clap(long, default_value = "false")]
 	pub(crate) default_bootnode: bool,
 	/// Type of the chain [default: development].
 	#[arg(short = 't', long = "type", value_enum)]
@@ -379,13 +379,13 @@ async fn guide_user_to_generate_spec(args: BuildSpecCommand) -> anyhow::Result<B
 	}
 	// Prompt relays chains based on the chain type
 	match chain_type {
-		ChainType::Live =>
+		ChainType::Live => {
 			for relay in RelayChain::VARIANTS {
 				if !matches!(
 					relay,
-					RelayChain::Westend |
-						RelayChain::Paseo | RelayChain::Kusama |
-						RelayChain::Polkadot
+					RelayChain::Westend
+						| RelayChain::Paseo | RelayChain::Kusama
+						| RelayChain::Polkadot
 				) {
 					continue;
 				} else {
@@ -395,14 +395,15 @@ async fn guide_user_to_generate_spec(args: BuildSpecCommand) -> anyhow::Result<B
 						relay.get_detailed_message().unwrap_or_default(),
 					);
 				}
-			},
-		_ =>
+			}
+		},
+		_ => {
 			for relay in RelayChain::VARIANTS {
 				if matches!(
 					relay,
-					RelayChain::Westend |
-						RelayChain::Paseo | RelayChain::Kusama |
-						RelayChain::Polkadot
+					RelayChain::Westend
+						| RelayChain::Paseo | RelayChain::Kusama
+						| RelayChain::Polkadot
 				) {
 					continue;
 				} else {
@@ -412,7 +413,8 @@ async fn guide_user_to_generate_spec(args: BuildSpecCommand) -> anyhow::Result<B
 						relay.get_detailed_message().unwrap_or_default(),
 					);
 				}
-			},
+			}
+		},
 	}
 
 	let relay_chain = prompt.interact()?.clone();

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -143,7 +143,7 @@ pub struct BuildSpecCommand {
 	/// Type of the chain.
 	#[arg(short = 't', long = "type", value_enum)]
 	pub(crate) chain_type: Option<ChainType>,
-	/// Provide the chain specification to use (e.g. dev , local, custom or a path to an existing file).
+	/// Provide the chain specification to use (e.g. dev, local, custom or a path to an existing file).
 	#[arg(short = 'c', long = "chain")]
 	pub(crate) chain: Option<String>,
 	/// Relay chain this parachain will connect to.
@@ -206,7 +206,7 @@ impl BuildSpecCommand {
 			Some(chain) => chain,
 			_ => {
 				// Prompt for chain if not provided.
-				input("Provide the chain specification to use (e.g. dev , local, custom or a path to an existing file)")
+				input("Provide the chain specification to use (e.g. dev, local, custom or a path to an existing file)")
 					.default_input("dev")
 					.interact()?
 			},
@@ -403,8 +403,6 @@ impl BuildSpec {
 	// it triggers a build process.
 	fn build(&self, cli: &mut impl cli::traits::Cli) -> anyhow::Result<&'static str> {
 		cli.intro("Building your chain spec")?;
-		let spinner = spinner();
-		spinner.start("Generating chain specification...");
 		let mut generated_files = vec![];
 
 		// Ensure binary is built.
@@ -417,6 +415,8 @@ impl BuildSpec {
 			#[cfg(not(test))]
 			sleep(Duration::from_secs(3))
 		}
+		let spinner = spinner();
+		spinner.start("Generating chain specification...");
 
 		// Generate chain spec.
 		generate_plain_chain_spec(

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -315,8 +315,8 @@ impl BuildSpecCommand {
 		// Protocol id.
 		let protocol_id = match protocol_id
 		{
-			Some(protocol_id) if !prompt => protocol_id,
-			_ => {
+			Some(protocol_id) => protocol_id,
+			None => {
 				let default =
 					chain_spec.as_ref().and_then(|cs| cs.get_protocol_id()).unwrap_or(DEFAULT_PROTOCOL_ID).to_string();
 				if prompt {

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -364,7 +364,7 @@ async fn guide_user_to_generate_spec(args: BuildSpecCommand) -> anyhow::Result<B
 	}
 	let chain_type: ChainType = prompt.interact()?.clone();
 	// Prompt for chain
-	let chain: String = input(" Specify the chain specification. It can be one of the predefined ones (dev, local) or a custom one.")
+	let chain: String = input("Specify the chain specification. It can be one of the predefined ones (dev, local) or a custom one.")
 		.placeholder("dev")
 		.default_input("dev")
 		.interact()?;

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -246,86 +246,85 @@ impl BuildSpecCommand {
 		let chain_spec = ChainSpec::from(&output_file).ok();
 
 		// Para id.
-		let id = match id.or_else(|| {
-			chain_spec.as_ref().and_then(|cs| cs.get_parachain_id().map(|id| id as u32))
-		}) {
-			Some(id) if !prompt => id,
-			// No para id provided or user wants to make changes.
-			_ => {
-				let default = id.unwrap_or(DEFAULT_PARA_ID).to_string();
-				input("What parachain ID should be used?")
-					.placeholder(&default)
-					.default_input(&default)
-					.interact()?
+		let id = match id {
+			Some(id) => id,
+			None => {
+				let default =
+					chain_spec.as_ref().and_then(|cs| cs.get_parachain_id().map(|id| id as u32)).unwrap_or(DEFAULT_PARA_ID);
+				if prompt {
+					// Prompt for para id.
+					input("What parachain ID should be used?")
+						.default_input(&default.to_string())
+						.interact()?
+				} else { default }
 			},
 		};
 
 		// Chain type.
-		let chain_type = match chain_type.clone().or_else(|| {
-			chain_spec
-				.as_ref()
-				.and_then(|cs| cs.get_chain_type())
-				.and_then(|r| ChainType::from_str(r, true).ok())
-		}) {
-			Some(chain_type) if !prompt => chain_type,
-			// No chain type provided or user wants to make changes.
-			_ => {
-				// Prompt for chain type.
-				let default = chain_type.unwrap_or_default();
-				let mut prompt =
-					cliclack::select("Choose the chain type: ".to_string()).initial_value(&default);
-				for chain_type in ChainType::VARIANTS {
-					prompt = prompt.item(
-						chain_type,
-						chain_type.get_message().unwrap_or(chain_type.as_ref()),
-						chain_type.get_detailed_message().unwrap_or_default(),
-					);
-				}
-				prompt.interact()?.clone()
+		let chain_type = match chain_type {
+			Some(chain_type) => chain_type,
+			None => {
+				let default =
+					chain_spec
+						.as_ref()
+						.and_then(|cs| cs.get_chain_type())
+						.and_then(|r| ChainType::from_str(r, true).ok()).unwrap_or_default();
+				if prompt {
+					// Prompt for chain type.
+					let mut prompt =
+						cliclack::select("Choose the chain type: ".to_string()).initial_value(&default);
+					for chain_type in ChainType::VARIANTS {
+						prompt = prompt.item(
+							chain_type,
+							chain_type.get_message().unwrap_or(chain_type.as_ref()),
+							chain_type.get_detailed_message().unwrap_or_default(),
+						);
+					}
+					prompt.interact()?.clone()
+				} else { default }
 			},
 		};
 
 		// Relay.
-		let relay = match relay.clone().or_else(|| {
-			chain_spec
-				.as_ref()
-				.and_then(|cs| cs.get_relay_chain())
-				.and_then(|r| RelayChain::from_str(r, true).ok())
-		}) {
-			Some(relay) if !prompt => relay,
-			// No relay provided or user wants to make changes.
-			_ => {
-				// Prompt for relay if not provided.
-				let default = relay.unwrap_or_default();
-				let mut prompt = cliclack::select(
-					"Choose the relay chain your chain will be connecting to: ".to_string(),
-				)
-				.initial_value(&default);
-				for relay in RelayChain::VARIANTS {
-					prompt = prompt.item(
-						relay,
-						relay.get_message().unwrap_or(relay.as_ref()),
-						relay.get_detailed_message().unwrap_or_default(),
-					);
-				}
-				prompt.interact()?.clone()
+		let relay = match relay {
+			Some(relay) => relay,
+			None => {
+				let default =
+					chain_spec
+						.as_ref()
+						.and_then(|cs| cs.get_relay_chain())
+						.and_then(|r| RelayChain::from_str(r, true).ok()).unwrap_or_default();
+				if prompt {
+					// Prompt for relay.
+					let mut prompt = cliclack::select(
+						"Choose the relay chain your chain will be connecting to: ".to_string(),
+					)
+						.initial_value(&default);
+					for relay in RelayChain::VARIANTS {
+						prompt = prompt.item(
+							relay,
+							relay.get_message().unwrap_or(relay.as_ref()),
+							relay.get_detailed_message().unwrap_or_default(),
+						);
+					}
+					prompt.interact()?.clone()
+				} else { default }
 			},
 		};
 
 		// Protocol id.
 		let protocol_id = match protocol_id
-			.clone()
-			.or_else(|| chain_spec.as_ref().and_then(|cs| cs.get_protocol_id().map(String::from)))
 		{
 			Some(protocol_id) if !prompt => protocol_id,
-			// No protocol id provided or user wants to make changes.
 			_ => {
-				// Prompt for protocol id if not provided.
-				let default = protocol_id.unwrap_or(DEFAULT_PROTOCOL_ID.to_string());
-				input("Enter the protocol ID that will identify your network:")
-					.placeholder(&default)
-					.default_input(&default)
-					.interact()?
+				let default =
+					chain_spec.as_ref().and_then(|cs| cs.get_protocol_id()).unwrap_or(DEFAULT_PROTOCOL_ID).to_string();
+				if prompt {
+					// Prompt for protocol id.
+					input("Enter the protocol ID that will identify your network:")
+						.default_input(&default)
+						.interact()?
+				} else { default }
 			},
 		};
 

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -124,7 +124,7 @@ pub(crate) enum RelayChain {
 }
 
 /// Command for generating a chain specification.
-#[derive(Args, Clone)]
+#[derive(Args)]
 pub struct BuildSpecCommand {
 	/// File name for the resulting spec. If a path is given,
 	/// the necessary directories will be created

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -142,7 +142,7 @@ pub struct BuildSpecCommand {
 	#[arg(short = 'i', long = "id")]
 	pub(crate) id: Option<u32>,
 	/// Whether to keep localhost as a bootnode.
-	#[clap(long, default_value = "false")]
+	#[clap(long)]
 	pub(crate) default_bootnode: bool,
 	/// Type of the chain [default: development].
 	#[arg(short = 't', long = "type", value_enum)]
@@ -381,13 +381,13 @@ async fn guide_user_to_generate_spec(args: BuildSpecCommand) -> anyhow::Result<B
 	}
 	// Prompt relays chains based on the chain type
 	match chain_type {
-		ChainType::Live => {
+		ChainType::Live =>
 			for relay in RelayChain::VARIANTS {
 				if !matches!(
 					relay,
-					RelayChain::Westend
-						| RelayChain::Paseo | RelayChain::Kusama
-						| RelayChain::Polkadot
+					RelayChain::Westend |
+						RelayChain::Paseo | RelayChain::Kusama |
+						RelayChain::Polkadot
 				) {
 					continue;
 				} else {
@@ -397,15 +397,14 @@ async fn guide_user_to_generate_spec(args: BuildSpecCommand) -> anyhow::Result<B
 						relay.get_detailed_message().unwrap_or_default(),
 					);
 				}
-			}
-		},
-		_ => {
+			},
+		_ =>
 			for relay in RelayChain::VARIANTS {
 				if matches!(
 					relay,
-					RelayChain::Westend
-						| RelayChain::Paseo | RelayChain::Kusama
-						| RelayChain::Polkadot
+					RelayChain::Westend |
+						RelayChain::Paseo | RelayChain::Kusama |
+						RelayChain::Polkadot
 				) {
 					continue;
 				} else {
@@ -415,8 +414,7 @@ async fn guide_user_to_generate_spec(args: BuildSpecCommand) -> anyhow::Result<B
 						relay.get_detailed_message().unwrap_or_default(),
 					);
 				}
-			}
-		},
+			},
 	}
 
 	let relay_chain = prompt.interact()?.clone();

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -138,8 +138,7 @@ pub struct BuildSpecCommand {
 	/// the necessary directories will be created
 	#[arg(short = 'o', long = "output")]
 	pub(crate) output_file: Option<PathBuf>,
-	// TODO: remove at release ...
-	/// [DEPRECATED] since v0.6.0, use `profile`.
+	/// [DEPRECATED] and will be removed in v0.7.0, use `profile`.
 	#[arg(short = 'r', long, conflicts_with = "profile")]
 	pub(crate) release: bool,
 	/// Build profile for the binary to generate the chain specification.

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -143,8 +143,7 @@ pub struct BuildSpecCommand {
 	/// Type of the chain.
 	#[arg(short = 't', long = "type", value_enum)]
 	pub(crate) chain_type: Option<ChainType>,
-	/// Specify the chain specification. It can be one of the predefined ones (e.g. dev, local or a
-	/// custom one) or the path to an existing chain spec.
+	/// Provide the chain specification to use (e.g. dev , local, custom or a path to an existing file).
 	#[arg(short = 'c', long = "chain")]
 	pub(crate) chain: Option<String>,
 	/// Relay chain this parachain will connect to.
@@ -180,6 +179,9 @@ impl BuildSpecCommand {
 
 	/// Complete chain specification requirements by prompting for missing inputs, validating
 	/// provided values, and preparing a BuildSpec to generate file(s).
+	///
+	/// # Arguments
+	/// * `cli` - The cli.
 	async fn complete_build_spec(
 		self,
 		cli: &mut impl cli::traits::Cli,
@@ -204,8 +206,7 @@ impl BuildSpecCommand {
 			Some(chain) => chain,
 			_ => {
 				// Prompt for chain if not provided.
-				input("Specify the chain specification. It can be one of the predefined ones (e.g. dev, local or a custom one) or the path to an existing chain spec.")
-					.placeholder("dev")
+				input("Provide the chain specification to use (e.g. dev , local, custom or a path to an existing file)")
 					.default_input("dev")
 					.interact()?
 			},
@@ -235,7 +236,6 @@ impl BuildSpecCommand {
 					// Prompt for output file if not provided.
 					let default_output = format!("./{DEFAULT_SPEC_NAME}");
 					input("Name of the plain chain spec file. If a path is given, the necessary directories will be created:")
-						.placeholder(&default_output)
 						.default_input(&default_output)
 						.interact()?
 				},

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -379,13 +379,13 @@ async fn guide_user_to_generate_spec(args: BuildSpecCommand) -> anyhow::Result<B
 	}
 	// Prompt relays chains based on the chain type
 	match chain_type {
-		ChainType::Live => {
+		ChainType::Live =>
 			for relay in RelayChain::VARIANTS {
 				if !matches!(
 					relay,
-					RelayChain::Westend
-						| RelayChain::Paseo | RelayChain::Kusama
-						| RelayChain::Polkadot
+					RelayChain::Westend |
+						RelayChain::Paseo | RelayChain::Kusama |
+						RelayChain::Polkadot
 				) {
 					continue;
 				} else {
@@ -395,15 +395,14 @@ async fn guide_user_to_generate_spec(args: BuildSpecCommand) -> anyhow::Result<B
 						relay.get_detailed_message().unwrap_or_default(),
 					);
 				}
-			}
-		},
-		_ => {
+			},
+		_ =>
 			for relay in RelayChain::VARIANTS {
 				if matches!(
 					relay,
-					RelayChain::Westend
-						| RelayChain::Paseo | RelayChain::Kusama
-						| RelayChain::Polkadot
+					RelayChain::Westend |
+						RelayChain::Paseo | RelayChain::Kusama |
+						RelayChain::Polkadot
 				) {
 					continue;
 				} else {
@@ -413,8 +412,7 @@ async fn guide_user_to_generate_spec(args: BuildSpecCommand) -> anyhow::Result<B
 						relay.get_detailed_message().unwrap_or_default(),
 					);
 				}
-			}
-		},
+			},
 	}
 
 	let relay_chain = prompt.interact()?.clone();

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -46,20 +46,20 @@ pub(crate) enum ChainType {
 	// A development chain that runs mainly on one node.
 	#[default]
 	#[strum(
-		serialize = "Development",
+		serialize = "development",
 		message = "Development",
 		detailed_message = "Meant for a development chain that runs mainly on one node."
 	)]
 	Development,
 	// A local chain that runs locally on multiple nodes for testing purposes.
 	#[strum(
-		serialize = "Local",
+		serialize = "local",
 		message = "Local",
 		detailed_message = "Meant for a local chain that runs locally on multiple nodes for testing purposes."
 	)]
 	Local,
 	// A live chain.
-	#[strum(serialize = "Live", message = "Live", detailed_message = "Meant for a live chain.")]
+	#[strum(serialize = "live", message = "Live", detailed_message = "Meant for a live chain.")]
 	Live,
 }
 
@@ -137,7 +137,7 @@ pub struct BuildSpecCommand {
 	#[arg(short = 'o', long = "output")]
 	pub(crate) output_file: Option<PathBuf>,
 	/// Build profile for the binary to generate the chain specification.
-	#[arg(short = 'r', long, value_enum)]
+	#[arg(long, value_enum)]
 	pub(crate) profile: Option<Profile>,
 	/// Parachain ID to be used when generating the chain spec files.
 	#[arg(short = 'i', long)]
@@ -346,9 +346,7 @@ impl BuildSpecCommand {
 						.placeholder(&default)
 						.default_input(&default)
 						.interact()?
-				} else {
-					default
-				}
+				} else { default }
 			},
 		};
 
@@ -442,16 +440,15 @@ impl BuildSpec {
 	// it triggers a build process.
 	fn build(self, cli: &mut impl cli::traits::Cli) -> anyhow::Result<&'static str> {
 		cli.intro("Building your chain spec")?;
-		let mut generated_files = vec![];
-
 		let BuildSpec {
 			ref output_file, ref profile, id, default_bootnode, ref chain, genesis_state, genesis_code,
 		.. } = self;
-
 		// Ensure binary is built.
 		let binary_path = ensure_binary_exists(cli, &profile)?;
+
 		let spinner = spinner();
 		spinner.start("Generating chain specification...");
+		let mut generated_files = vec![];
 
 		// Generate chain spec.
 		generate_plain_chain_spec(

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -536,31 +536,45 @@ fn ensure_binary_exists(
 }
 
 // Prepare the output path provided.
+
 fn prepare_output_path(output_path: impl AsRef<Path>) -> anyhow::Result<PathBuf> {
 	let mut output_path = output_path.as_ref().to_path_buf();
+	// Convert to string to check for trailing slash.
+	let output_path_str = output_path.to_string_lossy();
+	let ends_with_slash = output_path_str.ends_with(std::path::MAIN_SEPARATOR);
+	// Check if the path has an extension.
+	let has_extension = output_path.extension().is_some();
 	// Check if the path ends with '.json'
 	let is_json_file = output_path
 		.extension()
 		.and_then(|ext| ext.to_str())
 		.map(|ext| ext.eq_ignore_ascii_case("json"))
 		.unwrap_or(false);
-
-	if !is_json_file {
+	if ends_with_slash {
 		// Treat as directory.
 		if !output_path.exists() {
 			create_dir_all(&output_path)?;
 		}
 		output_path.push(DEFAULT_SPEC_NAME);
-	} else {
-		// Treat as file.
-		if let Some(parent_dir) = output_path.parent() {
-			if !parent_dir.exists() {
-				create_dir_all(parent_dir)?;
-			}
+	} else if !has_extension {
+		// No extension, treat as file, set extension to '.json'.
+		output_path.set_extension("json");
+	} else if !is_json_file {
+		// Has an extension but not '.json', change extension to '.json'.
+		output_path.set_extension("json");
+	}
+	// Else: Ends with '.json', treat as file (no changes needed).
+
+	// After modifications, create the parent directory if it doesn't exist.
+	if let Some(parent_dir) = output_path.parent() {
+		if !parent_dir.exists() {
+			create_dir_all(parent_dir)?;
 		}
 	}
 	Ok(output_path)
 }
+
+
 
 #[cfg(test)]
 mod tests {
@@ -769,31 +783,33 @@ mod tests {
 		let temp_dir = TempDir::new()?;
 		let temp_dir_path = temp_dir.path();
 
-		// No directory path.
-		let file = temp_dir_path.join("chain-spec.json");
-		let result = prepare_output_path(&file)?;
-		// Expected path: chain-spec.json
-		assert_eq!(result, file);
-
-		// Existing directory Path.
-		for dir in ["existing_dir", "existing_dir/", "existing_dir_json"] {
-			let existing_dir = temp_dir_path.join(dir);
-			create_dir_all(&existing_dir)?;
-			let result = prepare_output_path(&existing_dir)?;
-			// Expected path: existing_dir/chain-spec.json
-			let expected_path = existing_dir.join(DEFAULT_SPEC_NAME);
+		let test_cases = [
+			("chain-spec.json", "chain-spec.json"),
+			("existing_dir", "existing_dir.json"),
+			("existing_dir/", "existing_dir/chain-spec.json"),
+			("non_existing_dir", "non_existing_dir.json"),
+			("non_existing_dir/", "non_existing_dir/chain-spec.json"),
+			("some_file	", "some_file.json"),
+			("some_dir/some_file", "some_dir/some_file.json"),
+		];
+		for (input_str, expected_str) in &test_cases {
+			let input_path = temp_dir_path.join(input_str);
+			let expected_path = temp_dir_path.join(expected_str);
+			// Create directories for existing paths
+			if input_str.starts_with("existing_dir") {
+				let dir_to_create = if input_str.ends_with('/') {
+					input_path.clone()
+				} else {
+					input_path.parent().unwrap_or(&input_path).to_path_buf()
+				};
+				create_dir_all(&dir_to_create)?;
+			}
+			let result = prepare_output_path(&input_path)?;
 			assert_eq!(result, expected_path);
-		}
-
-		// Non-existing directory Path.
-		for dir in ["non_existing_dir", "non_existing_dir/", "non_existing_dir_json"] {
-			let non_existing_dir = temp_dir_path.join(dir);
-			let result = prepare_output_path(&non_existing_dir)?;
-			// Expected path: non_existing_dir/chain-spec.json
-			let expected_path = non_existing_dir.join(DEFAULT_SPEC_NAME);
-			assert_eq!(result, expected_path);
-			// The directory should now exist.
-			assert!(result.parent().unwrap().exists());
+			// Ensure the parent directory exists
+			if let Some(parent_dir) = result.parent() {
+				assert!(parent_dir.exists());
+			}
 		}
 
 		Ok(())

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -6,7 +6,7 @@ use crate::{
 	style::style,
 };
 use clap::{Args, ValueEnum};
-use cliclack::{confirm, input, multi_progress, spinner};
+use cliclack::{confirm, input, spinner};
 use pop_common::Profile;
 use pop_parachains::{
 	binary_path, build_parachain, export_wasm_file, generate_genesis_state_file,
@@ -206,7 +206,8 @@ impl BuildSpecCommand {
 			#[cfg(not(test))]
 			sleep(Duration::from_secs(3))
 		}
-		let multi = multi_progress("Generating chain specification...");
+		let spinner = spinner();
+		spinner.start("Generating chain specification...");
 
 		// Create output path if needed
 		let mut output_path = self.output_file.unwrap_or_else(|| PathBuf::from("./"));
@@ -233,7 +234,7 @@ impl BuildSpecCommand {
 		let binary_path = match binary_path(&mode.target_directory(&cwd), &cwd.join("node")) {
 			Ok(binary_path) => binary_path,
 			_ => {
-				multi.stop();
+				spinner.clear();
 				cli.info("Node was not found. The project will be built locally.".to_string())?;
 				cli.warning("NOTE: this may take some time...")?;
 				build_parachain(&cwd, None, &mode, None)?
@@ -241,8 +242,7 @@ impl BuildSpecCommand {
 		};
 
 		// Generate plain spec.
-		let spinner = multi.add(spinner());
-		spinner.start("Generating plain chain specification...");
+		spinner.set_message("Generating plain chain specification...");
 		let mut generated_files = vec![];
 		generate_plain_chain_spec(
 			&binary_path,
@@ -301,8 +301,7 @@ impl BuildSpecCommand {
 				.push(format!("Genesis State file exported at: {}", genesis_state_file.display()));
 		}
 
-		spinner.stop("Done.");
-		multi.stop();
+		spinner.stop("Chain specification built successfully.");
 
 		let generated_files: Vec<_> = generated_files
 			.iter()

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -606,11 +606,11 @@ mod tests {
 			.expect_warning("Your call has not been executed.")
 			.expect_confirm(
 				"Do you want to perform another call using the existing smart contract?",
-				false,
+				true,
 			)
 			.expect_confirm(
 				"Do you want to perform another call using the existing smart contract?",
-				true,
+				false,
 			)
 			.expect_select(
 				"Select the message to call:",

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -612,7 +612,7 @@ mod tests {
 				"Do you want to perform another call using the existing smart contract?",
 				true,
 			)
-			.expect_select::<PathBuf>(
+			.expect_select(
 				"Select the message to call:",
 				Some(false),
 				true,
@@ -669,8 +669,7 @@ mod tests {
 		];
 		// The inputs are processed in reverse order.
 		let mut cli = MockCli::new()
-			.expect_input("Signer calling the contract:", "//Alice".into())
-			.expect_select::<PathBuf>(
+			.expect_select(
 				"Select the message to call:",
 				Some(false),
 				true,
@@ -678,17 +677,19 @@ mod tests {
 				1, // "get" message
 			)
 			.expect_input(
-				"Provide the on-chain contract address:",
-				"15XausWjFLBBFLDXUSBRfSfZk25warm4wZRV4ZxhZbfvjrJm".into(),
+				"Where is your project or contract artifact located?",
+				temp_dir.path().join("testing").display().to_string(),
 			)
 			.expect_input(
 				"Where is your contract deployed?",
 				"wss://rpc1.paseo.popnetwork.xyz".into(),
 			)
 			.expect_input(
-				"Where is your project or contract artifact located?",
-				temp_dir.path().join("testing").display().to_string(),
-			).expect_info(format!(
+				"Provide the on-chain contract address:",
+				"15XausWjFLBBFLDXUSBRfSfZk25warm4wZRV4ZxhZbfvjrJm".into(),
+			)
+			.expect_input("Signer calling the contract:", "//Alice".into())
+			.expect_info(format!(
 	            "pop call contract --path {} --contract 15XausWjFLBBFLDXUSBRfSfZk25warm4wZRV4ZxhZbfvjrJm --message get --url wss://rpc1.paseo.popnetwork.xyz/ --suri //Alice",
 	            temp_dir.path().join("testing").display().to_string(),
 	        ));
@@ -750,13 +751,7 @@ mod tests {
 		// The inputs are processed in reverse order.
 		let mut cli = MockCli::new()
 			.expect_confirm("Do you want to execute the call? (Selecting 'No' will perform a dry run)", true)
-			.expect_input("Signer calling the contract:", "//Alice".into())
-			.expect_input("Enter the proof size limit:", "".into()) // Only if call
-			.expect_input("Enter the gas limit:", "".into()) // Only if call
-			.expect_input("Value to transfer to the call:", "50".into()) // Only if payable
-			.expect_input("Enter the value for the parameter: number", "2".into()) // Args for specific_flip
-			.expect_input("Enter the value for the parameter: new_value", "true".into()) // Args for specific_flip
-			.expect_select::<PathBuf>(
+			.expect_select(
 				"Select the message to call:",
 				Some(false),
 				true,
@@ -764,17 +759,24 @@ mod tests {
 				2, // "specific_flip" message
 			)
 			.expect_input(
-				"Provide the on-chain contract address:",
-				"15XausWjFLBBFLDXUSBRfSfZk25warm4wZRV4ZxhZbfvjrJm".into(),
+				"Where is your project or contract artifact located?",
+				temp_dir.path().join("testing").display().to_string(),
 			)
 			.expect_input(
 				"Where is your contract deployed?",
 				"wss://rpc1.paseo.popnetwork.xyz".into(),
 			)
 			.expect_input(
-				"Where is your project or contract artifact located?",
-				temp_dir.path().join("testing").display().to_string(),
-			).expect_info(format!(
+				"Provide the on-chain contract address:",
+				"15XausWjFLBBFLDXUSBRfSfZk25warm4wZRV4ZxhZbfvjrJm".into(),
+			)
+			.expect_input("Enter the value for the parameter: new_value", "true".into()) // Args for specific_flip
+			.expect_input("Enter the value for the parameter: number", "2".into()) // Args for specific_flip
+			.expect_input("Value to transfer to the call:", "50".into()) // Only if payable
+			.expect_input("Enter the gas limit:", "".into()) // Only if call
+			.expect_input("Enter the proof size limit:", "".into()) // Only if call
+			.expect_input("Signer calling the contract:", "//Alice".into())
+			.expect_info(format!(
 				"pop call contract --path {} --contract 15XausWjFLBBFLDXUSBRfSfZk25warm4wZRV4ZxhZbfvjrJm --message specific_flip --args \"true\", \"2\" --value 50 --url wss://rpc1.paseo.popnetwork.xyz/ --suri //Alice --execute",
 				temp_dir.path().join("testing").display().to_string(),
 			));
@@ -837,11 +839,7 @@ mod tests {
 		];
 		// The inputs are processed in reverse order.
 		let mut cli = MockCli::new()
-			.expect_input("Signer calling the contract:", "//Alice".into())
-			.expect_input("Value to transfer to the call:", "50".into()) // Only if payable
-			.expect_input("Enter the value for the parameter: number", "2".into()) // Args for specific_flip
-			.expect_input("Enter the value for the parameter: new_value", "true".into()) // Args for specific_flip
-			.expect_select::<PathBuf>(
+			.expect_select(
 				"Select the message to call:",
 				Some(false),
 				true,
@@ -849,17 +847,22 @@ mod tests {
 				2, // "specific_flip" message
 			)
 			.expect_input(
-				"Provide the on-chain contract address:",
-				"15XausWjFLBBFLDXUSBRfSfZk25warm4wZRV4ZxhZbfvjrJm".into(),
+				"Where is your project or contract artifact located?",
+				temp_dir.path().join("testing").display().to_string(),
 			)
 			.expect_input(
 				"Where is your contract deployed?",
 				"wss://rpc1.paseo.popnetwork.xyz".into(),
 			)
 			.expect_input(
-				"Where is your project or contract artifact located?",
-				temp_dir.path().join("testing").display().to_string(),
-			).expect_info(format!(
+				"Provide the on-chain contract address:",
+				"15XausWjFLBBFLDXUSBRfSfZk25warm4wZRV4ZxhZbfvjrJm".into(),
+			)
+			.expect_input("Enter the value for the parameter: new_value", "true".into()) // Args for specific_flip
+			.expect_input("Enter the value for the parameter: number", "2".into()) // Args for specific_flip
+			.expect_input("Value to transfer to the call:", "50".into()) // Only if payable
+			.expect_input("Signer calling the contract:", "//Alice".into())
+			.expect_info(format!(
 				"pop call contract --path {} --contract 15XausWjFLBBFLDXUSBRfSfZk25warm4wZRV4ZxhZbfvjrJm --message specific_flip --args \"true\", \"2\" --value 50 --url wss://rpc1.paseo.popnetwork.xyz/ --suri //Alice --execute",
 				temp_dir.path().join("testing").display().to_string(),
 			));

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -46,9 +46,9 @@ pub(crate) enum Command {
 /// Help message for the build command.
 fn about_build() -> &'static str {
 	#[cfg(all(feature = "parachain", feature = "contract"))]
-	return "Build a parachain, smart contract or Rust package.";
+	return "Build a parachain, chain specification, smart contract or Rust package.";
 	#[cfg(all(feature = "parachain", not(feature = "contract")))]
-	return "Build a parachain or Rust package.";
+	return "Build a parachain, chain specification or Rust package.";
 	#[cfg(all(feature = "contract", not(feature = "parachain")))]
 	return "Build a smart contract or Rust package.";
 }

--- a/crates/pop-cli/tests/parachain.rs
+++ b/crates/pop-cli/tests/parachain.rs
@@ -48,7 +48,7 @@ async fn parachain_lifecycle() -> Result<()> {
 
 	let temp_parachain_dir = temp_dir.join("test_parachain");
 	// pop build spec --output ./target/pop/test-spec.json --id 2222 --type development --relay
-	// paseo-local --protocol-id pop-protocol"
+	// paseo-local --protocol-id pop-protocol" --chain local
 	Command::cargo_bin("pop")
 		.unwrap()
 		.current_dir(&temp_parachain_dir)
@@ -61,6 +61,8 @@ async fn parachain_lifecycle() -> Result<()> {
 			"2222",
 			"--type",
 			"development",
+			"--chain",
+			"local",
 			"--relay",
 			"paseo-local",
 			"--genesis-state",
@@ -86,6 +88,7 @@ async fn parachain_lifecycle() -> Result<()> {
 	assert!(content.contains("\"tokenSymbol\": \"POP\""));
 	assert!(content.contains("\"relay_chain\": \"paseo-local\""));
 	assert!(content.contains("\"protocolId\": \"pop-protocol\""));
+	assert!(content.contains("\"id\": \"local_testnet\""));
 
 	// pop up parachain -p "./test_parachain"
 	let mut cmd = Cmd::new(cargo_bin("pop"))

--- a/crates/pop-cli/tests/parachain.rs
+++ b/crates/pop-cli/tests/parachain.rs
@@ -65,6 +65,8 @@ async fn parachain_lifecycle() -> Result<()> {
 			"local",
 			"--relay",
 			"paseo-local",
+			"--profile",
+			"release",
 			"--genesis-state",
 			"--genesis-code",
 			"--protocol-id",

--- a/crates/pop-common/Cargo.toml
+++ b/crates/pop-common/Cargo.toml
@@ -26,6 +26,7 @@ thiserror.workspace = true
 tokio.workspace = true
 toml_edit.workspace = true
 url.workspace = true
+toml.workspace = true
 
 [dev-dependencies]
 mockito.workspace = true

--- a/crates/pop-common/Cargo.toml
+++ b/crates/pop-common/Cargo.toml
@@ -19,6 +19,7 @@ reqwest.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 strum.workspace = true
+strum_macros.workspace = true
 tar.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
@@ -28,5 +29,4 @@ url.workspace = true
 
 [dev-dependencies]
 mockito.workspace = true
-strum_macros.workspace = true
 tempfile.workspace = true

--- a/crates/pop-common/src/build.rs
+++ b/crates/pop-common/src/build.rs
@@ -40,11 +40,7 @@ impl Profile {
 
 impl From<Profile> for bool {
 	fn from(value: Profile) -> Self {
-		if value == Profile::Debug {
-			false
-		} else {
-			true
-		}
+		value != Profile::Debug
 	}
 }
 

--- a/crates/pop-common/src/build.rs
+++ b/crates/pop-common/src/build.rs
@@ -16,7 +16,7 @@ use strum_macros::{VariantArray, AsRefStr, EnumMessage, EnumString};
 pub enum Profile {
 	/// Debug profile, optimized for debugging.
 	#[strum(
-		serialize = "Debug",
+		serialize = "debug",
 		message = "Debug",
 		detailed_message = "Optimized for debugging."
 	)]
@@ -24,14 +24,14 @@ pub enum Profile {
 	/// Release profile, optimized without any debugging functionality.
 	#[default]
 	#[strum(
-		serialize = "Release",
+		serialize = "release",
 		message = "Release",
 		detailed_message = "Optimized without any debugging functionality."
 	)]
 	Release,
 	/// Production profile, optimized for ultimate performance.
 	#[strum(
-		serialize = "Production",
+		serialize = "production",
 		message = "Production",
 		detailed_message = "Optimized for ultimate performance."
 	)]
@@ -52,9 +52,9 @@ impl Profile {
 impl fmt::Display for Profile {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
-			Self::Debug => write!(f, "DEBUG"),
-			Self::Release => write!(f, "RELEASE"),
-			Self::Production => write!(f, "PRODUCTION"),
+			Self::Debug => write!(f, "debug"),
+			Self::Release => write!(f, "release"),
+			Self::Production => write!(f, "production"),
 		}
 	}
 }

--- a/crates/pop-common/src/build.rs
+++ b/crates/pop-common/src/build.rs
@@ -72,7 +72,7 @@ impl fmt::Display for Profile {
 mod tests {
 	use super::*;
 	use std::path::Path;
-	use strum::{EnumMessage};
+	use strum::EnumMessage;
 
 	#[test]
 	fn profile_from_string() {
@@ -83,10 +83,7 @@ mod tests {
 
 	#[test]
 	fn profile_detailed_message() {
-		assert_eq!(
-			Profile::Debug.get_detailed_message(),
-			Some("Optimized for debugging.")
-		);
+		assert_eq!(Profile::Debug.get_detailed_message(), Some("Optimized for debugging."));
 		assert_eq!(
 			Profile::Release.get_detailed_message(),
 			Some("Optimized without any debugging functionality.")
@@ -134,4 +131,3 @@ mod tests {
 		assert_eq!(bool::from(Profile::Production), true);
 	}
 }
-

--- a/crates/pop-common/src/build.rs
+++ b/crates/pop-common/src/build.rs
@@ -1,15 +1,41 @@
-use std::{
-	fmt,
-	path::{Path, PathBuf},
-};
+use std::{fmt, path::{Path, PathBuf}};
+use strum_macros::{VariantArray, AsRefStr, EnumMessage, EnumString};
 
 /// Enum representing a build profile.
-#[derive(Debug, PartialEq)]
+#[derive(
+	AsRefStr,
+	Clone,
+	Default,
+	Debug,
+	EnumString,
+	EnumMessage,
+	VariantArray,
+	Eq,
+	PartialEq,
+)]
 pub enum Profile {
 	/// Debug profile, optimized for debugging.
+	#[strum(
+		serialize = "Debug",
+		message = "Debug",
+		detailed_message = "Optimized for debugging."
+	)]
 	Debug,
 	/// Release profile, optimized without any debugging functionality.
+	#[default]
+	#[strum(
+		serialize = "Release",
+		message = "Release",
+		detailed_message = "Optimized without any debugging functionality."
+	)]
 	Release,
+	/// Production profile, optimized for ultimate performance.
+	#[strum(
+		serialize = "Production",
+		message = "Production",
+		detailed_message = "Optimized for ultimate performance."
+	)]
+	Production,
 }
 
 impl Profile {
@@ -18,16 +44,7 @@ impl Profile {
 		match self {
 			Profile::Release => path.join("target/release"),
 			Profile::Debug => path.join("target/debug"),
-		}
-	}
-}
-
-impl From<bool> for Profile {
-	fn from(release: bool) -> Self {
-		if release {
-			Profile::Release
-		} else {
-			Profile::Debug
+			Profile::Production => path.join("target/production"),
 		}
 	}
 }
@@ -37,6 +54,8 @@ impl fmt::Display for Profile {
 		match self {
 			Self::Debug => write!(f, "DEBUG"),
 			Self::Release => write!(f, "RELEASE"),
+			Self::Production => write!(f, "PRODUCTION"),
 		}
 	}
 }
+

--- a/crates/pop-common/src/build.rs
+++ b/crates/pop-common/src/build.rs
@@ -67,3 +67,71 @@ impl fmt::Display for Profile {
 		}
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::path::Path;
+	use strum::{EnumMessage};
+
+	#[test]
+	fn profile_from_string() {
+		assert_eq!("debug".parse::<Profile>().unwrap(), Profile::Debug);
+		assert_eq!("release".parse::<Profile>().unwrap(), Profile::Release);
+		assert_eq!("production".parse::<Profile>().unwrap(), Profile::Production);
+	}
+
+	#[test]
+	fn profile_detailed_message() {
+		assert_eq!(
+			Profile::Debug.get_detailed_message(),
+			Some("Optimized for debugging.")
+		);
+		assert_eq!(
+			Profile::Release.get_detailed_message(),
+			Some("Optimized without any debugging functionality.")
+		);
+		assert_eq!(
+			Profile::Production.get_detailed_message(),
+			Some("Optimized for ultimate performance.")
+		);
+	}
+
+	#[test]
+	fn profile_target_directory() {
+		let base_path = Path::new("/example/path");
+
+		assert_eq!(
+			Profile::Debug.target_directory(base_path),
+			Path::new("/example/path/target/debug")
+		);
+		assert_eq!(
+			Profile::Release.target_directory(base_path),
+			Path::new("/example/path/target/release")
+		);
+		assert_eq!(
+			Profile::Production.target_directory(base_path),
+			Path::new("/example/path/target/production")
+		);
+	}
+
+	#[test]
+	fn profile_default() {
+		let default_profile = Profile::default();
+		assert_eq!(default_profile, Profile::Release);
+	}
+
+	#[test]
+	fn profile_from_bool() {
+		assert_eq!(Profile::from(true), Profile::Release);
+		assert_eq!(Profile::from(false), Profile::Debug);
+	}
+
+	#[test]
+	fn profile_into_bool() {
+		assert_eq!(bool::from(Profile::Debug), false);
+		assert_eq!(bool::from(Profile::Release), true);
+		assert_eq!(bool::from(Profile::Production), true);
+	}
+}
+

--- a/crates/pop-common/src/build.rs
+++ b/crates/pop-common/src/build.rs
@@ -1,25 +1,14 @@
-use std::{fmt, path::{Path, PathBuf}};
-use strum_macros::{VariantArray, AsRefStr, EnumMessage, EnumString};
+use std::{
+	fmt,
+	path::{Path, PathBuf},
+};
+use strum_macros::{AsRefStr, EnumMessage, EnumString, VariantArray};
 
 /// Enum representing a build profile.
-#[derive(
-	AsRefStr,
-	Clone,
-	Default,
-	Debug,
-	EnumString,
-	EnumMessage,
-	VariantArray,
-	Eq,
-	PartialEq,
-)]
+#[derive(AsRefStr, Clone, Default, Debug, EnumString, EnumMessage, VariantArray, Eq, PartialEq)]
 pub enum Profile {
 	/// Debug profile, optimized for debugging.
-	#[strum(
-		serialize = "debug",
-		message = "Debug",
-		detailed_message = "Optimized for debugging."
-	)]
+	#[strum(serialize = "debug", message = "Debug", detailed_message = "Optimized for debugging.")]
 	Debug,
 	/// Release profile, optimized without any debugging functionality.
 	#[default]
@@ -49,6 +38,26 @@ impl Profile {
 	}
 }
 
+impl From<Profile> for bool {
+	fn from(value: Profile) -> Self {
+		if value == Profile::Debug {
+			false
+		} else {
+			true
+		}
+	}
+}
+
+impl From<bool> for Profile {
+	fn from(value: bool) -> Self {
+		if value {
+			Profile::Release
+		} else {
+			Profile::Debug
+		}
+	}
+}
+
 impl fmt::Display for Profile {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
@@ -58,4 +67,3 @@ impl fmt::Display for Profile {
 		}
 	}
 }
-

--- a/crates/pop-common/src/manifest.rs
+++ b/crates/pop-common/src/manifest.rs
@@ -98,8 +98,6 @@ pub fn add_crate_to_workspace(workspace_toml: &Path, crate_path: &Path) -> anyho
 	Ok(())
 }
 
-use std::fs;
-
 /// Adds a "production" profile to the Cargo.toml manifest if it doesn't already exist.
 ///
 /// # Arguments
@@ -108,7 +106,7 @@ pub fn add_production_profile(project: &Path) -> anyhow::Result<()> {
 	let root_toml_path = project.join("Cargo.toml");
 	let mut manifest = Manifest::from_path(&root_toml_path)?;
 	// Check if the `production` profile already exists.
-	if manifest.profile.custom.get("production").is_some() {
+	if manifest.profile.custom.contains_key("production") {
 		return Ok(());
 	}
 	// Create the production profile with required fields.
@@ -475,7 +473,6 @@ mod tests {
 
 		// Call the function to add the production profile
 		let result = add_production_profile(project_path);
-		println!("{:?}", result);
 		assert!(result.is_ok());
 
 		// Verify the production profile is added

--- a/crates/pop-common/src/manifest.rs
+++ b/crates/pop-common/src/manifest.rs
@@ -2,7 +2,7 @@
 
 use crate::Error;
 use anyhow;
-pub use cargo_toml::{Dependency, Manifest};
+pub use cargo_toml::{Dependency, LtoSetting, Manifest, Profile, Profiles};
 use std::{
 	fs::{read_to_string, write},
 	path::{Path, PathBuf},
@@ -58,6 +58,7 @@ pub fn find_workspace_toml(target_dir: &Path) -> Option<PathBuf> {
 
 /// This function is used to add a crate to a workspace.
 /// # Arguments
+///
 /// * `workspace_toml` - The path to the workspace `Cargo.toml`
 /// * `crate_path`: The path to the crate that should be added to the workspace
 pub fn add_crate_to_workspace(workspace_toml: &Path, crate_path: &Path) -> anyhow::Result<()> {
@@ -94,6 +95,46 @@ pub fn add_crate_to_workspace(workspace_toml: &Path, crate_path: &Path) -> anyho
 	}
 
 	write(workspace_toml, doc.to_string())?;
+	Ok(())
+}
+
+use std::fs;
+
+/// Adds a "production" profile to the Cargo.toml manifest if it doesn't already exist.
+///
+/// # Arguments
+/// * `project` - The path to the root of the Cargo project containing the Cargo.toml.
+pub fn add_production_profile(project: &Path) -> anyhow::Result<()> {
+	let root_toml_path = project.join("Cargo.toml");
+	let mut manifest = Manifest::from_path(&root_toml_path)?;
+	// Check if the `production` profile already exists.
+	if manifest.profile.custom.get("production").is_some() {
+		return Ok(());
+	}
+	// Create the production profile with required fields.
+	let production_profile = Profile {
+		opt_level: None,
+		debug: None,
+		split_debuginfo: None,
+		rpath: None,
+		lto: Some(LtoSetting::Fat),
+		debug_assertions: None,
+		codegen_units: Some(1),
+		panic: None,
+		incremental: None,
+		overflow_checks: None,
+		strip: None,
+		package: std::collections::BTreeMap::new(),
+		build_override: None,
+		inherits: Some("release".to_string()),
+	};
+	// Insert the new profile into the custom profiles
+	manifest.profile.custom.insert("production".to_string(), production_profile);
+
+	// Serialize the updated manifest and write it back to the file
+	let toml_string = toml::to_string(&manifest)?;
+	write(&root_toml_path, toml_string)?;
+
 	Ok(())
 }
 
@@ -418,5 +459,44 @@ mod tests {
 				.path(),
 		);
 		assert!(add_crate.is_err());
+	}
+
+	#[test]
+	fn add_production_profile_works() {
+		let test_builder = TestBuilder::default().add_workspace().add_workspace_cargo_toml(
+			r#"[profile.release]
+            opt-level = 3
+            "#,
+		);
+
+		let binding = test_builder.workspace.expect("Workspace should exist");
+		let project_path = binding.path();
+		let cargo_toml_path = project_path.join("Cargo.toml");
+
+		// Call the function to add the production profile
+		let result = add_production_profile(project_path);
+		println!("{:?}", result);
+		assert!(result.is_ok());
+
+		// Verify the production profile is added
+		let manifest =
+			Manifest::from_path(&cargo_toml_path).expect("Should parse updated Cargo.toml");
+		let production_profile = manifest
+			.profile
+			.custom
+			.get("production")
+			.expect("Production profile should exist");
+		assert_eq!(production_profile.codegen_units, Some(1));
+		assert_eq!(production_profile.inherits.as_deref(), Some("release"));
+		assert_eq!(production_profile.lto, Some(LtoSetting::Fat));
+
+		// Test idempotency: Running the function again should not modify the manifest
+		let initial_toml_content =
+			read_to_string(&cargo_toml_path).expect("Cargo.toml should be readable");
+		let second_result = add_production_profile(project_path);
+		assert!(second_result.is_ok());
+		let final_toml_content =
+			read_to_string(&cargo_toml_path).expect("Cargo.toml should be readable");
+		assert_eq!(initial_toml_content, final_toml_content);
 	}
 }

--- a/crates/pop-parachains/README.md
+++ b/crates/pop-parachains/README.md
@@ -46,7 +46,7 @@ let package = None;  // The optional package to be built.
 let binary_path = build_parachain(&path, package, &Profile::Release, None).unwrap();;
 // Generate a plain chain specification file of a parachain
 let plain_chain_spec_path = path.join("plain-parachain-chainspec.json");
-generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true, Some("dev"));
+generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true, "dev");
 // Customize your chain specification
 let mut chain_spec = ChainSpec::from(&plain_chain_spec_path).unwrap();
 chain_spec.replace_para_id(2002);
@@ -70,7 +70,7 @@ let package = None;  // The optional package to be built.
 let binary_path = build_parachain(&path, package, &Profile::Release, None).unwrap();;
 // Generate a plain chain specification file of a parachain
 let plain_chain_spec_path = path.join("plain-parachain-chainspec.json");
-generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true, Some("dev"));
+generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true, "dev");
 // Generate a raw chain specification file of a parachain
 let chain_spec = generate_raw_chain_spec(&binary_path, &plain_chain_spec_path, "raw-parachain-chainspec.json").unwrap();
 // Export the WebAssembly runtime for the parachain.

--- a/crates/pop-parachains/README.md
+++ b/crates/pop-parachains/README.md
@@ -46,7 +46,7 @@ let package = None;  // The optional package to be built.
 let binary_path = build_parachain(&path, package, &Profile::Release, None).unwrap();;
 // Generate a plain chain specification file of a parachain
 let plain_chain_spec_path = path.join("plain-parachain-chainspec.json");
-generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true);
+generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true, Some("dev"));
 // Customize your chain specification
 let mut chain_spec = ChainSpec::from(&plain_chain_spec_path).unwrap();
 chain_spec.replace_para_id(2002);
@@ -70,7 +70,7 @@ let package = None;  // The optional package to be built.
 let binary_path = build_parachain(&path, package, &Profile::Release, None).unwrap();;
 // Generate a plain chain specification file of a parachain
 let plain_chain_spec_path = path.join("plain-parachain-chainspec.json");
-generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true);
+generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true, Some("dev"));
 // Generate a raw chain specification file of a parachain
 let chain_spec = generate_raw_chain_spec(&binary_path, &plain_chain_spec_path, "raw-parachain-chainspec.json").unwrap();
 // Export the WebAssembly runtime for the parachain.

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -79,9 +79,14 @@ pub fn generate_plain_chain_spec(
 	binary_path: &Path,
 	plain_chain_spec: &Path,
 	default_bootnode: bool,
+	chain: Option<&str>,
 ) -> Result<(), Error> {
 	check_command_exists(binary_path, "build-spec")?;
 	let mut args = vec!["build-spec"];
+	if let Some(chain_spec_id) = chain {
+		args.push("--chain");
+		args.push(chain_spec_id);
+	}
 	if !default_bootnode {
 		args.push("--disable-default-bootnode");
 	}
@@ -458,6 +463,7 @@ default_command = "pop-node"
 			&binary_path,
 			&temp_dir.path().join("plain-parachain-chainspec.json"),
 			true,
+			Some("local"),
 		)?;
 		assert!(plain_chain_spec.exists());
 		{

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -93,10 +93,12 @@ pub fn generate_plain_chain_spec(
 	// Run the command and redirect output to the temporary file.
 	cmd(binary_path, args).stdout_path(temp_file.path()).stderr_null().run()?;
 	// Atomically replace the chain spec file with the temporary file.
-	temp_file
-		.persist(plain_chain_spec)
-		.map_err(|e| AnyhowError(anyhow!("Failed to replace the chain spec file with the temporary file: {}",
-			e.to_string())))?;
+	temp_file.persist(plain_chain_spec).map_err(|e| {
+		AnyhowError(anyhow!(
+			"Failed to replace the chain spec file with the temporary file: {}",
+			e.to_string()
+		))
+	})?;
 	Ok(())
 }
 

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -31,8 +31,10 @@ pub fn build_parachain(
 		args.push("--package");
 		args.push(package)
 	}
-	if matches!(profile, &Profile::Release) {
+	if profile == &Profile::Release {
 		args.push("--release");
+	} else if profile == &Profile::Production {
+		args.push("--profile=production");
 	}
 	cmd("cargo", args).dir(path).run()?;
 	binary_path(&profile.target_directory(path), node_path.unwrap_or(&path.join("node")))
@@ -336,8 +338,8 @@ mod tests {
 	use anyhow::Result;
 	use pop_common::{manifest::Dependency, set_executable_permission};
 	use std::{fs, fs::write, io::Write, path::Path};
-	use tempfile::{tempdir, Builder, TempDir};
 	use strum::VariantArray;
+	use tempfile::{tempdir, Builder, TempDir};
 
 	fn setup_template_and_instantiate() -> Result<TempDir> {
 		let temp_dir = tempdir().expect("Failed to create temp dir");

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -336,9 +336,10 @@ mod tests {
 	use anyhow::Result;
 	use pop_common::{manifest::Dependency, set_executable_permission};
 	use std::{fs, fs::write, io::Write, path::Path};
-	use tempfile::{tempdir, Builder};
+	use tempfile::{tempdir, Builder, TempDir};
+	use strum::VariantArray;
 
-	fn setup_template_and_instantiate() -> Result<tempfile::TempDir> {
+	fn setup_template_and_instantiate() -> Result<TempDir> {
 		let temp_dir = tempdir().expect("Failed to create temp dir");
 		let config = Config {
 			symbol: "DOT".to_string(),
@@ -361,9 +362,9 @@ mod tests {
 	}
 
 	// Function that generates a Cargo.toml inside node directory for testing.
-	fn generate_mock_node(temp_dir: &Path) -> Result<(), Error> {
+	fn generate_mock_node(temp_dir: &Path, name: Option<&str>) -> Result<PathBuf, Error> {
 		// Create a node directory
-		let target_dir = temp_dir.join("node");
+		let target_dir = temp_dir.join(name.unwrap_or("node"));
 		fs::create_dir(&target_dir)?;
 		// Create a Cargo.toml file
 		let mut toml_file = fs::File::create(target_dir.join("Cargo.toml"))?;
@@ -378,7 +379,7 @@ mod tests {
 
 			"#
 		)?;
-		Ok(())
+		Ok(target_dir)
 	}
 
 	// Function that fetch a binary from pop network
@@ -387,13 +388,13 @@ mod tests {
 		writeln!(
 			config.as_file(),
 			r#"
-[relaychain]
-chain = "paseo-local"
+            [relaychain]
+            chain = "paseo-local"
 
-[[parachains]]
-id = 4385
-default_command = "pop-node"
-"#
+			[[parachains]]
+			id = 4385
+			default_command = "pop-node"
+			"#
 		)?;
 		let mut zombienet =
 			Zombienet::new(&cache, config.path().to_str().unwrap(), None, None, None, None, None)
@@ -416,20 +417,45 @@ default_command = "pop-node"
 		Ok(binary_path)
 	}
 
+	fn add_production_profile(project: &Path) -> Result<()> {
+		let root_toml_path = project.join("Cargo.toml");
+		let mut root_toml_content = fs::read_to_string(&root_toml_path)?;
+		root_toml_content.push_str(
+			r#"
+			[profile.production]
+			codegen-units = 1
+			inherits = "release"
+			lto = true
+			"#,
+		);
+		// Write the updated content back to the file
+		write(&root_toml_path, root_toml_content)?;
+		Ok(())
+	}
+
 	#[test]
 	fn build_parachain_works() -> Result<()> {
-		let temp_dir = tempdir()?;
 		let name = "parachain_template_node";
+		let temp_dir = tempdir()?;
 		cmd("cargo", ["new", name, "--bin"]).dir(temp_dir.path()).run()?;
-		generate_mock_node(&temp_dir.path().join(name))?;
-		let binary = build_parachain(&temp_dir.path().join(name), None, &Profile::Release, None)?;
-		let target_directory = temp_dir.path().join(name).join("target/release");
-		assert!(target_directory.exists());
-		assert!(target_directory.join("parachain_template_node").exists());
-		assert_eq!(
-			binary.display().to_string(),
-			target_directory.join("parachain_template_node").display().to_string()
-		);
+		let project = temp_dir.path().join(name);
+		add_production_profile(&project)?;
+		for node in vec![None, Some("custom_node")] {
+			let node_path = generate_mock_node(&project, node)?;
+			for package in vec![None, Some(String::from("parachain_template_node"))] {
+				for profile in Profile::VARIANTS {
+					let node_path = node.map(|_| node_path.as_path());
+					let binary = build_parachain(&project, package.clone(), &profile, node_path)?;
+					let target_directory = profile.target_directory(&project);
+					assert!(target_directory.exists());
+					assert!(target_directory.join("parachain_template_node").exists());
+					assert_eq!(
+						binary.display().to_string(),
+						target_directory.join("parachain_template_node").display().to_string()
+					);
+				}
+			}
+		}
 		Ok(())
 	}
 

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -78,7 +78,7 @@ pub fn binary_path(target_path: &Path, node_path: &Path) -> Result<PathBuf, Erro
 /// * `plain_chain_spec` - Location of the plain_parachain_spec file to be generated.
 /// * `default_bootnode` - Whether to include localhost as a bootnode.
 /// * `chain` - The chain specification. It can be one of the predefined ones (e.g. dev, local or a
-///		custom one) or the path to an existing chain spec.
+///   custom one) or the path to an existing chain spec.
 pub fn generate_plain_chain_spec(
 	binary_path: &Path,
 	plain_chain_spec: &Path,

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -462,7 +462,7 @@ default_command = "pop-node"
 		generate_plain_chain_spec(
 			&binary_path,
 			&temp_dir.path().join("plain-parachain-chainspec.json"),
-			true,
+			false,
 			Some("local"),
 		)?;
 		assert!(plain_chain_spec.exists());
@@ -479,6 +479,8 @@ default_command = "pop-node"
 		assert!(raw_chain_spec.exists());
 		let content = fs::read_to_string(raw_chain_spec.clone()).expect("Could not read file");
 		assert!(content.contains("\"para_id\": 2001"));
+		assert!(content.contains("\"id\": \"pop-devnet\""));
+		assert!(content.contains("\"bootNodes\": []"));
 		// Test export wasm file
 		let wasm_file = export_wasm_file(&binary_path, &raw_chain_spec, "para-2001-wasm")?;
 		assert!(wasm_file.exists());

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -75,22 +75,29 @@ pub fn binary_path(target_path: &Path, node_path: &Path) -> Result<PathBuf, Erro
 /// * `binary_path` - The path to the node binary executable that contains the `build-spec` command.
 /// * `plain_chain_spec` - Location of the plain_parachain_spec file to be generated.
 /// * `default_bootnode` - Whether to include localhost as a bootnode.
+/// * `chain` - The chain specification. It can be one of the predefined ones (e.g. dev, local or a
+/// 	custom one) or the path to an existing chain spec.
 pub fn generate_plain_chain_spec(
 	binary_path: &Path,
 	plain_chain_spec: &Path,
 	default_bootnode: bool,
-	chain: Option<&str>,
+	chain: &str,
 ) -> Result<(), Error> {
 	check_command_exists(binary_path, "build-spec")?;
 	let mut args = vec!["build-spec"];
-	if let Some(chain_spec_id) = chain {
-		args.push("--chain");
-		args.push(chain_spec_id);
-	}
+	args.push("--chain");
+	args.push(chain);
 	if !default_bootnode {
 		args.push("--disable-default-bootnode");
 	}
-	cmd(binary_path, args).stdout_path(plain_chain_spec).stderr_null().run()?;
+	// Create a temporary file.
+	let temp_file = tempfile::NamedTempFile::new_in(std::env::temp_dir())?;
+	// Run the command and redirect output to the temporary file.
+	cmd(binary_path, args).stdout_path(temp_file.path()).stderr_null().run()?;
+	// Atomically replace the chain spec file with the temporary file.
+	let _ = temp_file
+		.persist(plain_chain_spec)
+		.map_err(|_| Error::AnyhowError(anyhow::anyhow!("error")));
 	Ok(())
 }
 
@@ -463,7 +470,7 @@ default_command = "pop-node"
 			&binary_path,
 			&temp_dir.path().join("plain-parachain-chainspec.json"),
 			false,
-			Some("local"),
+			"local",
 		)?;
 		assert!(plain_chain_spec.exists());
 		{

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -78,7 +78,7 @@ pub fn binary_path(target_path: &Path, node_path: &Path) -> Result<PathBuf, Erro
 /// * `plain_chain_spec` - Location of the plain_parachain_spec file to be generated.
 /// * `default_bootnode` - Whether to include localhost as a bootnode.
 /// * `chain` - The chain specification. It can be one of the predefined ones (e.g. dev, local or a
-/// 	custom one) or the path to an existing chain spec.
+///		custom one) or the path to an existing chain spec.
 pub fn generate_plain_chain_spec(
 	binary_path: &Path,
 	plain_chain_spec: &Path,


### PR DESCRIPTION
Fixes https://github.com/r0gue-io/pop-cli/issues/305

### Changes

1. Add the flag `--chain` to specify the chain specification. Is to add this flag: https://github.com/paritytech/polkadot-sdk/blob/master/substrate/client/cli/src/params/shared_params.rs#L32 when running the `build-spec` command of the binary.
To generate `pop-node`  chain_spec mainnet for example can be done with:
`pop build spec --release --id 4024 --type live --relay paseo  --chain mainnet`
 (https://github.com/r0gue-io/pop-node/blob/main/node/src/command.rs#L73)

2. As pointed in the issue the `--default-bootnode` was a bit confusing because by default was set to true and to don't  include localhost as the default bootnode has to be specified with  `--default-bootnode false`.
Set by default to false and included if specified `--default-bootnode`.
The other approach is to change the name to `--disable-default-bootnode` and set it by default to false unless the flag is included.
