### PR TITLE
feat: parse files when the argument values are very big

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,6 +2918,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2925,12 +3043,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -3838,6 +3967,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -7022,6 +7157,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7194,6 +7340,16 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -7630,12 +7786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7698,9 +7848,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -7713,6 +7863,18 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -8483,6 +8645,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8527,6 +8701,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff4524214bc4629eba08d78ceb1d6507070cc0bcbbed23af74e19e6e924a24cf"
 
 [[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8548,6 +8746,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8561,6 +8780,28 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ toml = "0.5.0"
 # networking
 reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-url = "2.5"
+url = "2.5.4"
 
 # contracts
 subxt-signer = { version = "0.37.0", features = ["subxt", "sr25519"] }

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -77,9 +77,8 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call
-				|| !cli
-					.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call ||
+				!cli.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -142,9 +141,8 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) => {
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
-				},
+				Some(ref extrinsic_name) =>
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -181,9 +179,8 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None => {
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
-				},
+				None =>
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 			};
 
 			return Ok(CallParachain {
@@ -205,11 +202,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none()
-			|| self.extrinsic.is_none()
-			|| self.args.is_empty()
-			|| self.url.is_none()
-			|| self.suri.is_none()
+		self.pallet.is_none() ||
+			self.extrinsic.is_none() ||
+			self.args.is_empty() ||
+			self.url.is_none() ||
+			self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -292,9 +289,8 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -75,9 +75,8 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call
-				|| !cli
-					.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call ||
+				!cli.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -140,9 +139,8 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) => {
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
-				},
+				Some(ref extrinsic_name) =>
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -179,9 +177,8 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None => {
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
-				},
+				None =>
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 			};
 
 			return Ok(CallParachain {
@@ -203,11 +200,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none()
-			|| self.extrinsic.is_none()
-			|| self.args.is_empty()
-			|| self.url.is_none()
-			|| self.suri.is_none()
+		self.pallet.is_none() ||
+			self.extrinsic.is_none() ||
+			self.args.is_empty() ||
+			self.url.is_none() ||
+			self.suri.is_none()
 	}
 }
 
