### PR TITLE
refactor: use Default derive macro and define constants for test values

### DIFF
--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -91,9 +91,8 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call
-				|| !cli
-					.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call ||
+				!cli.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -156,9 +155,8 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) => {
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
-				},
+				Some(ref extrinsic_name) =>
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -195,9 +193,8 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None => {
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
-				},
+				None =>
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 			};
 
 			return Ok(CallParachain {
@@ -259,11 +256,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none()
-			|| self.extrinsic.is_none()
-			|| self.args.is_empty()
-			|| self.url.is_none()
-			|| self.suri.is_none()
+		self.pallet.is_none() ||
+			self.extrinsic.is_none() ||
+			self.args.is_empty() ||
+			self.url.is_none() ||
+			self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -346,9 +343,8 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -91,9 +91,8 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call
-				|| !cli
-					.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call ||
+				!cli.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -156,9 +155,8 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) => {
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
-				},
+				Some(ref extrinsic_name) =>
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -195,9 +193,8 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None => {
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
-				},
+				None =>
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 			};
 
 			return Ok(CallParachain {
@@ -223,9 +220,8 @@ impl CallParachainCommand {
 			None => &cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 		};
 		cli.info(format!("Encoded call data: {}", call_data))?;
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -259,11 +255,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none()
-			|| self.extrinsic.is_none()
-			|| self.args.is_empty()
-			|| self.url.is_none()
-			|| self.suri.is_none()
+		self.pallet.is_none() ||
+			self.extrinsic.is_none() ||
+			self.args.is_empty() ||
+			self.url.is_none() ||
+			self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -346,9 +342,8 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -594,7 +589,7 @@ mod tests {
 		let mut cli = MockCli::new()
 		.expect_intro("Call a parachain")
 		.expect_input("Which chain would you like to interact with?", POP_NETWORK_TESTNET_URL.into())
-		.expect_select::<Pallet>(
+		.expect_select(
 			"Select the extrinsic to call:",
 			Some(true),
 			true,

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -91,8 +91,9 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call ||
-				!cli.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call
+				|| !cli
+					.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -155,8 +156,9 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) =>
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
+				Some(ref extrinsic_name) => {
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
+				},
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -193,8 +195,9 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None =>
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
+				None => {
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
+				},
 			};
 
 			return Ok(CallParachain {
@@ -256,11 +259,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none() ||
-			self.extrinsic.is_none() ||
-			self.args.is_empty() ||
-			self.url.is_none() ||
-			self.suri.is_none()
+		self.pallet.is_none()
+			|| self.extrinsic.is_none()
+			|| self.args.is_empty()
+			|| self.url.is_none()
+			|| self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -343,8 +346,9 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm &&
-			!cli.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm
+			&& !cli
+				.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -567,15 +571,8 @@ mod tests {
 
 	#[tokio::test]
 	async fn configure_chain_works() -> Result<()> {
-		let call_config = CallParachainCommand {
-			pallet: None,
-			extrinsic: None,
-			args: vec![].to_vec(),
-			url: None,
-			suri: Some(DEFAULT_URI.to_string()),
-			skip_confirm: false,
-			call_data: None,
-		};
+		let call_config =
+			CallParachainCommand { suri: Some(DEFAULT_URI.to_string()), ..Default::default() };
 		let mut cli = MockCli::new().expect_intro("Call a parachain").expect_input(
 			"Which chain would you like to interact with?",
 			"wss://rpc1.paseo.popnetwork.xyz".into(),
@@ -587,15 +584,8 @@ mod tests {
 
 	#[tokio::test]
 	async fn guide_user_to_call_parachain_works() -> Result<()> {
-		let mut call_config = CallParachainCommand {
-			pallet: Some("System".to_string()),
-			extrinsic: None,
-			args: vec![].to_vec(),
-			url: None,
-			suri: None,
-			skip_confirm: false,
-			call_data: None,
-		};
+		let mut call_config =
+			CallParachainCommand { pallet: Some("System".to_string()), ..Default::default() };
 
 		let mut cli = MockCli::new()
 		.expect_intro("Call a parachain")
@@ -639,15 +629,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn guide_user_to_configure_predefined_action_works() -> Result<()> {
-		let mut call_config = CallParachainCommand {
-			pallet: None,
-			extrinsic: None,
-			args: vec![].to_vec(),
-			url: None,
-			suri: None,
-			skip_confirm: false,
-			call_data: None,
-		};
+		let mut call_config = CallParachainCommand::default();
 
 		let mut cli = MockCli::new().expect_intro("Call a parachain").expect_input(
 			"Which chain would you like to interact with?",

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -18,7 +18,7 @@ const DEFAULT_URI: &str = "//Alice";
 const ENCODED_CALL_DATA_MAX_LEN: usize = 500; // Maximum length of encoded call data to display.
 
 /// Command to execute extrinsics with configurable pallets, arguments, and signing options.
-#[derive(Args, Clone)]
+#[derive(Args, Clone, Default)]
 pub struct CallParachainCommand {
 	/// The pallet containing the extrinsic to execute.
 	#[arg(short, long, value_parser = parse_pallet_name)]
@@ -695,17 +695,8 @@ mod tests {
 	async fn prepare_extrinsic_works() -> Result<()> {
 		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
 		let mut call_config = CallParachain {
-			pallet: Pallet {
-				name: "WrongName".to_string(),
-				docs: "".to_string(),
-				extrinsics: vec![],
-			},
-			extrinsic: Extrinsic {
-				name: "WrongName".to_string(),
-				docs: "".to_string(),
-				is_supported: false,
-				params: vec![],
-			},
+			pallet: Pallet { name: "WrongName".to_string(), ..Default::default() },
+			extrinsic: Extrinsic { name: "WrongName".to_string(), ..Default::default() },
 			args: vec!["0x11".to_string()].to_vec(),
 			suri: DEFAULT_URI.to_string(),
 			skip_confirm: false,

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -91,8 +91,9 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call ||
-				!cli.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call
+				|| !cli
+					.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -155,8 +156,9 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) =>
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
+				Some(ref extrinsic_name) => {
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
+				},
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -193,8 +195,9 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None =>
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
+				None => {
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
+				},
 			};
 
 			return Ok(CallParachain {
@@ -220,8 +223,9 @@ impl CallParachainCommand {
 			None => &cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 		};
 		cli.info(format!("Encoded call data: {}", call_data))?;
-		if !self.skip_confirm &&
-			!cli.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm
+			&& !cli
+				.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -255,11 +259,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none() ||
-			self.extrinsic.is_none() ||
-			self.args.is_empty() ||
-			self.url.is_none() ||
-			self.suri.is_none()
+		self.pallet.is_none()
+			|| self.extrinsic.is_none()
+			|| self.args.is_empty()
+			|| self.url.is_none()
+			|| self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -342,8 +346,9 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm &&
-			!cli.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm
+			&& !cli
+				.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -91,8 +91,9 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call ||
-				!cli.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call
+				|| !cli
+					.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -155,8 +156,9 @@ impl CallParachainCommand {
 
 			// Resolve extrinsic.
 			let extrinsic = match self.extrinsic {
-				Some(ref extrinsic_name) =>
-					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?,
+				Some(ref extrinsic_name) => {
+					find_extrinsic_by_name(&chain.pallets, &pallet.name, extrinsic_name).await?
+				},
 				None => {
 					let mut prompt_extrinsic = cli.select("Select the extrinsic to call:");
 					for extrinsic in &pallet.extrinsics {
@@ -193,8 +195,9 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None =>
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
+				None => {
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
+				},
 			};
 
 			return Ok(CallParachain {
@@ -256,11 +259,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none() ||
-			self.extrinsic.is_none() ||
-			self.args.is_empty() ||
-			self.url.is_none() ||
-			self.suri.is_none()
+		self.pallet.is_none()
+			|| self.extrinsic.is_none()
+			|| self.args.is_empty()
+			|| self.url.is_none()
+			|| self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -343,8 +346,9 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm &&
-			!cli.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm
+			&& !cli
+				.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{

--- a/crates/pop-common/src/metadata.rs
+++ b/crates/pop-common/src/metadata.rs
@@ -162,10 +162,11 @@ mod tests {
 	use anyhow::Result;
 	use subxt::{OnlineClient, SubstrateConfig};
 
+	const POP_NETWORK_TESTNET_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
+
 	#[tokio::test]
 	async fn format_type_works() -> Result<()> {
-		let client =
-			OnlineClient::<SubstrateConfig>::from_url("wss://rpc1.paseo.popnetwork.xyz").await?;
+		let client = OnlineClient::<SubstrateConfig>::from_url(POP_NETWORK_TESTNET_URL).await?;
 		let metadata = client.metadata();
 		let registry = metadata.types();
 

--- a/crates/pop-parachains/src/call/metadata/action.rs
+++ b/crates/pop-parachains/src/call/metadata/action.rs
@@ -126,6 +126,9 @@ mod tests {
 	use anyhow::Result;
 	use std::collections::HashMap;
 
+	const POP_NETWORK_TESTNET_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
+	const POLKADOT_NETWORK_URL: &str = "wss://polkadot-rpc.publicnode.com";
+
 	#[test]
 	fn action_descriptions_are_correct() {
 		let descriptions = HashMap::from([
@@ -184,7 +187,7 @@ mod tests {
 	async fn supported_actions_works() -> Result<()> {
 		// Test Pop Parachain.
 		let mut client: subxt::OnlineClient<subxt::SubstrateConfig> =
-			set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
+			set_up_client(POP_NETWORK_TESTNET_URL).await?;
 		let mut actions = supported_actions(&parse_chain_metadata(&client).await?).await;
 		assert_eq!(actions.len(), 5);
 		assert_eq!(actions[0], Action::Transfer);
@@ -194,7 +197,7 @@ mod tests {
 		assert_eq!(actions[4], Action::MintNFT);
 
 		// Test Polkadot Relay Chain.
-		client = set_up_client("wss://polkadot-rpc.publicnode.com").await?;
+		client = set_up_client(POLKADOT_NETWORK_URL).await?;
 		actions = supported_actions(&parse_chain_metadata(&client).await?).await;
 		assert_eq!(actions.len(), 4);
 		assert_eq!(actions[0], Action::Transfer);

--- a/crates/pop-parachains/src/call/metadata/mod.rs
+++ b/crates/pop-parachains/src/call/metadata/mod.rs
@@ -10,7 +10,7 @@ pub mod action;
 pub mod params;
 
 /// Represents a pallet in the blockchain, including its extrinsics.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Default, Clone, PartialEq, Eq)]
 pub struct Pallet {
 	/// The name of the pallet.
 	pub name: String,

--- a/crates/pop-parachains/src/call/metadata/mod.rs
+++ b/crates/pop-parachains/src/call/metadata/mod.rs
@@ -240,24 +240,6 @@ mod tests {
 
 	#[tokio::test]
 	async fn parse_extrinsic_arguments_works() -> Result<()> {
-		/// Helper function to create a `Param` with default values.
-		fn create_param(
-			name: &str,
-			type_name: &str,
-			is_sequence: bool,
-			is_variant: bool,
-			is_tuple: bool,
-		) -> Param {
-			Param {
-				name: name.to_string(),
-				type_name: type_name.to_string(),
-				sub_params: vec![],
-				is_optional: false,
-				is_sequence,
-				is_variant,
-				is_tuple,
-			}
-		}
 		// Values for testing from: https://docs.rs/scale-value/0.18.0/scale_value/stringify/fn.from_str.html
 		// and https://docs.rs/scale-value/0.18.0/scale_value/stringify/fn.from_str_custom.html
 		let args = [

--- a/crates/pop-parachains/src/call/metadata/mod.rs
+++ b/crates/pop-parachains/src/call/metadata/mod.rs
@@ -240,6 +240,24 @@ mod tests {
 
 	#[tokio::test]
 	async fn parse_extrinsic_arguments_works() -> Result<()> {
+		/// Helper function to create a `Param` with default values.
+		fn create_param(
+			name: &str,
+			type_name: &str,
+			is_sequence: bool,
+			is_variant: bool,
+			is_tuple: bool,
+		) -> Param {
+			Param {
+				name: name.to_string(),
+				type_name: type_name.to_string(),
+				sub_params: vec![],
+				is_optional: false,
+				is_sequence,
+				is_variant,
+				is_tuple,
+			}
+		}
 		// Values for testing from: https://docs.rs/scale-value/0.18.0/scale_value/stringify/fn.from_str.html
 		// and https://docs.rs/scale-value/0.18.0/scale_value/stringify/fn.from_str_custom.html
 		let args = [

--- a/crates/pop-parachains/src/call/metadata/mod.rs
+++ b/crates/pop-parachains/src/call/metadata/mod.rs
@@ -180,9 +180,11 @@ mod tests {
 	use anyhow::Result;
 	use subxt::ext::scale_bits;
 
+	const POP_NETWORK_TESTNET_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
+
 	#[tokio::test]
 	async fn parse_chain_metadata_works() -> Result<()> {
-		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
+		let client = set_up_client(POP_NETWORK_TESTNET_URL).await?;
 		let pallets = parse_chain_metadata(&client).await?;
 		// Test the first pallet is parsed correctly
 		let first_pallet = pallets.first().unwrap();
@@ -208,7 +210,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn find_pallet_by_name_works() -> Result<()> {
-		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
+		let client = set_up_client(POP_NETWORK_TESTNET_URL).await?;
 		let pallets = parse_chain_metadata(&client).await?;
 		assert!(matches!(
 			find_pallet_by_name(&pallets, "WrongName").await,
@@ -221,7 +223,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn find_extrinsic_by_name_works() -> Result<()> {
-		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
+		let client = set_up_client(POP_NETWORK_TESTNET_URL).await?;
 		let pallets = parse_chain_metadata(&client).await?;
 		assert!(matches!(
 			find_extrinsic_by_name(&pallets, "WrongName", "wrong_extrinsic").await,

--- a/crates/pop-parachains/src/call/metadata/mod.rs
+++ b/crates/pop-parachains/src/call/metadata/mod.rs
@@ -10,7 +10,7 @@ pub mod action;
 pub mod params;
 
 /// Represents a pallet in the blockchain, including its extrinsics.
-#[derive(Default, Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Pallet {
 	/// The name of the pallet.
 	pub name: String,
@@ -27,7 +27,7 @@ impl Display for Pallet {
 }
 
 /// Represents an extrinsic.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Extrinsic {
 	/// The name of the extrinsic.
 	pub name: String,

--- a/crates/pop-parachains/src/call/metadata/params.rs
+++ b/crates/pop-parachains/src/call/metadata/params.rs
@@ -157,9 +157,11 @@ mod tests {
 	use crate::set_up_client;
 	use anyhow::Result;
 
+	const POP_NETWORK_TESTNET_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
+
 	#[tokio::test]
 	async fn field_to_param_works() -> Result<()> {
-		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
+		let client = set_up_client(POP_NETWORK_TESTNET_URL).await?;
 		let metadata = client.metadata();
 		// Test a supported extrinsic
 		let extrinsic = metadata

--- a/crates/pop-parachains/src/call/metadata/params.rs
+++ b/crates/pop-parachains/src/call/metadata/params.rs
@@ -66,9 +66,7 @@ fn type_to_param(name: String, registry: &PortableRegistry, type_id: u32) -> Res
 				type_name: sub_param.type_name,
 				sub_params: sub_param.sub_params,
 				is_optional: true,
-				is_tuple: false,
-				is_variant: false,
-				is_sequence: false,
+				..Default::default()
 			})
 		} else {
 			Err(Error::MetadataParsingError(name))
@@ -77,15 +75,8 @@ fn type_to_param(name: String, registry: &PortableRegistry, type_id: u32) -> Res
 		// Determine the formatted type name.
 		let type_name = format_type(type_info, registry);
 		match &type_info.type_def {
-			TypeDef::Primitive(_) | TypeDef::Array(_) | TypeDef::Compact(_) => Ok(Param {
-				name,
-				type_name,
-				sub_params: Vec::new(),
-				is_optional: false,
-				is_tuple: false,
-				is_variant: false,
-				is_sequence: false,
-			}),
+			TypeDef::Primitive(_) | TypeDef::Array(_) | TypeDef::Compact(_) =>
+				Ok(Param { name, type_name, ..Default::default() }),
 			TypeDef::Composite(composite) => {
 				let sub_params = composite
 					.fields
@@ -100,15 +91,7 @@ fn type_to_param(name: String, registry: &PortableRegistry, type_id: u32) -> Res
 					})
 					.collect::<Result<Vec<Param>, Error>>()?;
 
-				Ok(Param {
-					name,
-					type_name,
-					sub_params,
-					is_optional: false,
-					is_tuple: false,
-					is_variant: false,
-					is_sequence: false,
-				})
+				Ok(Param { name, type_name, sub_params, ..Default::default() })
 			},
 			TypeDef::Variant(variant) => {
 				let variant_params = variant
@@ -131,10 +114,8 @@ fn type_to_param(name: String, registry: &PortableRegistry, type_id: u32) -> Res
 							name: variant_param.name.clone(),
 							type_name: "".to_string(),
 							sub_params: variant_sub_params,
-							is_optional: false,
-							is_tuple: false,
 							is_variant: true,
-							is_sequence: false,
+							..Default::default()
 						})
 					})
 					.collect::<Result<Vec<Param>, Error>>()?;
@@ -143,21 +124,12 @@ fn type_to_param(name: String, registry: &PortableRegistry, type_id: u32) -> Res
 					name,
 					type_name,
 					sub_params: variant_params,
-					is_optional: false,
-					is_tuple: false,
 					is_variant: true,
-					is_sequence: false,
+					..Default::default()
 				})
 			},
-			TypeDef::Sequence(_) => Ok(Param {
-				name,
-				type_name,
-				sub_params: Vec::new(),
-				is_optional: false,
-				is_tuple: false,
-				is_variant: false,
-				is_sequence: true,
-			}),
+			TypeDef::Sequence(_) =>
+				Ok(Param { name, type_name, is_sequence: true, ..Default::default() }),
 			TypeDef::Tuple(tuple) => {
 				let sub_params = tuple
 					.fields
@@ -172,15 +144,7 @@ fn type_to_param(name: String, registry: &PortableRegistry, type_id: u32) -> Res
 					})
 					.collect::<Result<Vec<Param>, Error>>()?;
 
-				Ok(Param {
-					name,
-					type_name,
-					sub_params,
-					is_optional: false,
-					is_tuple: true,
-					is_variant: false,
-					is_sequence: false,
-				})
+				Ok(Param { name, type_name, sub_params, is_tuple: true, ..Default::default() })
 			},
 			_ => Err(Error::MetadataParsingError(name)),
 		}

--- a/crates/pop-parachains/src/call/mod.rs
+++ b/crates/pop-parachains/src/call/mod.rs
@@ -203,8 +203,8 @@ mod tests {
 		let extrinsic = Extrinsic {
 			name: "wrong_extrinsic".to_string(),
 			docs: "documentation".to_string(),
-			params: vec![],
 			is_supported: true,
+			..Default::default()
 		};
 		let tx = construct_extrinsic("WrongPallet", &extrinsic, vec!["0x11".to_string()]).await?;
 		assert!(matches!(

--- a/crates/pop-parachains/src/call/mod.rs
+++ b/crates/pop-parachains/src/call/mod.rs
@@ -125,9 +125,11 @@ pub async fn sign_and_submit_extrinsic_with_call_data(
 #[cfg(test)]
 mod tests {
 	use super::*;
-
 	use crate::{find_extrinsic_by_name, parse_chain_metadata, set_up_client};
 	use anyhow::Result;
+
+	const ALICE_SURI: &str = "//Alice";
+	const POP_NETWORK_TESTNET_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
 
 	#[tokio::test]
 	async fn set_up_client_works() -> Result<()> {
@@ -135,13 +137,13 @@ mod tests {
 			set_up_client("wss://wronguri.xyz").await,
 			Err(Error::ConnectionFailure(_))
 		));
-		set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
+		set_up_client(POP_NETWORK_TESTNET_URL).await?;
 		Ok(())
 	}
 
 	#[tokio::test]
 	async fn construct_extrinsic_works() -> Result<()> {
-		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
+		let client = set_up_client(POP_NETWORK_TESTNET_URL).await?;
 		let pallets = parse_chain_metadata(&client).await?;
 		let transfer_allow_death =
 			find_extrinsic_by_name(&pallets, "Balances", "transfer_allow_death").await?;
@@ -151,7 +153,7 @@ mod tests {
 			construct_extrinsic(
 				"Balances",
 				&transfer_allow_death,
-				vec!["Bob".to_string(), "100".to_string()],
+				vec![ALICE_SURI.to_string(), "100".to_string()],
 			)
 			.await,
 			Err(Error::ParamProcessingError)
@@ -173,7 +175,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn encode_call_data_works() -> Result<()> {
-		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
+		let client = set_up_client(POP_NETWORK_TESTNET_URL).await?;
 		let pallets = parse_chain_metadata(&client).await?;
 		let remark = find_extrinsic_by_name(&pallets, "System", "remark").await?;
 		let extrinsic = construct_extrinsic("System", &remark, vec!["0x11".to_string()]).await?;
@@ -199,7 +201,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn sign_and_submit_wrong_extrinsic_fails() -> Result<()> {
-		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
+		let client = set_up_client(POP_NETWORK_TESTNET_URL).await?;
 		let extrinsic = Extrinsic {
 			name: "wrong_extrinsic".to_string(),
 			docs: "documentation".to_string(),
@@ -208,7 +210,7 @@ mod tests {
 		};
 		let tx = construct_extrinsic("WrongPallet", &extrinsic, vec!["0x11".to_string()]).await?;
 		assert!(matches!(
-			sign_and_submit_extrinsic(client, tx, "//Alice").await,
+			sign_and_submit_extrinsic(client, tx, ALICE_SURI).await,
 			Err(Error::ExtrinsicSubmissionError(message)) if message.contains("PalletNameNotFound(\"WrongPallet\"))")
 		));
 		Ok(())


### PR DESCRIPTION
This PR is a simple refactor to address feedback from previous PRs, primarily to improve test readability:

1. Use the Default derive macro in structs. (https://github.com/r0gue-io/pop-cli/pull/363#discussion_r1875837228 and https://github.com/r0gue-io/pop-cli/pull/348#discussion_r1875734357)
2. Define constants for repeated values like URL in tests. (https://github.com/r0gue-io/pop-cli/pull/363#discussion_r1875843371)