### PR TITLE
feat: reuse existing chain spec

### DIFF
--- a/crates/pop-cli/src/cli.rs
+++ b/crates/pop-cli/src/cli.rs
@@ -13,6 +13,8 @@ pub(crate) mod traits {
 		fn confirm(&mut self, prompt: impl Display) -> impl Confirm;
 		/// Prints an info message.
 		fn info(&mut self, text: impl Display) -> Result<()>;
+		/// Constructs a new [`Input`] prompt.
+		fn input(&mut self, prompt: impl Display) -> impl Input;
 		/// Prints a header of the prompt sequence.
 		fn intro(&mut self, title: impl Display) -> Result<()>;
 		/// Constructs a new [`MultiSelect`] prompt.
@@ -21,6 +23,8 @@ pub(crate) mod traits {
 		fn outro(&mut self, message: impl Display) -> Result<()>;
 		/// Prints a footer of the prompt sequence with a failure style.
 		fn outro_cancel(&mut self, message: impl Display) -> Result<()>;
+		/// Constructs a new [`Select`] prompt.
+		fn select<T: Clone + Eq>(&mut self, prompt: impl Display) -> impl Select<T>;
 		/// Prints a success message.
 		fn success(&mut self, message: impl Display) -> Result<()>;
 		/// Prints a warning message.
@@ -29,8 +33,27 @@ pub(crate) mod traits {
 
 	/// A confirmation prompt.
 	pub trait Confirm {
+		/// Sets the initially selected value.
+		fn initial_value(self, initial_value: bool) -> Self;
 		/// Starts the prompt interaction.
 		fn interact(&mut self) -> Result<bool>;
+	}
+
+	/// A text input prompt.
+	pub trait Input {
+		/// Sets the default value for the input.
+		fn default_input(self, value: &str) -> Self;
+		/// Starts the prompt interaction.
+		fn interact(&mut self) -> Result<String>;
+		/// Sets the placeholder (hint) text for the input.
+		fn placeholder(self, value: &str) -> Self;
+		/// Sets whether the input is required.
+		fn required(self, required: bool) -> Self;
+		/// Sets a validation callback for the input that is called when the user submits.
+		fn validate(
+			self,
+			validator: impl Fn(&String) -> std::result::Result<(), &'static str> + 'static,
+		) -> Self;
 	}
 
 	/// A multi-select prompt.
@@ -41,6 +64,16 @@ pub(crate) mod traits {
 		fn item(self, value: T, label: impl Display, hint: impl Display) -> Self;
 		/// Sets whether the input is required.
 		fn required(self, required: bool) -> Self;
+	}
+
+	/// A select prompt.
+	pub trait Select<T> {
+		/// Sets the initially selected value.
+		fn initial_value(self, initial_value: T) -> Self;
+		/// Starts the prompt interaction.
+		fn interact(&mut self) -> Result<T>;
+		/// Adds an item to the selection prompt.
+		fn item(self, value: T, label: impl Display, hint: impl Display) -> Self;
 	}
 }
 
@@ -55,6 +88,11 @@ impl traits::Cli for Cli {
 	/// Prints an info message.
 	fn info(&mut self, text: impl Display) -> Result<()> {
 		cliclack::log::info(text)
+	}
+
+	/// Constructs a new [`Input`] prompt.
+	fn input(&mut self, prompt: impl Display) -> impl traits::Input {
+		Input(cliclack::input(prompt))
 	}
 
 	/// Prints a header of the prompt sequence.
@@ -79,6 +117,11 @@ impl traits::Cli for Cli {
 		cliclack::outro_cancel(message)
 	}
 
+	/// Constructs a new [`Select`] prompt.
+	fn select<T: Clone + Eq>(&mut self, prompt: impl Display) -> impl traits::Select<T> {
+		Select::<T>(cliclack::select(prompt))
+	}
+
 	/// Prints a success message.
 	fn success(&mut self, message: impl Display) -> Result<()> {
 		cliclack::log::success(message)
@@ -93,9 +136,46 @@ impl traits::Cli for Cli {
 /// A confirmation prompt using cliclack.
 struct Confirm(cliclack::Confirm);
 impl traits::Confirm for Confirm {
+	/// Sets the initially selected value.
+	fn initial_value(mut self, initial_value: bool) -> Self {
+		self.0 = self.0.initial_value(initial_value);
+		self
+	}
 	/// Starts the prompt interaction.
 	fn interact(&mut self) -> Result<bool> {
 		self.0.interact()
+	}
+}
+
+/// A input prompt using cliclack.
+struct Input(cliclack::Input);
+impl traits::Input for Input {
+	/// Sets the default value for the input.
+	fn default_input(mut self, value: &str) -> Self {
+		self.0 = self.0.default_input(value);
+		self
+	}
+	/// Starts the prompt interaction.
+	fn interact(&mut self) -> Result<String> {
+		self.0.interact()
+	}
+	/// Sets the placeholder (hint) text for the input.
+	fn placeholder(mut self, placeholder: &str) -> Self {
+		self.0 = self.0.placeholder(placeholder);
+		self
+	}
+	/// Sets whether the input is required.
+	fn required(mut self, required: bool) -> Self {
+		self.0 = self.0.required(required);
+		self
+	}
+	/// Sets a validation callback for the input that is called when the user submits.
+	fn validate(
+		mut self,
+		validator: impl Fn(&String) -> std::result::Result<(), &'static str> + 'static,
+	) -> Self {
+		self.0 = self.0.validate(validator);
+		self
 	}
 }
 
@@ -121,21 +201,44 @@ impl<T: Clone + Eq> traits::MultiSelect<T> for MultiSelect<T> {
 	}
 }
 
+/// A select prompt using cliclack.
+struct Select<T: Clone + Eq>(cliclack::Select<T>);
+
+impl<T: Clone + Eq> traits::Select<T> for Select<T> {
+	fn initial_value(mut self, initial_value: T) -> Self {
+		self.0 = self.0.initial_value(initial_value);
+		self
+	}
+
+	/// Starts the prompt interaction.
+	fn interact(&mut self) -> Result<T> {
+		self.0.interact()
+	}
+
+	/// Adds an item to the selection prompt.
+	fn item(mut self, value: T, label: impl Display, hint: impl Display) -> Self {
+		self.0 = self.0.item(value, label, hint);
+		self
+	}
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
 	use super::traits::*;
-	use std::{fmt::Display, io::Result};
+	use std::{fmt::Display, io::Result, usize};
 
 	/// Mock Cli with optional expectations
 	#[derive(Default)]
 	pub(crate) struct MockCli {
-		confirm_expectation: Option<(String, bool)>,
+		confirm_expectation: Vec<(String, bool)>,
 		info_expectations: Vec<String>,
+		input_expectations: Vec<(String, String)>,
 		intro_expectation: Option<String>,
 		outro_expectation: Option<String>,
 		multiselect_expectation:
 			Option<(String, Option<bool>, bool, Option<Vec<(String, String)>>)>,
 		outro_cancel_expectation: Option<String>,
+		select_expectation: Vec<(String, Option<bool>, bool, Option<Vec<(String, String)>>, usize)>,
 		success_expectations: Vec<String>,
 		warning_expectations: Vec<String>,
 	}
@@ -146,12 +249,17 @@ pub(crate) mod tests {
 		}
 
 		pub(crate) fn expect_confirm(mut self, prompt: impl Display, confirm: bool) -> Self {
-			self.confirm_expectation = Some((prompt.to_string(), confirm));
+			self.confirm_expectation.insert(0, (prompt.to_string(), confirm));
+			self
+		}
+
+		pub(crate) fn expect_input(mut self, prompt: impl Display, input: String) -> Self {
+			self.input_expectations.insert(0, (prompt.to_string(), input));
 			self
 		}
 
 		pub(crate) fn expect_info(mut self, message: impl Display) -> Self {
-			self.info_expectations.push(message.to_string());
+			self.info_expectations.insert(0, message.to_string());
 			self
 		}
 
@@ -181,6 +289,19 @@ pub(crate) mod tests {
 			self
 		}
 
+		pub(crate) fn expect_select(
+			mut self,
+			prompt: impl Display,
+			required: Option<bool>,
+			collect: bool,
+			items: Option<Vec<(String, String)>>,
+			item: usize,
+		) -> Self {
+			self.select_expectation
+				.insert(0, (prompt.to_string(), required, collect, items, item));
+			self
+		}
+
 		pub(crate) fn expect_success(mut self, message: impl Display) -> Self {
 			self.success_expectations.push(message.to_string());
 			self
@@ -192,11 +313,14 @@ pub(crate) mod tests {
 		}
 
 		pub(crate) fn verify(self) -> anyhow::Result<()> {
-			if let Some((expectation, _)) = self.confirm_expectation {
-				panic!("`{expectation}` confirm expectation not satisfied")
+			if !self.confirm_expectation.is_empty() {
+				panic!("`{:?}` confirm expectations not satisfied", self.confirm_expectation)
 			}
 			if !self.info_expectations.is_empty() {
 				panic!("`{}` info log expectations not satisfied", self.info_expectations.join(","))
+			}
+			if !self.input_expectations.is_empty() {
+				panic!("`{:?}` input expectation not satisfied", self.input_expectations)
 			}
 			if let Some(expectation) = self.intro_expectation {
 				panic!("`{expectation}` intro expectation not satisfied")
@@ -209,6 +333,16 @@ pub(crate) mod tests {
 			}
 			if let Some(expectation) = self.outro_cancel_expectation {
 				panic!("`{expectation}` outro cancel expectation not satisfied")
+			}
+			if !self.select_expectation.is_empty() {
+				panic!(
+					"`{}` select prompt expectation not satisfied",
+					self.select_expectation
+						.iter()
+						.map(|(s, _, _, _, _)| s.clone()) // Extract the `String` part
+						.collect::<Vec<_>>()
+						.join(", ")
+				);
 			}
 			if !self.success_expectations.is_empty() {
 				panic!(
@@ -229,7 +363,7 @@ pub(crate) mod tests {
 	impl Cli for MockCli {
 		fn confirm(&mut self, prompt: impl Display) -> impl Confirm {
 			let prompt = prompt.to_string();
-			if let Some((expectation, confirm)) = self.confirm_expectation.take() {
+			if let Some((expectation, confirm)) = self.confirm_expectation.pop() {
 				assert_eq!(expectation, prompt, "prompt does not satisfy expectation");
 				return MockConfirm { confirm };
 			}
@@ -240,6 +374,20 @@ pub(crate) mod tests {
 			let message = message.to_string();
 			self.info_expectations.retain(|x| *x != message);
 			Ok(())
+		}
+
+		fn input(&mut self, prompt: impl Display) -> impl Input {
+			let prompt = prompt.to_string();
+			if let Some((expectation, input)) = self.input_expectations.pop() {
+				assert_eq!(expectation, prompt, "prompt does not satisfy expectation");
+				return MockInput {
+					prompt: input.clone(),
+					input,
+					placeholder: "".to_string(),
+					required: false,
+				};
+			}
+			MockInput::default()
 		}
 
 		fn intro(&mut self, title: impl Display) -> Result<()> {
@@ -288,6 +436,24 @@ pub(crate) mod tests {
 			Ok(())
 		}
 
+		fn select<T: Clone + Eq>(&mut self, prompt: impl Display) -> impl Select<T> {
+			let prompt = prompt.to_string();
+			if let Some((expectation, _, collect, items_expectation, item)) =
+				self.select_expectation.pop()
+			{
+				assert_eq!(expectation, prompt, "prompt does not satisfy expectation");
+				return MockSelect {
+					items_expectation,
+					collect,
+					items: vec![],
+					item,
+					initial_value: None,
+				};
+			}
+
+			MockSelect::default()
+		}
+
 		fn success(&mut self, message: impl Display) -> Result<()> {
 			let message = message.to_string();
 			self.success_expectations.retain(|x| *x != message);
@@ -308,8 +474,48 @@ pub(crate) mod tests {
 	}
 
 	impl Confirm for MockConfirm {
+		fn initial_value(mut self, _initial_value: bool) -> Self {
+			self.confirm = self.confirm; // Ignore initial value and always return mock value
+			self
+		}
 		fn interact(&mut self) -> Result<bool> {
 			Ok(self.confirm)
+		}
+	}
+
+	/// Mock input prompt
+	#[derive(Default)]
+	struct MockInput {
+		prompt: String,
+		input: String,
+		placeholder: String,
+		required: bool,
+	}
+
+	impl Input for MockInput {
+		fn interact(&mut self) -> Result<String> {
+			Ok(self.prompt.clone())
+		}
+		fn default_input(mut self, value: &str) -> Self {
+			self.input = value.to_string();
+			self
+		}
+
+		fn placeholder(mut self, value: &str) -> Self {
+			self.placeholder = value.to_string();
+			self
+		}
+
+		fn required(mut self, value: bool) -> Self {
+			self.required = value;
+			self
+		}
+
+		fn validate(
+			self,
+			_validator: impl Fn(&String) -> std::result::Result<(), &'static str> + 'static,
+		) -> Self {
+			self
 		}
 	}
 
@@ -356,6 +562,52 @@ pub(crate) mod tests {
 			if let Some(expectation) = self.required_expectation.as_ref() {
 				assert_eq!(*expectation, required, "required does not satisfy expectation");
 				self.required_expectation = None;
+			}
+			self
+		}
+	}
+
+	/// Mock select prompt
+	pub(crate) struct MockSelect<T> {
+		items_expectation: Option<Vec<(String, String)>>,
+		collect: bool,
+		items: Vec<T>,
+		item: usize,
+		initial_value: Option<T>,
+	}
+
+	impl<T> MockSelect<T> {
+		pub(crate) fn default() -> Self {
+			Self {
+				items_expectation: None,
+				collect: false,
+				items: vec![],
+				item: 0,
+				initial_value: None,
+			}
+		}
+	}
+
+	impl<T: Clone + Eq> Select<T> for MockSelect<T> {
+		fn initial_value(mut self, initial_value: T) -> Self {
+			self.initial_value = Some(initial_value);
+			self
+		}
+
+		fn interact(&mut self) -> Result<T> {
+			Ok(self.items[self.item].clone())
+		}
+
+		fn item(mut self, value: T, label: impl Display, hint: impl Display) -> Self {
+			// Check expectations
+			if let Some(items) = self.items_expectation.as_mut() {
+				let item = (label.to_string(), hint.to_string());
+				assert!(items.contains(&item), "`{item:?}` item does not satisfy any expectations");
+				items.retain(|x| *x != item);
+			}
+			// Collect if specified
+			if self.collect {
+				self.items.push(value);
 			}
 			self
 		}

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -12,11 +12,7 @@ use pop_parachains::{
 	binary_path, build_parachain, export_wasm_file, generate_genesis_state_file,
 	generate_plain_chain_spec, generate_raw_chain_spec, is_supported, ChainSpec,
 };
-use std::{
-	env::current_dir,
-	fs::create_dir_all,
-	path::{Path, PathBuf},
-};
+use std::{env::current_dir, fs::create_dir_all, path::PathBuf};
 #[cfg(not(test))]
 use std::{thread::sleep, time::Duration};
 use strum::{EnumMessage, VariantArray};
@@ -127,78 +123,283 @@ pub(crate) enum RelayChain {
 	PolkadotLocal,
 }
 
-#[derive(Args)]
+/// Command for generating a chain specification.
+#[derive(Args, Clone)]
 pub struct BuildSpecCommand {
 	/// File name for the resulting spec. If a path is given,
 	/// the necessary directories will be created
-	/// [default: ./chain-spec.json].
 	#[arg(short = 'o', long = "output")]
 	pub(crate) output_file: Option<PathBuf>,
 	/// This command builds the node if it has not been built already.
 	/// For production, always build in release mode to exclude debug features.
-	#[clap(short = 'r', long, default_value = "true")]
+	#[arg(short = 'r', long)]
 	pub(crate) release: bool,
 	/// Parachain ID to be used when generating the chain spec files.
-	#[arg(short = 'i', long = "id")]
+	#[arg(short = 'i', long)]
 	pub(crate) id: Option<u32>,
 	/// Whether to keep localhost as a bootnode.
-	#[clap(long)]
+	#[arg(long)]
 	pub(crate) default_bootnode: bool,
-	/// Type of the chain [default: development].
+	/// Type of the chain.
 	#[arg(short = 't', long = "type", value_enum)]
 	pub(crate) chain_type: Option<ChainType>,
-	/// Specify the chain specification. It can be one of the predefined ones (dev, local) or a
-	/// custom one.
-	#[arg(short = 'c', long = "chain", default_value = "dev")]
+	/// Specify the chain specification. It can be one of the predefined ones (e.g. dev, local or a
+	/// custom one) or the path to an existing chain spec.
+	#[arg(short = 'c', long = "chain")]
 	pub(crate) chain: Option<String>,
-	/// Relay chain this parachain will connect to [default: paseo-local].
+	/// Relay chain this parachain will connect to.
 	#[arg(long, value_enum)]
 	pub(crate) relay: Option<RelayChain>,
 	/// Protocol-id to use in the specification.
 	#[arg(long = "protocol-id")]
 	pub(crate) protocol_id: Option<String>,
-	/// Whether the genesis state file should be generated [default: true].
-	#[clap(long = "genesis-state", default_value = "true")]
+	/// Whether the genesis state file should be generated.
+	#[arg(long = "genesis-state")]
 	pub(crate) genesis_state: bool,
-	/// Whether the genesis code file should be generated [default: true].
-	#[clap(long = "genesis-code", default_value = "true")]
+	/// Whether the genesis code file should be generated.
+	#[arg(long = "genesis-code")]
 	pub(crate) genesis_code: bool,
 }
 
 impl BuildSpecCommand {
-	/// Executes the command.
+	/// Executes the build spec command.
 	pub(crate) async fn execute(self) -> anyhow::Result<&'static str> {
+		let mut cli = Cli;
 		// Checks for appchain project in `./`.
 		if is_supported(None)? {
-			// If para id has been provided we can build the spec
-			// otherwise, we need to guide the user.
-			let _ = match self.id {
-				Some(_) => self.build(&mut Cli),
-				None => {
-					let config = guide_user_to_generate_spec(self).await?;
-					config.build(&mut Cli)
-				},
-			};
-			Ok("spec")
+			let build_spec = self.complete_build_spec(&mut cli).await?;
+			build_spec.build(&mut cli)
 		} else {
-			Cli.intro("Building your chain spec")?;
-			Cli.outro_cancel(
+			cli.intro("Generate your chain spec")?;
+			cli.outro_cancel(
 				"🚫 Can't build a specification for target. Maybe not a chain project ?",
 			)?;
 			Ok("spec")
 		}
 	}
 
-	/// Builds a parachain spec.
-	///
-	/// # Arguments
-	/// * `cli` - The CLI implementation to be used.
-	fn build(self, cli: &mut impl cli::traits::Cli) -> anyhow::Result<&'static str> {
-		cli.intro("Building your chain spec")?;
+	/// Completes chain specification requirements by prompting for missing inputs, validating
+	/// provided values, and preparing a BuildSpec for generating chain spec files.
+	async fn complete_build_spec(
+		self,
+		cli: &mut impl cli::traits::Cli,
+	) -> anyhow::Result<BuildSpec> {
+		cli.intro("Generate your chain spec")?;
 
-		// Either a para id was already provided or user has been guided to provide one.
-		let para_id = self.id.unwrap_or(DEFAULT_PARA_ID);
-		// Notify user in case we need to build the parachain project.
+		let BuildSpecCommand {
+			output_file,
+			release,
+			id,
+			default_bootnode,
+			chain_type,
+			chain,
+			relay,
+			protocol_id,
+			genesis_state,
+			genesis_code,
+		} = self;
+
+		// Prompt for chain specification.
+		let chain = match chain {
+			Some(chain) => chain,
+			_ => {
+				input("Specify the chain specification. It can be one of the predefined ones (e.g. dev, local or a custom one) or the path to an existing chain spec.")
+					.placeholder("dev")
+					.default_input("dev")
+					.interact()?
+			},
+		};
+
+		// Check if the provided chain specification is a file.
+		let maybe_chain_spec_file = PathBuf::from(&chain);
+		let output_file = if maybe_chain_spec_file.exists() && maybe_chain_spec_file.is_file() {
+			if output_file.is_some() {
+				cli.warning("NOTE: If an existing chain spec file is provided it will be used for the output path.")?;
+			}
+			// Set the provided chain specification file as output file.
+			maybe_chain_spec_file
+		} else {
+			let output_file = match output_file {
+				Some(output) => output,
+				None => {
+					// Prompt for output file if not provided.
+					let default_output = format!("./{DEFAULT_SPEC_NAME}");
+					input("Name of the plain chain spec file. If a path is given, the necessary directories will be created:")
+						.placeholder(&default_output)
+						.default_input(&default_output)
+						.interact()?
+				},
+			};
+			prepare_output_path(output_file)?
+		};
+		// If chain specification file already exists, obtain values for defaults when prompting.
+		let chain_spec = ChainSpec::from(&output_file).ok();
+
+		// Prompt for para id if not provided.
+		let id = match id {
+			Some(id) => id,
+			None => {
+				let default_id = chain_spec
+					.as_ref()
+					.and_then(|cs| cs.get_parachain_id())
+					.unwrap_or(DEFAULT_PARA_ID as u64)
+					.to_string();
+				input("What parachain ID should be used?")
+					.placeholder(&default_id)
+					.default_input(&default_id)
+					.interact()?
+			},
+		};
+
+		// Prompt for chain type if not provided.
+		let chain_type = match chain_type {
+			Some(chain_type) => chain_type,
+			None => {
+				let mut prompt = cliclack::select("Choose the chain type: ".to_string());
+				let default = chain_spec
+					.as_ref()
+					.and_then(|cs| cs.get_chain_type())
+					.and_then(|r| ChainType::from_str(r, true).ok());
+				if let Some(chain_type) = default.as_ref() {
+					prompt = prompt.initial_value(chain_type);
+				}
+				for (i, chain_type) in ChainType::VARIANTS.iter().enumerate() {
+					if default.is_none() && i == 0 {
+						prompt = prompt.initial_value(chain_type);
+					}
+					prompt = prompt.item(
+						chain_type,
+						chain_type.get_message().unwrap_or(chain_type.as_ref()),
+						chain_type.get_detailed_message().unwrap_or_default(),
+					);
+				}
+				prompt.interact()?.clone()
+			},
+		};
+
+		// Prompt for relay chain if not provided.
+		let relay = match relay {
+			Some(relay) => relay,
+			None => {
+				let mut prompt = cliclack::select(
+					"Choose the relay chain your chain will be connecting to: ".to_string(),
+				);
+				let default = chain_spec
+					.as_ref()
+					.and_then(|cs| cs.get_relay_chain())
+					.and_then(|r| RelayChain::from_str(r, true).ok());
+				if let Some(relay) = default.as_ref() {
+					prompt = prompt.initial_value(relay);
+				}
+				for relay in RelayChain::VARIANTS {
+					prompt = prompt.item(
+						relay,
+						relay.get_message().unwrap_or(relay.as_ref()),
+						relay.get_detailed_message().unwrap_or_default(),
+					);
+				}
+				prompt.interact()?.clone()
+			},
+		};
+
+		// Prompt for default bootnode if not provided and chain type is Local or Live.
+		let default_bootnode = if !default_bootnode {
+			match chain_type {
+				ChainType::Development => true,
+				_ => confirm("Would you like to use local host as a bootnode ?".to_string())
+					.interact()?,
+			}
+		} else {
+			true
+		};
+
+		// Prompt for protocol-id if not provided.
+		let protocol_id = match protocol_id {
+			Some(protocol_id) => protocol_id,
+			None => {
+				let default = chain_spec
+					.as_ref()
+					.and_then(|cs| cs.get_protocol_id())
+					.unwrap_or(DEFAULT_PROTOCOL_ID)
+					.to_string();
+				input("Enter the protocol ID that will identify your network:")
+					.placeholder(&default)
+					.default_input(&default)
+					.interact()?
+			},
+		};
+
+		// Prompt for genesis state if not provided.
+		let genesis_state = if !genesis_state {
+			confirm("Should the genesis state file be generated ?".to_string())
+				.initial_value(true)
+				.interact()?
+		} else {
+			true
+		};
+
+		// Prompt for genesis code if not provided.
+		let genesis_code = if !genesis_code {
+			confirm("Should the genesis code file be generated ?".to_string())
+				.initial_value(true)
+				.interact()?
+		} else {
+			true
+		};
+
+		// Only prompt user for build profile if a live spec is being built on debug mode.
+		let release = if !release && matches!(chain_type, ChainType::Live) {
+			confirm("Using Debug profile to build a Live specification. Should Release be used instead ?")
+				.initial_value(true)
+				.interact()?
+		} else {
+			release
+		};
+
+		Ok(BuildSpec {
+			output_file,
+			release,
+			id,
+			default_bootnode,
+			chain_type,
+			chain,
+			relay,
+			protocol_id,
+			genesis_state,
+			genesis_code,
+		})
+	}
+}
+
+// Represents the configuration for building a chain specification.
+struct BuildSpec {
+	output_file: PathBuf,
+	release: bool,
+	id: u32,
+	default_bootnode: bool,
+	chain_type: ChainType,
+	chain: String,
+	relay: RelayChain,
+	protocol_id: String,
+	genesis_state: bool,
+	genesis_code: bool,
+}
+
+impl BuildSpec {
+	// Executes the process of generating the chain specification.
+	//
+	// This function generates plain and raw chain spec files based on the provided configuration,
+	// optionally including genesis state and runtime artifacts. If the node binary is missing,
+	// it triggers a build process.
+	fn build(&self, cli: &mut impl cli::traits::Cli) -> anyhow::Result<&'static str> {
+		cli.intro("Building your chain spec")?;
+		let spinner = spinner();
+		spinner.start("Generating chain specification...");
+		let mut generated_files = vec![];
+
+		// Ensure binary is built.
+		let mode: Profile = self.release.into();
+		let binary_path = ensure_binary_exists(cli, &mode)?;
 		if !self.release {
 			cli.warning(
 				"NOTE: this command defaults to DEBUG builds for development chain types. Please use `--release` (or simply `-r` for a release build...)",
@@ -206,78 +407,32 @@ impl BuildSpecCommand {
 			#[cfg(not(test))]
 			sleep(Duration::from_secs(3))
 		}
-		let spinner = spinner();
-		spinner.start("Generating chain specification...");
 
-		// Create output path if needed
-		let mut output_path = self.output_file.unwrap_or_else(|| PathBuf::from("./"));
-		let mut plain_chain_spec;
-		if output_path.is_dir() {
-			if !output_path.exists() {
-				// Generate the output path if needed
-				create_dir_all(&output_path)?;
-			}
-			plain_chain_spec = output_path.join(DEFAULT_SPEC_NAME);
-		} else {
-			plain_chain_spec = output_path.clone();
-			output_path.pop();
-			if !output_path.exists() {
-				// Generate the output path if needed
-				create_dir_all(&output_path)?;
-			}
-		}
-		plain_chain_spec.set_extension("json");
-
-		// Locate binary, if it doesn't exist trigger build.
-		let mode: Profile = self.release.into();
-		let cwd = current_dir().unwrap_or(PathBuf::from("./"));
-		let binary_path = match binary_path(&mode.target_directory(&cwd), &cwd.join("node")) {
-			Ok(binary_path) => binary_path,
-			_ => {
-				spinner.clear();
-				cli.info("Node was not found. The project will be built locally.".to_string())?;
-				cli.warning("NOTE: this may take some time...")?;
-				build_parachain(&cwd, None, &mode, None)?
-			},
-		};
-
-		// Generate plain spec.
-		spinner.set_message("Generating plain chain specification...");
-		let mut generated_files = vec![];
+		// Generate chain spec.
 		generate_plain_chain_spec(
 			&binary_path,
-			&plain_chain_spec,
+			&self.output_file,
 			self.default_bootnode,
-			self.chain.as_deref(),
+			&self.chain,
 		)?;
+		// Customize spec based on input.
+		self.customize()?;
 		generated_files.push(format!(
 			"Plain text chain specification file generated at: {}",
-			plain_chain_spec.display()
+			self.output_file.display()
 		));
-
-		// Customize spec based on input.
-		let mut chain_spec = ChainSpec::from(&plain_chain_spec)?;
-		chain_spec.replace_para_id(para_id)?;
-		let relay = self.relay.unwrap_or(RelayChain::PaseoLocal).to_string();
-		chain_spec.replace_relay_chain(&relay)?;
-		let chain_type = self.chain_type.unwrap_or(ChainType::Development).to_string();
-		chain_spec.replace_chain_type(&chain_type)?;
-		if self.protocol_id.is_some() {
-			let protocol_id = self.protocol_id.unwrap_or(DEFAULT_PROTOCOL_ID.to_string());
-			chain_spec.replace_protocol_id(&protocol_id)?;
-		}
-		chain_spec.to_file(&plain_chain_spec)?;
 
 		// Generate raw spec.
 		spinner.set_message("Generating raw chain specification...");
-		let spec_name = plain_chain_spec
+		let spec_name = self
+			.output_file
 			.file_name()
 			.and_then(|s| s.to_str())
 			.unwrap_or(DEFAULT_SPEC_NAME)
 			.trim_end_matches(".json");
 		let raw_spec_name = format!("{spec_name}-raw.json");
 		let raw_chain_spec =
-			generate_raw_chain_spec(&binary_path, &plain_chain_spec, &raw_spec_name)?;
+			generate_raw_chain_spec(&binary_path, &self.output_file, &raw_spec_name)?;
 		generated_files.push(format!(
 			"Raw chain specification file generated at: {}",
 			raw_chain_spec.display()
@@ -286,15 +441,14 @@ impl BuildSpecCommand {
 		// Generate genesis artifacts.
 		if self.genesis_code {
 			spinner.set_message("Generating genesis code...");
-			let wasm_file_name = format!("para-{}.wasm", para_id);
+			let wasm_file_name = format!("para-{}.wasm", self.id);
 			let wasm_file = export_wasm_file(&binary_path, &raw_chain_spec, &wasm_file_name)?;
 			generated_files
 				.push(format!("WebAssembly runtime file exported at: {}", wasm_file.display()));
 		}
-
 		if self.genesis_state {
 			spinner.set_message("Generating genesis state...");
-			let genesis_file_name = format!("para-{}-genesis-state", para_id);
+			let genesis_file_name = format!("para-{}-genesis-state", self.id);
 			let genesis_state_file =
 				generate_genesis_state_file(&binary_path, &raw_chain_spec, &genesis_file_name)?;
 			generated_files
@@ -302,7 +456,6 @@ impl BuildSpecCommand {
 		}
 
 		spinner.stop("Chain specification built successfully.");
-
 		let generated_files: Vec<_> = generated_files
 			.iter()
 			.map(|s| style(format!("{} {s}", console::Emoji("●", ">"))).dim().to_string())
@@ -312,162 +465,51 @@ impl BuildSpecCommand {
 			"Need help? Learn more at {}\n",
 			style("https://learn.onpop.io").magenta().underlined()
 		))?;
-
 		Ok("spec")
+	}
+
+	// Customize a chain specification.
+	fn customize(&self) -> anyhow::Result<()> {
+		let mut chain_spec = ChainSpec::from(&self.output_file)?;
+		chain_spec.replace_para_id(self.id)?;
+		chain_spec.replace_relay_chain(&self.relay.to_string())?;
+		chain_spec.replace_chain_type(&self.chain_type.to_string())?;
+		chain_spec.replace_protocol_id(&self.protocol_id)?;
+		chain_spec.to_file(&self.output_file)?;
+		Ok(())
 	}
 }
 
-/// Guide the user to generate their chain specification.
-async fn guide_user_to_generate_spec(args: BuildSpecCommand) -> anyhow::Result<BuildSpecCommand> {
-	Cli.intro("Generate your chain spec")?;
-
-	// Confirm output path
-	let default_output = format!("./{DEFAULT_SPEC_NAME}");
-	let output_file: String = input("Name of the plain chain spec file. If a path is given, the necessary directories will be created:")
-		.placeholder(&default_output)
-		.default_input(&default_output)
-		.interact()?;
-
-	// Check if specified chain spec already exists, allowing us to default values for prompts
-	let path = Path::new(&output_file);
-	let chain_spec =
-		(path.is_file() && path.exists()).then(|| ChainSpec::from(path).ok()).flatten();
-
-	// Prompt for chain id.
-	let default = chain_spec
-		.as_ref()
-		.and_then(|cs| cs.get_parachain_id())
-		.unwrap_or(DEFAULT_PARA_ID as u64)
-		.to_string();
-	let para_id: u32 = input("What parachain ID should be used?")
-		.placeholder(&default)
-		.default_input(&default)
-		.interact()?;
-
-	// Prompt for chain type.
-	// If relay is Kusama or Polkadot, then Live type is used and user is not prompted.
-	let mut prompt = cliclack::select("Choose the chain type: ".to_string());
-	let default = chain_spec
-		.as_ref()
-		.and_then(|cs| cs.get_chain_type())
-		.and_then(|r| ChainType::from_str(r, true).ok());
-	if let Some(chain_type) = default.as_ref() {
-		prompt = prompt.initial_value(chain_type);
+// Locate binary, if it doesn't exist trigger build.
+fn ensure_binary_exists(
+	cli: &mut impl cli::traits::Cli,
+	mode: &Profile,
+) -> anyhow::Result<PathBuf> {
+	let cwd = current_dir().unwrap_or(PathBuf::from("./"));
+	match binary_path(&mode.target_directory(&cwd), &cwd.join("node")) {
+		Ok(binary_path) => Ok(binary_path),
+		_ => {
+			cli.info("Node was not found. The project will be built locally.".to_string())?;
+			cli.warning("NOTE: this may take some time...")?;
+			build_parachain(&cwd, None, mode, None).map_err(|e| e.into())
+		},
 	}
-	for (i, chain_type) in ChainType::VARIANTS.iter().enumerate() {
-		if default.is_none() && i == 0 {
-			prompt = prompt.initial_value(chain_type);
+}
+
+// Prepare the output path provided.
+fn prepare_output_path(mut output_path: PathBuf) -> anyhow::Result<PathBuf> {
+	if output_path.is_dir() {
+		if !output_path.exists() {
+			create_dir_all(&output_path)?;
 		}
-		prompt = prompt.item(
-			chain_type,
-			chain_type.get_message().unwrap_or(chain_type.as_ref()),
-			chain_type.get_detailed_message().unwrap_or_default(),
-		);
+		output_path.push(DEFAULT_SPEC_NAME);
+	} else {
+		if let Some(parent_dir) = output_path.parent() {
+			if !parent_dir.exists() {
+				create_dir_all(&output_path)?;
+			}
+		}
 	}
-	let chain_type: ChainType = prompt.interact()?.clone();
-	// Prompt for chain
-	let chain: String = input("Specify the chain specification. It can be one of the predefined ones (dev, local) or a custom one.")
-		.placeholder("dev")
-		.default_input("dev")
-		.interact()?;
-
-	// Prompt for relay chain.
-	let mut prompt =
-		cliclack::select("Choose the relay chain your chain will be connecting to: ".to_string());
-	let default = chain_spec
-		.as_ref()
-		.and_then(|cs| cs.get_relay_chain())
-		.and_then(|r| RelayChain::from_str(r, true).ok());
-	if let Some(relay) = default.as_ref() {
-		prompt = prompt.initial_value(relay);
-	}
-	// Prompt relays chains based on the chain type
-	match chain_type {
-		ChainType::Live =>
-			for relay in RelayChain::VARIANTS {
-				if !matches!(
-					relay,
-					RelayChain::Westend |
-						RelayChain::Paseo | RelayChain::Kusama |
-						RelayChain::Polkadot
-				) {
-					continue;
-				} else {
-					prompt = prompt.item(
-						relay,
-						relay.get_message().unwrap_or(relay.as_ref()),
-						relay.get_detailed_message().unwrap_or_default(),
-					);
-				}
-			},
-		_ =>
-			for relay in RelayChain::VARIANTS {
-				if matches!(
-					relay,
-					RelayChain::Westend |
-						RelayChain::Paseo | RelayChain::Kusama |
-						RelayChain::Polkadot
-				) {
-					continue;
-				} else {
-					prompt = prompt.item(
-						relay,
-						relay.get_message().unwrap_or(relay.as_ref()),
-						relay.get_detailed_message().unwrap_or_default(),
-					);
-				}
-			},
-	}
-
-	let relay_chain = prompt.interact()?.clone();
-
-	// Prompt for default bootnode if chain type is Local or Live.
-	let default_bootnode = match chain_type {
-		ChainType::Development => true,
-		_ => confirm("Would you like to use local host as a bootnode ?".to_string()).interact()?,
-	};
-
-	// Prompt for protocol-id.
-	let default = chain_spec
-		.as_ref()
-		.and_then(|cs| cs.get_protocol_id())
-		.unwrap_or(DEFAULT_PROTOCOL_ID)
-		.to_string();
-	let protocol_id: String = input("Enter the protocol ID that will identify your network:")
-		.placeholder(&default)
-		.default_input(&default)
-		.interact()?;
-
-	// Prompt for genesis state
-	let genesis_state = confirm("Should the genesis state file be generated ?".to_string())
-		.initial_value(true)
-		.interact()?;
-
-	// Prompt for genesis code
-	let genesis_code = confirm("Should the genesis code file be generated ?".to_string())
-		.initial_value(true)
-		.interact()?;
-
-	// Only check user to check their profile selection if a live spec is being built on debug mode.
-	let profile =
-		if !args.release && matches!(chain_type, ChainType::Live) {
-			confirm("Using Debug profile to build a Live specification. Should Release be used instead ?")
-    		.initial_value(true)
-    		.interact()?
-		} else {
-			args.release
-		};
-
-	Ok(BuildSpecCommand {
-		output_file: Some(PathBuf::from(output_file)),
-		release: profile,
-		id: Some(para_id),
-		default_bootnode,
-		chain_type: Some(chain_type),
-		chain: Some(chain),
-		relay: Some(relay_chain),
-		protocol_id: Some(protocol_id),
-		genesis_state,
-		genesis_code,
-	})
+	output_path.set_extension("json");
+	Ok(output_path)
 }

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -143,7 +143,7 @@ pub struct BuildSpecCommand {
 	/// Type of the chain.
 	#[arg(short = 't', long = "type", value_enum)]
 	pub(crate) chain_type: Option<ChainType>,
-	/// Provide the chain specification to use (e.g. dev , local, custom or a path to an existing file).
+	/// Provide the chain specification to use (e.g. dev, local, custom or a path to an existing file).
 	#[arg(short = 'c', long = "chain")]
 	pub(crate) chain: Option<String>,
 	/// Relay chain this parachain will connect to.
@@ -206,7 +206,7 @@ impl BuildSpecCommand {
 			Some(chain) => chain,
 			_ => {
 				// Prompt for chain if not provided.
-				input("Provide the chain specification to use (e.g. dev , local, custom or a path to an existing file)")
+				input("Provide the chain specification to use (e.g. dev, local, custom or a path to an existing file)")
 					.default_input("dev")
 					.interact()?
 			},
@@ -403,8 +403,6 @@ impl BuildSpec {
 	// it triggers a build process.
 	fn build(&self, cli: &mut impl cli::traits::Cli) -> anyhow::Result<&'static str> {
 		cli.intro("Building your chain spec")?;
-		let spinner = spinner();
-		spinner.start("Generating chain specification...");
 		let mut generated_files = vec![];
 
 		// Ensure binary is built.
@@ -417,6 +415,8 @@ impl BuildSpec {
 			#[cfg(not(test))]
 			sleep(Duration::from_secs(3))
 		}
+		let spinner = spinner();
+		spinner.start("Generating chain specification...");
 
 		// Generate chain spec.
 		generate_plain_chain_spec(

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -315,8 +315,8 @@ impl BuildSpecCommand {
 		// Protocol id.
 		let protocol_id = match protocol_id
 		{
-			Some(protocol_id) if !prompt => protocol_id,
-			_ => {
+			Some(protocol_id) => protocol_id,
+			None => {
 				let default =
 					chain_spec.as_ref().and_then(|cs| cs.get_protocol_id()).unwrap_or(DEFAULT_PROTOCOL_ID).to_string();
 				if prompt {

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -246,86 +246,85 @@ impl BuildSpecCommand {
 		let chain_spec = ChainSpec::from(&output_file).ok();
 
 		// Para id.
-		let id = match id.or_else(|| {
-			chain_spec.as_ref().and_then(|cs| cs.get_parachain_id().map(|id| id as u32))
-		}) {
-			Some(id) if !prompt => id,
-			// No para id provided or user wants to make changes.
-			_ => {
-				let default = id.unwrap_or(DEFAULT_PARA_ID).to_string();
-				input("What parachain ID should be used?")
-					.placeholder(&default)
-					.default_input(&default)
-					.interact()?
+		let id = match id {
+			Some(id) => id,
+			None => {
+				let default =
+					chain_spec.as_ref().and_then(|cs| cs.get_parachain_id().map(|id| id as u32)).unwrap_or(DEFAULT_PARA_ID);
+				if prompt {
+					// Prompt for para id.
+					input("What parachain ID should be used?")
+						.default_input(&default.to_string())
+						.interact()?
+				} else { default }
 			},
 		};
 
 		// Chain type.
-		let chain_type = match chain_type.clone().or_else(|| {
-			chain_spec
-				.as_ref()
-				.and_then(|cs| cs.get_chain_type())
-				.and_then(|r| ChainType::from_str(r, true).ok())
-		}) {
-			Some(chain_type) if !prompt => chain_type,
-			// No chain type provided or user wants to make changes.
-			_ => {
-				// Prompt for chain type.
-				let default = chain_type.unwrap_or_default();
-				let mut prompt =
-					cliclack::select("Choose the chain type: ".to_string()).initial_value(&default);
-				for chain_type in ChainType::VARIANTS {
-					prompt = prompt.item(
-						chain_type,
-						chain_type.get_message().unwrap_or(chain_type.as_ref()),
-						chain_type.get_detailed_message().unwrap_or_default(),
-					);
-				}
-				prompt.interact()?.clone()
+		let chain_type = match chain_type {
+			Some(chain_type) => chain_type,
+			None => {
+				let default =
+					chain_spec
+						.as_ref()
+						.and_then(|cs| cs.get_chain_type())
+						.and_then(|r| ChainType::from_str(r, true).ok()).unwrap_or_default();
+				if prompt {
+					// Prompt for chain type.
+					let mut prompt =
+						cliclack::select("Choose the chain type: ".to_string()).initial_value(&default);
+					for chain_type in ChainType::VARIANTS {
+						prompt = prompt.item(
+							chain_type,
+							chain_type.get_message().unwrap_or(chain_type.as_ref()),
+							chain_type.get_detailed_message().unwrap_or_default(),
+						);
+					}
+					prompt.interact()?.clone()
+				} else { default }
 			},
 		};
 
 		// Relay.
-		let relay = match relay.clone().or_else(|| {
-			chain_spec
-				.as_ref()
-				.and_then(|cs| cs.get_relay_chain())
-				.and_then(|r| RelayChain::from_str(r, true).ok())
-		}) {
-			Some(relay) if !prompt => relay,
-			// No relay provided or user wants to make changes.
-			_ => {
-				// Prompt for relay if not provided.
-				let default = relay.unwrap_or_default();
-				let mut prompt = cliclack::select(
-					"Choose the relay chain your chain will be connecting to: ".to_string(),
-				)
-				.initial_value(&default);
-				for relay in RelayChain::VARIANTS {
-					prompt = prompt.item(
-						relay,
-						relay.get_message().unwrap_or(relay.as_ref()),
-						relay.get_detailed_message().unwrap_or_default(),
-					);
-				}
-				prompt.interact()?.clone()
+		let relay = match relay {
+			Some(relay) => relay,
+			None => {
+				let default =
+					chain_spec
+						.as_ref()
+						.and_then(|cs| cs.get_relay_chain())
+						.and_then(|r| RelayChain::from_str(r, true).ok()).unwrap_or_default();
+				if prompt {
+					// Prompt for relay.
+					let mut prompt = cliclack::select(
+						"Choose the relay chain your chain will be connecting to: ".to_string(),
+					)
+						.initial_value(&default);
+					for relay in RelayChain::VARIANTS {
+						prompt = prompt.item(
+							relay,
+							relay.get_message().unwrap_or(relay.as_ref()),
+							relay.get_detailed_message().unwrap_or_default(),
+						);
+					}
+					prompt.interact()?.clone()
+				} else { default }
 			},
 		};
 
 		// Protocol id.
 		let protocol_id = match protocol_id
-			.clone()
-			.or_else(|| chain_spec.as_ref().and_then(|cs| cs.get_protocol_id().map(String::from)))
 		{
 			Some(protocol_id) if !prompt => protocol_id,
-			// No protocol id provided or user wants to make changes.
 			_ => {
-				// Prompt for protocol id if not provided.
-				let default = protocol_id.unwrap_or(DEFAULT_PROTOCOL_ID.to_string());
-				input("Enter the protocol ID that will identify your network:")
-					.placeholder(&default)
-					.default_input(&default)
-					.interact()?
+				let default =
+					chain_spec.as_ref().and_then(|cs| cs.get_protocol_id()).unwrap_or(DEFAULT_PROTOCOL_ID).to_string();
+				if prompt {
+					// Prompt for protocol id.
+					input("Enter the protocol ID that will identify your network:")
+						.default_input(&default)
+						.interact()?
+				} else { default }
 			},
 		};
 

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -124,7 +124,7 @@ pub(crate) enum RelayChain {
 }
 
 /// Command for generating a chain specification.
-#[derive(Args, Clone)]
+#[derive(Args)]
 pub struct BuildSpecCommand {
 	/// File name for the resulting spec. If a path is given,
 	/// the necessary directories will be created

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -143,8 +143,7 @@ pub struct BuildSpecCommand {
 	/// Type of the chain.
 	#[arg(short = 't', long = "type", value_enum)]
 	pub(crate) chain_type: Option<ChainType>,
-	/// Specify the chain specification. It can be one of the predefined ones (e.g. dev, local or a
-	/// custom one) or the path to an existing chain spec.
+	/// Provide the chain specification to use (e.g. dev , local, custom or a path to an existing file).
 	#[arg(short = 'c', long = "chain")]
 	pub(crate) chain: Option<String>,
 	/// Relay chain this parachain will connect to.
@@ -180,6 +179,9 @@ impl BuildSpecCommand {
 
 	/// Complete chain specification requirements by prompting for missing inputs, validating
 	/// provided values, and preparing a BuildSpec to generate file(s).
+	///
+	/// # Arguments
+	/// * `cli` - The cli.
 	async fn complete_build_spec(
 		self,
 		cli: &mut impl cli::traits::Cli,
@@ -204,8 +206,7 @@ impl BuildSpecCommand {
 			Some(chain) => chain,
 			_ => {
 				// Prompt for chain if not provided.
-				input("Specify the chain specification. It can be one of the predefined ones (e.g. dev, local or a custom one) or the path to an existing chain spec.")
-					.placeholder("dev")
+				input("Provide the chain specification to use (e.g. dev , local, custom or a path to an existing file)")
 					.default_input("dev")
 					.interact()?
 			},
@@ -235,7 +236,6 @@ impl BuildSpecCommand {
 					// Prompt for output file if not provided.
 					let default_output = format!("./{DEFAULT_SPEC_NAME}");
 					input("Name of the plain chain spec file. If a path is given, the necessary directories will be created:")
-						.placeholder(&default_output)
 						.default_input(&default_output)
 						.interact()?
 				},

--- a/crates/pop-parachains/README.md
+++ b/crates/pop-parachains/README.md
@@ -46,7 +46,7 @@ let package = None;  // The optional package to be built.
 let binary_path = build_parachain(&path, package, &Profile::Release, None).unwrap();;
 // Generate a plain chain specification file of a parachain
 let plain_chain_spec_path = path.join("plain-parachain-chainspec.json");
-generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true, Some("dev"));
+generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true, "dev");
 // Customize your chain specification
 let mut chain_spec = ChainSpec::from(&plain_chain_spec_path).unwrap();
 chain_spec.replace_para_id(2002);
@@ -70,7 +70,7 @@ let package = None;  // The optional package to be built.
 let binary_path = build_parachain(&path, package, &Profile::Release, None).unwrap();;
 // Generate a plain chain specification file of a parachain
 let plain_chain_spec_path = path.join("plain-parachain-chainspec.json");
-generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true, Some("dev"));
+generate_plain_chain_spec(&binary_path, &plain_chain_spec_path, true, "dev");
 // Generate a raw chain specification file of a parachain
 let chain_spec = generate_raw_chain_spec(&binary_path, &plain_chain_spec_path, "raw-parachain-chainspec.json").unwrap();
 // Export the WebAssembly runtime for the parachain.

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -93,10 +93,12 @@ pub fn generate_plain_chain_spec(
 	// Run the command and redirect output to the temporary file.
 	cmd(binary_path, args).stdout_path(temp_file.path()).stderr_null().run()?;
 	// Atomically replace the chain spec file with the temporary file.
-	temp_file
-		.persist(plain_chain_spec)
-		.map_err(|e| AnyhowError(anyhow!("Failed to replace the chain spec file with the temporary file: {}",
-			e.to_string())))?;
+	temp_file.persist(plain_chain_spec).map_err(|e| {
+		AnyhowError(anyhow!(
+			"Failed to replace the chain spec file with the temporary file: {}",
+			e.to_string()
+		))
+	})?;
 	Ok(())
 }
 

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -75,22 +75,29 @@ pub fn binary_path(target_path: &Path, node_path: &Path) -> Result<PathBuf, Erro
 /// * `binary_path` - The path to the node binary executable that contains the `build-spec` command.
 /// * `plain_chain_spec` - Location of the plain_parachain_spec file to be generated.
 /// * `default_bootnode` - Whether to include localhost as a bootnode.
+/// * `chain` - The chain specification. It can be one of the predefined ones (e.g. dev, local or a
+/// 	custom one) or the path to an existing chain spec.
 pub fn generate_plain_chain_spec(
 	binary_path: &Path,
 	plain_chain_spec: &Path,
 	default_bootnode: bool,
-	chain: Option<&str>,
+	chain: &str,
 ) -> Result<(), Error> {
 	check_command_exists(binary_path, "build-spec")?;
 	let mut args = vec!["build-spec"];
-	if let Some(chain_spec_id) = chain {
-		args.push("--chain");
-		args.push(chain_spec_id);
-	}
+	args.push("--chain");
+	args.push(chain);
 	if !default_bootnode {
 		args.push("--disable-default-bootnode");
 	}
-	cmd(binary_path, args).stdout_path(plain_chain_spec).stderr_null().run()?;
+	// Create a temporary file.
+	let temp_file = tempfile::NamedTempFile::new_in(std::env::temp_dir())?;
+	// Run the command and redirect output to the temporary file.
+	cmd(binary_path, args).stdout_path(temp_file.path()).stderr_null().run()?;
+	// Atomically replace the chain spec file with the temporary file.
+	let _ = temp_file
+		.persist(plain_chain_spec)
+		.map_err(|_| Error::AnyhowError(anyhow::anyhow!("error")));
 	Ok(())
 }
 
@@ -472,7 +479,7 @@ default_command = "pop-node"
 			&binary_path,
 			&temp_dir.path().join("plain-parachain-chainspec.json"),
 			false,
-			Some("local"),
+			"local",
 		)?;
 		assert!(plain_chain_spec.exists());
 		{


### PR DESCRIPTION
Allow to provide an existing chain spec file for the `chain` flag. I aimed for flexibility and a clear flow in the code so that it is easily adaptable for future requirements.

Added an additional `BuildSpec` struct to separate the flow between getting the users input and secondary input (prompts), and generating the files with the provided options. This also allowed to not have to worry about the `Option` fields in the `BuildSpecCmd` which complicated the code. 

If the user provides a chain spec file and it does not want to make changes to it (user is prompted whether it wants this), and e.g. the para id is not present in the file, a default value is used. No warning has been added as the chance of this happening is very small. Either due to a user mistake by manually removing it or a chain spec file is provided that is created without the pop cli which could cause to have no para id present. There will always be a para id in a chain spec file if it is created with the pop cli. **This example counts for all the other `Option` fields in the `BuildSpecCmd`.**

No tests have been written yet due to time and can be done if required

The build profile will be added as a separate PR after this is merged. 