@@ -275,9 +272,8 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -262,7 +262,7 @@ impl CallParachain {
 	) -> Result<DynamicPayload> {
 		let tx = match construct_extrinsic(
 			self.pallet.name.as_str(),
-			self.extrinsic.name.as_str(),
+			&self.extrinsic,
 			self.args.clone(),
 		)
 		.await

--- a/crates/pop-parachains/src/call/metadata/mod.rs
+++ b/crates/pop-parachains/src/call/metadata/mod.rs
@@ -146,14 +146,13 @@ pub async fn find_extrinsic_by_name(
 /// Parses and processes raw string parameters for an extrinsic, mapping them to `Value` types.
 ///
 /// # Arguments
-/// * `extrinsic`: The definition of the extrinsic, containing parameter metadata.
+/// * `params`: The metadata definition for each parameter of the extrinsic.
 /// * `raw_params`: A vector of raw string arguments for the extrinsic.
 pub async fn parse_extrinsic_arguments(
-	extrinsic: &Extrinsic,
+	params: &[Param],
 	raw_params: Vec<String>,
 ) -> Result<Vec<Value>, Error> {
-	extrinsic
-		.params
+	params
 		.iter()
 		.zip(raw_params)
 		.map(|(param, raw_param)| {
@@ -241,24 +240,6 @@ mod tests {
 
 	#[tokio::test]
 	async fn parse_extrinsic_arguments_works() -> Result<()> {
-		/// Helper function to create a `Param` with default values.
-		fn create_param(
-			name: &str,
-			type_name: &str,
-			is_sequence: bool,
-			is_variant: bool,
-			is_tuple: bool,
-		) -> Param {
-			Param {
-				name: name.to_string(),
-				type_name: type_name.to_string(),
-				sub_params: vec![],
-				is_optional: false,
-				is_sequence,
-				is_variant,
-				is_tuple,
-			}
-		}
 		// Values for testing from: https://docs.rs/scale-value/0.18.0/scale_value/stringify/fn.from_str.html
 		// and https://docs.rs/scale-value/0.18.0/scale_value/stringify/fn.from_str_custom.html
 		let args = [
@@ -284,26 +265,21 @@ mod tests {
 				.into_iter()
 				.map(|b| Value::u128(b as u128))
 				.collect();
-		// Define mock extrinsic with parameters for testing.
-		let extrinsic = Extrinsic {
-			name: "test_extrinsic".to_string(),
-			docs: "Test extrinsic documentation".to_string(),
-			params: vec![
-				create_param("param_1", "u128", false, false, false),
-				create_param("param_2", "i128", false, false, false),
-				create_param("param_3", "bool", false, false, false),
-				create_param("param_4", "char", false, false, false),
-				create_param("param_5", "string", false, false, false),
-				create_param("param_6", "composite", false, false, false),
-				create_param("param_7", "variant", false, true, false),
-				create_param("param_8", "bit_sequence", false, false, false),
-				create_param("param_9", "tuple", false, false, true),
-				create_param("param_10", "composite", false, false, false),
-			],
-			is_supported: true,
-		};
+		// Define mock extrinsic parameters for testing.
+		let params = vec![
+			Param { type_name: "u128".to_string(), ..Default::default() },
+			Param { type_name: "i128".to_string(), ..Default::default() },
+			Param { type_name: "bool".to_string(), ..Default::default() },
+			Param { type_name: "char".to_string(), ..Default::default() },
+			Param { type_name: "string".to_string(), ..Default::default() },
+			Param { type_name: "compostie".to_string(), ..Default::default() },
+			Param { type_name: "variant".to_string(), is_variant: true, ..Default::default() },
+			Param { type_name: "bit_sequence".to_string(), ..Default::default() },
+			Param { type_name: "tuple".to_string(), is_tuple: true, ..Default::default() },
+			Param { type_name: "composite".to_string(), ..Default::default() },
+		];
 		assert_eq!(
-			parse_extrinsic_arguments(&extrinsic, args).await?,
+			parse_extrinsic_arguments(&params, args).await?,
 			[
 				Value::u128(1),
 				Value::i128(-1),

--- a/crates/pop-parachains/src/call/metadata/mod.rs
+++ b/crates/pop-parachains/src/call/metadata/mod.rs
@@ -191,6 +191,7 @@ mod tests {
 		assert!(!first_extrinsic.params.first().unwrap().is_optional);
 		assert!(!first_extrinsic.params.first().unwrap().is_tuple);
 		assert!(!first_extrinsic.params.first().unwrap().is_variant);
+		assert!(first_extrinsic.params.first().unwrap().is_sequence);
 		Ok(())
 	}
 

--- a/crates/pop-parachains/src/call/metadata/params.rs
+++ b/crates/pop-parachains/src/call/metadata/params.rs
@@ -20,6 +20,8 @@ pub struct Param {
 	pub is_tuple: bool,
 	/// Indicates if the parameter is a Variant.
 	pub is_variant: bool,
+	/// Indicates if the parameter is a Sequence.
+	pub is_sequence: bool,
 }
 
 /// Transforms a metadata field into its `Param` representation.
@@ -66,6 +68,7 @@ fn type_to_param(name: String, registry: &PortableRegistry, type_id: u32) -> Res
 				is_optional: true,
 				is_tuple: false,
 				is_variant: false,
+				is_sequence: false,
 			})
 		} else {
 			Err(Error::MetadataParsingError(name))
@@ -74,16 +77,14 @@ fn type_to_param(name: String, registry: &PortableRegistry, type_id: u32) -> Res
 		// Determine the formatted type name.
 		let type_name = format_type(type_info, registry);
 		match &type_info.type_def {
-			TypeDef::Primitive(_) |
-			TypeDef::Array(_) |
-			TypeDef::Sequence(_) |
-			TypeDef::Compact(_) => Ok(Param {
+			TypeDef::Primitive(_) | TypeDef::Array(_) | TypeDef::Compact(_) => Ok(Param {
 				name,
 				type_name,
 				sub_params: Vec::new(),
 				is_optional: false,
 				is_tuple: false,
 				is_variant: false,
+				is_sequence: false,
 			}),
 			TypeDef::Composite(composite) => {
 				let sub_params = composite
@@ -106,6 +107,7 @@ fn type_to_param(name: String, registry: &PortableRegistry, type_id: u32) -> Res
 					is_optional: false,
 					is_tuple: false,
 					is_variant: false,
+					is_sequence: false,
 				})
 			},
 			TypeDef::Variant(variant) => {
@@ -132,6 +134,7 @@ fn type_to_param(name: String, registry: &PortableRegistry, type_id: u32) -> Res
 							is_optional: false,
 							is_tuple: false,
 							is_variant: true,
+							is_sequence: false,
 						})
 					})
 					.collect::<Result<Vec<Param>, Error>>()?;
@@ -143,8 +146,18 @@ fn type_to_param(name: String, registry: &PortableRegistry, type_id: u32) -> Res
 					is_optional: false,
 					is_tuple: false,
 					is_variant: true,
+					is_sequence: false,
 				})
 			},
+			TypeDef::Sequence(_) => Ok(Param {
+				name,
+				type_name,
+				sub_params: Vec::new(),
+				is_optional: false,
+				is_tuple: false,
+				is_variant: false,
+				is_sequence: true,
+			}),
 			TypeDef::Tuple(tuple) => {
 				let sub_params = tuple
 					.fields
@@ -166,6 +179,7 @@ fn type_to_param(name: String, registry: &PortableRegistry, type_id: u32) -> Res
 					is_optional: false,
 					is_tuple: true,
 					is_variant: false,
+					is_sequence: false,
 				})
 			},
 			_ => Err(Error::MetadataParsingError(name)),

--- a/crates/pop-parachains/src/call/metadata/params.rs
+++ b/crates/pop-parachains/src/call/metadata/params.rs
@@ -6,7 +6,7 @@ use scale_info::{form::PortableForm, Field, PortableRegistry, TypeDef};
 use subxt::{Metadata, OnlineClient, SubstrateConfig};
 
 /// Describes a parameter of an extrinsic.
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Param {
 	/// The name of the parameter.
 	pub name: String,

--- a/crates/pop-parachains/src/call/metadata/params.rs
+++ b/crates/pop-parachains/src/call/metadata/params.rs
@@ -6,7 +6,7 @@ use scale_info::{form::PortableForm, Field, PortableRegistry, TypeDef};
 use subxt::{Metadata, OnlineClient, SubstrateConfig};
 
 /// Describes a parameter of an extrinsic.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct Param {
 	/// The name of the parameter.
 	pub name: String,

--- a/crates/pop-parachains/src/call/mod.rs
+++ b/crates/pop-parachains/src/call/mod.rs
@@ -126,7 +126,7 @@ mod tests {
 	async fn encode_call_data_works() -> Result<()> {
 		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
 		let pallets = parse_chain_metadata(&client).await?;
-		let remark = find_extrinsic_by_name(&pallets, "Balances", "remark").await?;
+		let remark = find_extrinsic_by_name(&pallets, "System", "remark").await?;
 		let extrinsic = construct_extrinsic("System", &remark, vec!["0x11".to_string()]).await?;
 		assert_eq!(encode_call_data(&client, &extrinsic)?, "0x00000411");
 		let extrinsic = construct_extrinsic("System", &remark, vec!["123".to_string()]).await?;

--- a/crates/pop-parachains/src/call/mod.rs
+++ b/crates/pop-parachains/src/call/mod.rs
@@ -31,7 +31,8 @@ pub async fn construct_extrinsic(
 	extrinsic: &Extrinsic,
 	args: Vec<String>,
 ) -> Result<DynamicPayload, Error> {
-	let parsed_args: Vec<Value> = metadata::parse_extrinsic_arguments(&extrinsic, args).await?;
+	let parsed_args: Vec<Value> =
+		metadata::parse_extrinsic_arguments(&extrinsic.params, args).await?;
 	Ok(subxt::dynamic::tx(pallet_name, extrinsic.name.clone(), parsed_args))
 }
 

--- a/crates/pop-parachains/src/call/mod.rs
+++ b/crates/pop-parachains/src/call/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::errors::Error;
+use crate::{errors::Error, Extrinsic};
 use pop_common::create_signer;
 use subxt::{
 	dynamic::Value,
@@ -28,11 +28,11 @@ pub async fn set_up_client(url: &str) -> Result<OnlineClient<SubstrateConfig>, E
 /// * `args` - A vector of string arguments to be passed to the extrinsic.
 pub async fn construct_extrinsic(
 	pallet_name: &str,
-	extrinsic_name: &str,
+	extrinsic: &Extrinsic,
 	args: Vec<String>,
 ) -> Result<DynamicPayload, Error> {
-	let parsed_args: Vec<Value> = metadata::parse_extrinsic_arguments(args).await?;
-	Ok(subxt::dynamic::tx(pallet_name, extrinsic_name, parsed_args))
+	let parsed_args: Vec<Value> = metadata::parse_extrinsic_arguments(&extrinsic, args).await?;
+	Ok(subxt::dynamic::tx(pallet_name, extrinsic.name.clone(), parsed_args))
 }
 
 /// Signs and submits a given extrinsic.
@@ -77,7 +77,7 @@ pub fn encode_call_data(
 mod tests {
 	use super::*;
 
-	use crate::set_up_client;
+	use crate::{find_extrinsic_by_name, parse_chain_metadata, set_up_client};
 	use anyhow::Result;
 
 	#[tokio::test]
@@ -92,11 +92,16 @@ mod tests {
 
 	#[tokio::test]
 	async fn construct_extrinsic_works() -> Result<()> {
+		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
+		let pallets = parse_chain_metadata(&client).await?;
+		let transfer_allow_death =
+			find_extrinsic_by_name(&pallets, "Balances", "transfer_allow_death").await?;
+
 		// Wrong parameters
 		assert!(matches!(
 			construct_extrinsic(
 				"Balances",
-				"transfer_allow_death",
+				&transfer_allow_death,
 				vec!["Bob".to_string(), "100".to_string()],
 			)
 			.await,
@@ -105,7 +110,7 @@ mod tests {
 		// Valid parameters
 		let extrinsic = construct_extrinsic(
 			"Balances",
-			"transfer_allow_death",
+			&transfer_allow_death,
 			vec![
 				"Id(5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty)".to_string(),
 				"100".to_string(),
@@ -120,16 +125,27 @@ mod tests {
 	#[tokio::test]
 	async fn encode_call_data_works() -> Result<()> {
 		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
-		let extrinsic = construct_extrinsic("System", "remark", vec!["0x11".to_string()]).await?;
+		let pallets = parse_chain_metadata(&client).await?;
+		let remark = find_extrinsic_by_name(&pallets, "Balances", "remark").await?;
+		let extrinsic = construct_extrinsic("System", &remark, vec!["0x11".to_string()]).await?;
 		assert_eq!(encode_call_data(&client, &extrinsic)?, "0x00000411");
+		let extrinsic = construct_extrinsic("System", &remark, vec!["123".to_string()]).await?;
+		assert_eq!(encode_call_data(&client, &extrinsic)?, "0x00000c313233");
+		let extrinsic = construct_extrinsic("System", &remark, vec!["test".to_string()]).await?;
+		assert_eq!(encode_call_data(&client, &extrinsic)?, "0x00001074657374");
 		Ok(())
 	}
 
 	#[tokio::test]
 	async fn sign_and_submit_wrong_extrinsic_fails() -> Result<()> {
 		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
-		let tx =
-			construct_extrinsic("WrongPallet", "wrongExtrinsic", vec!["0x11".to_string()]).await?;
+		let extrinsic = Extrinsic {
+			name: "wrong_extrinsic".to_string(),
+			docs: "documentation".to_string(),
+			params: vec![],
+			is_supported: true,
+		};
+		let tx = construct_extrinsic("WrongPallet", &extrinsic, vec!["0x11".to_string()]).await?;
 		assert!(matches!(
 			sign_and_submit_extrinsic(client, tx, "//Alice").await,
 			Err(Error::ExtrinsicSubmissionError(message)) if message.contains("PalletNameNotFound(\"WrongPallet\"))")

--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,7 @@ allow = [
     "GPL-3.0",
     "MIT",
     "MPL-2.0",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
     "Unlicense"
 ]


### PR DESCRIPTION
This PR is part of the `pop call parachain `feature. 
It improves handling the parameters with type `TypeDef::Sequence`  similar to the approach used in PolkadotJS.

1. Properly parsing user-provided values automatically encoding the value into a hexadecimal format. (Based on this comment https://github.com/r0gue-io/pop-cli/pull/316#discussion_r1874191647)
2.  Allowing users to provide large values through a file, similar to the approach used in PolkadotJS, instead of requiring direct string input:

![Captura de pantalla 2024-12-05 a las 20 59 12](https://github.com/user-attachments/assets/0443a147-f232-492c-a4d7-a8d589fe5eb2)

**For testing**
Run `pop call parachain`, input a relay chain url and select the `Register a parachain ID with genesis state and code` option.
```
◇  What would you like to do?
│  Register a parachain ID with genesis state and code 
│
◇  Enter the value for the parameter: id
│  2000
│
◇  The value for `genesis_head` might be too large to enter. Provide a file instead?
│  Yes 
│
◇  Enter the file path for the parameter `genesis_head`:
│  ../pop-node/para-2000-genesis-state
│
◇  The value for `validation_code` might be too large to enter. Provide a file instead?
│  Yes 
│
◇  Enter the file path for the parameter `validation_code`:
│  ../pop-node/para-2000.wasm
```

[sc-1507]