### PR TITLE
feat: flag sudo to wrap extrinsic

### DIFF
--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -94,8 +94,9 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call ||
-				!cli.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call
+				|| !cli
+					.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -158,8 +159,9 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) =>
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
+				Some(ref extrinsic_name) => {
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
+				},
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -204,8 +206,9 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None =>
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
+				None => {
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
+				},
 			};
 
 			return Ok(CallParachain {
@@ -232,8 +235,9 @@ impl CallParachainCommand {
 			None => &cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 		};
 		cli.info(format!("Encoded call data: {}", call_data))?;
-		if !self.skip_confirm &&
-			!cli.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm
+			&& !cli
+				.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -268,11 +272,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none() ||
-			self.extrinsic.is_none() ||
-			self.args.is_empty() ||
-			self.url.is_none() ||
-			self.suri.is_none()
+		self.pallet.is_none()
+			|| self.extrinsic.is_none()
+			|| self.args.is_empty()
+			|| self.url.is_none()
+			|| self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -359,8 +363,9 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm &&
-			!cli.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm
+			&& !cli
+				.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -94,8 +94,9 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call ||
-				!cli.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call
+				|| !cli
+					.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -158,8 +159,9 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) =>
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
+				Some(ref extrinsic_name) => {
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
+				},
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -200,8 +202,9 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None =>
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
+				None => {
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
+				},
 			};
 
 			return Ok(CallParachain {
@@ -228,8 +231,9 @@ impl CallParachainCommand {
 			None => &cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 		};
 		cli.info(format!("Encoded call data: {}", call_data))?;
-		if !self.skip_confirm &&
-			!cli.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm
+			&& !cli
+				.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -258,7 +262,7 @@ impl CallParachainCommand {
 	// execute the call via sudo.
 	async fn configure_sudo(&mut self, chain: &Chain, cli: &mut impl Cli) -> Result<()> {
 		match find_extrinsic_by_name(&chain.pallets, "Sudo", "sudo").await {
-			Ok(_) =>
+			Ok(_) => {
 				if !self.sudo {
 					self.sudo = cli
 						.confirm(
@@ -266,14 +270,16 @@ impl CallParachainCommand {
 						)
 						.initial_value(false)
 						.interact()?;
-				},
-			Err(_) =>
+				}
+			},
+			Err(_) => {
 				if self.sudo {
 					cli.warning(
 						"NOTE: sudo is not supported by the chain. Ignoring `--sudo` flag.",
 					)?;
 					self.sudo = false;
-				},
+				}
+			},
 		}
 		Ok(())
 	}
@@ -288,11 +294,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none() ||
-			self.extrinsic.is_none() ||
-			self.args.is_empty() ||
-			self.url.is_none() ||
-			self.suri.is_none()
+		self.pallet.is_none()
+			|| self.extrinsic.is_none()
+			|| self.args.is_empty()
+			|| self.url.is_none()
+			|| self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -379,8 +385,9 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm &&
-			!cli.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm
+			&& !cli
+				.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -94,9 +94,8 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call
-				|| !cli
-					.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call ||
+				!cli.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -159,9 +158,8 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) => {
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
-				},
+				Some(ref extrinsic_name) =>
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -195,20 +193,15 @@ impl CallParachainCommand {
 				self.expand_file_arguments()?
 			};
 
-			// Prompt the user to confirm if they want to execute the call via sudo.
-			if !self.sudo {
-				self.sudo = cli
-					.confirm("Would you like to dispatch this function call with `Root` origin?")
-					.initial_value(false)
-					.interact()?;
-			}
+			// If chain has sudo prompt the user to confirm if they want to execute the call via
+			// sudo.
+			self.configure_sudo(chain, cli).await?;
 
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None => {
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
-				},
+				None =>
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 			};
 
 			return Ok(CallParachain {
@@ -235,9 +228,8 @@ impl CallParachainCommand {
 			None => &cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 		};
 		cli.info(format!("Encoded call data: {}", call_data))?;
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -262,6 +254,28 @@ impl CallParachainCommand {
 		Ok(())
 	}
 
+	// Checks if the chain has the Sudo pallet and prompt the user to confirm if they want to
+	// execute the call via sudo.
+	async fn configure_sudo(&mut self, chain: &Chain, cli: &mut impl Cli) -> Result<()> {
+		match find_extrinsic_by_name(&chain.pallets, "Sudo", "sudo").await {
+			Ok(_) =>
+				if !self.sudo {
+					self.sudo = cli
+						.confirm(
+							"Would you like to dispatch this function call with `Root` origin?",
+						)
+						.initial_value(false)
+						.interact()?;
+				},
+			Err(_) =>
+				if self.sudo {
+					cli.warning("NOTE: sudo extrinsic is not supported by the chain. Ignoring `--sudo` flag.")?;
+					self.sudo = false;
+				},
+		}
+		Ok(())
+	}
+
 	// Resets specific fields to default values for a new call.
 	fn reset_for_new_call(&mut self) {
 		self.pallet = None;
@@ -272,11 +286,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none()
-			|| self.extrinsic.is_none()
-			|| self.args.is_empty()
-			|| self.url.is_none()
-			|| self.suri.is_none()
+		self.pallet.is_none() ||
+			self.extrinsic.is_none() ||
+			self.args.is_empty() ||
+			self.url.is_none() ||
+			self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -363,9 +377,8 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -779,6 +792,39 @@ mod tests {
 			.submit_extrinsic_from_call_data(&client, "0x00000411", &mut cli)
 			.await?;
 
+		cli.verify()
+	}
+
+	#[tokio::test]
+	async fn configure_sudo_works() -> Result<()> {
+		// Test when sudo pallet doesn't exist.
+		let mut call_config = CallParachainCommand {
+			pallet: None,
+			extrinsic: None,
+			args: vec![].to_vec(),
+			url: Some(Url::parse("wss://polkadot-rpc.publicnode.com")?),
+			suri: Some("//Alice".to_string()),
+			skip_confirm: false,
+			call_data: Some("0x00000411".to_string()),
+			sudo: true,
+		};
+		let mut cli = MockCli::new().expect_intro("Call a parachain").expect_warning(
+			"NOTE: sudo extrinsic is not supported by the chain. Ignoring `--sudo` flag.",
+		);
+		let chain = call_config.configure_chain(&mut cli).await?;
+		call_config.configure_sudo(&chain, &mut cli).await?;
+		assert!(!call_config.sudo);
+		cli.verify()?;
+
+		// Test when sudo pallet exist.
+		cli = MockCli::new().expect_intro("Call a parachain").expect_confirm(
+			"Would you like to dispatch this function call with `Root` origin?",
+			true,
+		);
+		call_config.url = Some(Url::parse("wss://rpc1.paseo.popnetwork.xyz")?);
+		let chain = call_config.configure_chain(&mut cli).await?;
+		call_config.configure_sudo(&chain, &mut cli).await?;
+		assert!(call_config.sudo);
 		cli.verify()
 	}
 

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -94,8 +94,9 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call ||
-				!cli.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call
+				|| !cli
+					.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -158,8 +159,9 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) =>
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
+				Some(ref extrinsic_name) => {
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
+				},
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -200,8 +202,9 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None =>
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
+				None => {
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
+				},
 			};
 
 			return Ok(CallParachain {
@@ -228,8 +231,9 @@ impl CallParachainCommand {
 			None => &cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 		};
 		cli.info(format!("Encoded call data: {}", call_data))?;
-		if !self.skip_confirm &&
-			!cli.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm
+			&& !cli
+				.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -258,7 +262,7 @@ impl CallParachainCommand {
 	// execute the call via sudo.
 	async fn configure_sudo(&mut self, chain: &Chain, cli: &mut impl Cli) -> Result<()> {
 		match find_extrinsic_by_name(&chain.pallets, "Sudo", "sudo").await {
-			Ok(_) =>
+			Ok(_) => {
 				if !self.sudo {
 					self.sudo = cli
 						.confirm(
@@ -266,12 +270,14 @@ impl CallParachainCommand {
 						)
 						.initial_value(false)
 						.interact()?;
-				},
-			Err(_) =>
+				}
+			},
+			Err(_) => {
 				if self.sudo {
 					cli.warning("NOTE: sudo extrinsic is not supported by the chain. Ignoring `--sudo` flag.")?;
 					self.sudo = false;
-				},
+				}
+			},
 		}
 		Ok(())
 	}
@@ -286,11 +292,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none() ||
-			self.extrinsic.is_none() ||
-			self.args.is_empty() ||
-			self.url.is_none() ||
-			self.suri.is_none()
+		self.pallet.is_none()
+			|| self.extrinsic.is_none()
+			|| self.args.is_empty()
+			|| self.url.is_none()
+			|| self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -377,8 +383,9 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm &&
-			!cli.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm
+			&& !cli
+				.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -407,7 +407,6 @@ async fn prompt_predefined_actions(
 	pallets: &[Pallet],
 	cli: &mut impl Cli,
 ) -> Result<Option<Action>> {
-	println!("1 select");
 	let mut predefined_action = cli.select("What would you like to do?");
 	for action in supported_actions(pallets).await {
 		predefined_action = predefined_action.item(

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -91,8 +91,9 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call ||
-				!cli.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call
+				|| !cli
+					.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -155,8 +156,9 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) =>
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
+				Some(ref extrinsic_name) => {
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
+				},
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -193,8 +195,9 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None =>
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
+				None => {
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
+				},
 			};
 
 			return Ok(CallParachain {
@@ -220,8 +223,9 @@ impl CallParachainCommand {
 			None => &cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 		};
 		cli.info(format!("Encoded call data: {}", call_data))?;
-		if !self.skip_confirm &&
-			!cli.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm
+			&& !cli
+				.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -255,11 +259,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none() ||
-			self.extrinsic.is_none() ||
-			self.args.is_empty() ||
-			self.url.is_none() ||
-			self.suri.is_none()
+		self.pallet.is_none()
+			|| self.extrinsic.is_none()
+			|| self.args.is_empty()
+			|| self.url.is_none()
+			|| self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -342,8 +346,9 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm &&
-			!cli.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm
+			&& !cli
+				.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -402,6 +407,7 @@ async fn prompt_predefined_actions(
 	pallets: &[Pallet],
 	cli: &mut impl Cli,
 ) -> Result<Option<Action>> {
+	println!("1 select");
 	let mut predefined_action = cli.select("What would you like to do?");
 	for action in supported_actions(pallets).await {
 		predefined_action = predefined_action.item(

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -94,9 +94,8 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call
-				|| !cli
-					.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call ||
+				!cli.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -159,9 +158,8 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) => {
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
-				},
+				Some(ref extrinsic_name) =>
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -206,9 +204,8 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None => {
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
-				},
+				None =>
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 			};
 
 			return Ok(CallParachain {
@@ -235,9 +232,8 @@ impl CallParachainCommand {
 			None => &cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 		};
 		cli.info(format!("Encoded call data: {}", call_data))?;
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -272,11 +268,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none()
-			|| self.extrinsic.is_none()
-			|| self.args.is_empty()
-			|| self.url.is_none()
-			|| self.suri.is_none()
+		self.pallet.is_none() ||
+			self.extrinsic.is_none() ||
+			self.args.is_empty() ||
+			self.url.is_none() ||
+			self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -363,9 +359,8 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -94,9 +94,8 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call
-				|| !cli
-					.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call ||
+				!cli.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -159,9 +158,8 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) => {
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
-				},
+				Some(ref extrinsic_name) =>
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -202,9 +200,8 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None => {
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
-				},
+				None =>
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 			};
 
 			return Ok(CallParachain {
@@ -231,9 +228,8 @@ impl CallParachainCommand {
 			None => &cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 		};
 		cli.info(format!("Encoded call data: {}", call_data))?;
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -262,7 +258,7 @@ impl CallParachainCommand {
 	// execute the call via sudo.
 	async fn configure_sudo(&mut self, chain: &Chain, cli: &mut impl Cli) -> Result<()> {
 		match find_extrinsic_by_name(&chain.pallets, "Sudo", "sudo").await {
-			Ok(_) => {
+			Ok(_) =>
 				if !self.sudo {
 					self.sudo = cli
 						.confirm(
@@ -270,14 +266,12 @@ impl CallParachainCommand {
 						)
 						.initial_value(false)
 						.interact()?;
-				}
-			},
-			Err(_) => {
+				},
+			Err(_) =>
 				if self.sudo {
 					cli.warning("NOTE: sudo extrinsic is not supported by the chain. Ignoring `--sudo` flag.")?;
 					self.sudo = false;
-				}
-			},
+				},
 		}
 		Ok(())
 	}
@@ -292,11 +286,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none()
-			|| self.extrinsic.is_none()
-			|| self.args.is_empty()
-			|| self.url.is_none()
-			|| self.suri.is_none()
+		self.pallet.is_none() ||
+			self.extrinsic.is_none() ||
+			self.args.is_empty() ||
+			self.url.is_none() ||
+			self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -383,9 +377,8 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -708,7 +708,7 @@ mod tests {
 		assert_eq!(call_parachain.extrinsic.name, "place_order_allow_death");
 		assert_eq!(call_parachain.args, ["10000".to_string(), "2000".to_string()].to_vec());
 		assert_eq!(call_parachain.suri, "//Bob");
-		assert!(!call_config.sudo);
+		assert!(!call_parachain.sudo);
 		assert_eq!(call_parachain.display(&chain), "pop call parachain --pallet OnDemand --extrinsic place_order_allow_death --args \"10000\" \"2000\" --url wss://polkadot-rpc.publicnode.com/ --suri //Bob");
 		cli.verify()
 	}

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -43,7 +43,7 @@ pub struct CallParachainCommand {
 	#[arg(name = "call", long, conflicts_with_all = ["pallet", "extrinsic", "args"])]
 	call_data: Option<String>,
 	/// Authenticates the sudo key and dispatches a function call with `Root` origin.
-	#[arg(name = "sudo", short = 'S', long)]
+	#[arg(short = 'S', long)]
 	sudo: bool,
 	/// Automatically signs and submits the extrinsic without prompting for confirmation.
 	#[arg(short('y'), long)]
@@ -195,10 +195,10 @@ impl CallParachainCommand {
 				self.expand_file_arguments()?
 			};
 
-			// Prompt the user to confirm if they want to execute the call with sudo privileges.
+			// Prompt the user to confirm if they want to execute the call via sudo.
 			if !self.sudo {
 				self.sudo = cli
-					.confirm("Would you like to execute this operation with sudo privileges?")
+					.confirm("Would you like to dispatch this function call with `Root` origin?")
 					.initial_value(false)
 					.interact()?;
 			}
@@ -346,7 +346,7 @@ impl CallParachain {
 				return Err(anyhow!("Error: {}", e));
 			},
 		};
-		// If sudo is enabled, wrap the call in a sudo call.
+		// If sudo is required, wrap the call in a sudo call.
 		let tx = if self.sudo { construct_sudo_extrinsic(tx).await? } else { tx };
 		let encoded_data = encode_call_data(client, &tx)?;
 		// If the encoded call data is too long, don't display it all.
@@ -637,7 +637,7 @@ mod tests {
 			0, // "remark" extrinsic
 		)
 		.expect_input("The value for `remark` might be too large to enter. You may enter the path to a file instead.", "0x11".into())
-		.expect_confirm("Would you like to execute this operation with sudo privileges?", true)
+		.expect_confirm("Would you like to dispatch this function call with `Root` origin?", true)
 		.expect_input("Signer of the extrinsic:", "//Bob".into());
 
 		let chain = call_config.configure_chain(&mut cli).await?;

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -269,7 +269,9 @@ impl CallParachainCommand {
 				},
 			Err(_) =>
 				if self.sudo {
-					cli.warning("NOTE: sudo extrinsic is not supported by the chain. Ignoring `--sudo` flag.")?;
+					cli.warning(
+						"NOTE: sudo is not supported by the chain. Ignoring `--sudo` flag.",
+					)?;
 					self.sudo = false;
 				},
 		}
@@ -808,9 +810,9 @@ mod tests {
 			call_data: Some("0x00000411".to_string()),
 			sudo: true,
 		};
-		let mut cli = MockCli::new().expect_intro("Call a parachain").expect_warning(
-			"NOTE: sudo extrinsic is not supported by the chain. Ignoring `--sudo` flag.",
-		);
+		let mut cli = MockCli::new()
+			.expect_intro("Call a parachain")
+			.expect_warning("NOTE: sudo is not supported by the chain. Ignoring `--sudo` flag.");
 		let chain = call_config.configure_chain(&mut cli).await?;
 		call_config.configure_sudo(&chain, &mut cli).await?;
 		assert!(!call_config.sudo);

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -94,9 +94,8 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call
-				|| !cli
-					.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call ||
+				!cli.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -159,9 +158,8 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) => {
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
-				},
+				Some(ref extrinsic_name) =>
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -202,9 +200,8 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None => {
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
-				},
+				None =>
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 			};
 
 			return Ok(CallParachain {
@@ -231,9 +228,8 @@ impl CallParachainCommand {
 			None => &cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 		};
 		cli.info(format!("Encoded call data: {}", call_data))?;
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -262,7 +258,7 @@ impl CallParachainCommand {
 	// execute the call via sudo.
 	async fn configure_sudo(&mut self, chain: &Chain, cli: &mut impl Cli) -> Result<()> {
 		match find_extrinsic_by_name(&chain.pallets, "Sudo", "sudo").await {
-			Ok(_) => {
+			Ok(_) =>
 				if !self.sudo {
 					self.sudo = cli
 						.confirm(
@@ -270,16 +266,14 @@ impl CallParachainCommand {
 						)
 						.initial_value(false)
 						.interact()?;
-				}
-			},
-			Err(_) => {
+				},
+			Err(_) =>
 				if self.sudo {
 					cli.warning(
 						"NOTE: sudo is not supported by the chain. Ignoring `--sudo` flag.",
 					)?;
 					self.sudo = false;
-				}
-			},
+				},
 		}
 		Ok(())
 	}
@@ -294,11 +288,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none()
-			|| self.extrinsic.is_none()
-			|| self.args.is_empty()
-			|| self.url.is_none()
-			|| self.suri.is_none()
+		self.pallet.is_none() ||
+			self.extrinsic.is_none() ||
+			self.args.is_empty() ||
+			self.url.is_none() ||
+			self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -385,9 +379,8 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{

--- a/crates/pop-parachains/src/call/mod.rs
+++ b/crates/pop-parachains/src/call/mod.rs
@@ -209,16 +209,6 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn decode_call_data_works() -> Result<()> {
-		assert!(matches!(decode_call_data("wrongcalldata"), Err(Error::CallDataDecodingError(..))));
-		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
-		let extrinsic = construct_extrinsic("System", "remark", vec!["0x11".to_string()]).await?;
-		let expected_call_data = extrinsic.encode_call_data(&client.metadata())?;
-		assert_eq!(decode_call_data("0x00000411")?, expected_call_data);
-		Ok(())
-	}
-
-	#[tokio::test]
 	async fn sign_and_submit_wrong_extrinsic_fails() -> Result<()> {
 		let client = set_up_client(POP_NETWORK_TESTNET_URL).await?;
 		let extrinsic = Extrinsic {
@@ -237,9 +227,12 @@ mod tests {
 
 	#[tokio::test]
 	async fn construct_sudo_extrinsic_works() -> Result<()> {
+		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
+		let pallets = parse_chain_metadata(&client).await?;
+		let force_transfer = find_extrinsic_by_name(&pallets, "Balances", "force_transfer").await?;
 		let extrinsic = construct_extrinsic(
 			"Balances",
-			"force_transfer",
+			&force_transfer,
 			vec![
 				"Id(5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty)".to_string(),
 				"Id(5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy)".to_string(),

--- a/crates/pop-parachains/src/call/mod.rs
+++ b/crates/pop-parachains/src/call/mod.rs
@@ -39,7 +39,8 @@ pub async fn construct_extrinsic(
 /// Constructs a Sudo extrinsic.
 ///
 /// # Arguments
-/// * `tx`: The transaction to be executed with sudo privileges.
+/// * `tx`: The transaction payload representing the function call to be dispatched with `Root`
+///   privileges.
 pub async fn construct_sudo_extrinsic(tx: DynamicPayload) -> Result<DynamicPayload, Error> {
 	Ok(subxt::dynamic::tx("Sudo", "sudo", [tx.into_value()].to_vec()))
 }

--- a/crates/pop-parachains/src/call/mod.rs
+++ b/crates/pop-parachains/src/call/mod.rs
@@ -229,9 +229,10 @@ mod tests {
 	async fn construct_sudo_extrinsic_works() -> Result<()> {
 		let extrinsic = construct_extrinsic(
 			"Balances",
-			"transfer_allow_death",
+			"force_transfer",
 			vec![
 				"Id(5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty)".to_string(),
+				"Id(5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy)".to_string(),
 				"100".to_string(),
 			],
 		)

--- a/crates/pop-parachains/src/call/mod.rs
+++ b/crates/pop-parachains/src/call/mod.rs
@@ -36,6 +36,14 @@ pub async fn construct_extrinsic(
 	Ok(subxt::dynamic::tx(pallet_name, extrinsic.name.clone(), parsed_args))
 }
 
+/// Constructs a Sudo extrinsic.
+///
+/// # Arguments
+/// * `tx`: The transaction to be executed with sudo privileges.
+pub async fn construct_sudo_extrinsic(tx: DynamicPayload) -> Result<DynamicPayload, Error> {
+	Ok(subxt::dynamic::tx("Sudo", "sudo", [tx.into_value()].to_vec()))
+}
+
 /// Signs and submits a given extrinsic.
 ///
 /// # Arguments

--- a/crates/pop-parachains/src/call/mod.rs
+++ b/crates/pop-parachains/src/call/mod.rs
@@ -223,4 +223,21 @@ mod tests {
 		));
 		Ok(())
 	}
+
+	#[tokio::test]
+	async fn construct_sudo_extrinsic_works() -> Result<()> {
+		let extrinsic = construct_extrinsic(
+			"Balances",
+			"transfer_allow_death",
+			vec![
+				"Id(5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty)".to_string(),
+				"100".to_string(),
+			],
+		)
+		.await?;
+		let sudo_extrinsic = construct_sudo_extrinsic(extrinsic).await?;
+		assert_eq!(sudo_extrinsic.call_name(), "sudo");
+		assert_eq!(sudo_extrinsic.pallet_name(), "Sudo");
+		Ok(())
+	}
 }

--- a/crates/pop-parachains/src/call/mod.rs
+++ b/crates/pop-parachains/src/call/mod.rs
@@ -209,6 +209,16 @@ mod tests {
 	}
 
 	#[tokio::test]
+	async fn decode_call_data_works() -> Result<()> {
+		assert!(matches!(decode_call_data("wrongcalldata"), Err(Error::CallDataDecodingError(..))));
+		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
+		let extrinsic = construct_extrinsic("System", "remark", vec!["0x11".to_string()]).await?;
+		let expected_call_data = extrinsic.encode_call_data(&client.metadata())?;
+		assert_eq!(decode_call_data("0x00000411")?, expected_call_data);
+		Ok(())
+	}
+
+	#[tokio::test]
 	async fn sign_and_submit_wrong_extrinsic_fails() -> Result<()> {
 		let client = set_up_client(POP_NETWORK_TESTNET_URL).await?;
 		let extrinsic = Extrinsic {

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -17,7 +17,7 @@ pub use build::{
 	generate_plain_chain_spec, generate_raw_chain_spec, is_supported, ChainSpec,
 };
 pub use call::{
-	construct_extrinsic, decode_call_data, encode_call_data,
+	construct_extrinsic, construct_sudo_extrinsic, decode_call_data, encode_call_data,
 	metadata::{
 		action::{supported_actions, Action},
 		find_extrinsic_by_name, find_pallet_by_name,


### PR DESCRIPTION
This PR is part of the `pop call parachain` feature. It adds the ability to submit an extrinsic as a sudo operation using the `--sudo` flag, wrapping the selected extrinsic with sudo privileges.

_**For testing:**_
You can run `pop call parachain` interactively to select the extrinsic you want to execute and choose to run it as a sudo at the end. 
Alternatively, you can specify it directly in the command line with:
`pop call parachain --pallet System --extrinsic remark --args "0x11" --url ws://localhost:9944/ --suri //Alice --sudo`

[sc-1516]