### PR TITLE
build(deps): remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9402,6 +9424,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-test",
  "url",
 ]
 
@@ -9428,6 +9451,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-test",
  "toml_edit 0.22.22",
  "url",
  "walkdir",
@@ -13678,6 +13702,19 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,28 +871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3552,15 +3530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6061,12 +6030,6 @@ dependencies = [
  "memchr",
  "nom",
 ]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
@@ -9369,7 +9332,6 @@ dependencies = [
  "pop-contracts",
  "pop-parachains",
  "pop-telemetry",
- "predicates",
  "reqwest 0.12.9",
  "serde",
  "serde_json",
@@ -9425,12 +9387,9 @@ dependencies = [
  "contract-build",
  "contract-extrinsics",
  "contract-transcode",
- "dirs",
  "duct",
- "flate2",
  "heck 0.5.0",
  "ink_env",
- "mockito",
  "pop-common",
  "reqwest 0.12.9",
  "scale-info",
@@ -9440,11 +9399,9 @@ dependencies = [
  "strum_macros 0.26.4",
  "subxt",
  "subxt-signer",
- "tar",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "tokio-test",
  "url",
 ]
 
@@ -9456,12 +9413,9 @@ dependencies = [
  "askama",
  "clap",
  "duct",
- "flate2",
  "glob",
  "indexmap 2.7.0",
- "mockito",
  "pop-common",
- "reqwest 0.12.9",
  "scale-info",
  "scale-value",
  "serde_json",
@@ -9471,11 +9425,9 @@ dependencies = [
  "subxt",
  "subxt-signer",
  "symlink",
- "tar",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "tokio-test",
  "toml_edit 0.22.22",
  "url",
  "walkdir",
@@ -9527,10 +9479,7 @@ checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
 dependencies = [
  "anstyle",
  "difflib",
- "float-cmp",
- "normalize-line-endings",
  "predicates-core",
- "regex",
 ]
 
 [[package]]
@@ -13729,19 +13678,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
-dependencies = [
- "async-stream",
- "bytes",
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,9 @@ git2 = { version = "0.18", features = ["vendored-openssl"] }
 glob = "0.3.1"
 log = "0.4.20"
 mockito = "1.4.0"
-predicates = "3.1.0"
 tar = "0.4.40"
 tempfile = "3.10"
 thiserror = "1.0.58"
-tokio-test = "0.4.4"
 toml = "0.5.0"
 
 # networking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ mockito = "1.4.0"
 tar = "0.4.40"
 tempfile = "3.10"
 thiserror = "1.0.58"
+tokio-test = "0.4.4"
 toml = "0.5.0"
 
 # networking

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -55,7 +55,6 @@ tower-http = { workspace = true, features = ["fs", "cors"] }
 [dev-dependencies]
 assert_cmd.workspace = true
 contract-extrinsics.workspace = true
-predicates.workspace = true
 subxt.workspace = true
 subxt-signer.workspace = true
 sp-weights.workspace = true

--- a/crates/pop-cli/src/cli.rs
+++ b/crates/pop-cli/src/cli.rs
@@ -304,6 +304,7 @@ pub(crate) mod tests {
 			self
 		}
 
+		#[allow(dead_code)]
 		pub(crate) fn expect_success(mut self, message: impl Display) -> Self {
 			self.success_expectations.push(message.to_string());
 			self

--- a/crates/pop-contracts/Cargo.toml
+++ b/crates/pop-contracts/Cargo.toml
@@ -13,9 +13,7 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 duct.workspace = true
-flate2.workspace = true
 reqwest.workspace = true
-tar.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
@@ -37,8 +35,3 @@ contract-transcode.workspace = true
 scale-info.workspace = true
 #  pop
 pop-common = { path = "../pop-common", version = "0.5.0" }
-
-[dev-dependencies]
-dirs.workspace = true
-mockito.workspace = true
-tokio-test.workspace = true

--- a/crates/pop-contracts/Cargo.toml
+++ b/crates/pop-contracts/Cargo.toml
@@ -33,5 +33,9 @@ contract-build.workspace = true
 contract-extrinsics.workspace = true
 contract-transcode.workspace = true
 scale-info.workspace = true
-#  pop
+# pop
 pop-common = { path = "../pop-common", version = "0.5.0" }
+
+[dev-dependencies]
+# Used in doc tests.
+tokio-test.workspace = true

--- a/crates/pop-parachains/Cargo.toml
+++ b/crates/pop-parachains/Cargo.toml
@@ -37,3 +37,6 @@ zombienet-sdk.workspace = true
 # Pop
 pop-common = { path = "../pop-common", version = "0.5.0" }
 
+[dev-dependencies]
+# Used in doc tests.
+tokio-test.workspace = true

--- a/crates/pop-parachains/Cargo.toml
+++ b/crates/pop-parachains/Cargo.toml
@@ -12,14 +12,12 @@ version.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 duct.workspace = true
-flate2.workspace = true
 glob.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 subxt-signer.workspace = true
 subxt.workspace = true
-tar.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
@@ -27,7 +25,6 @@ url.workspace = true
 
 askama.workspace = true
 indexmap.workspace = true
-reqwest.workspace = true
 scale-info.workspace = true
 scale-value.workspace = true
 sp-core.workspace = true
@@ -40,6 +37,3 @@ zombienet-sdk.workspace = true
 # Pop
 pop-common = { path = "../pop-common", version = "0.5.0" }
 
-[dev-dependencies]
-mockito.workspace = true
-tokio-test.workspace = true

--- a/crates/pop-parachains/src/utils/helpers.rs
+++ b/crates/pop-parachains/src/utils/helpers.rs
@@ -88,7 +88,6 @@ mod tests {
 	use super::*;
 	use crate::generator::parachain::ChainSpec;
 	use askama::Template;
-	use std::env::var;
 	use tempfile::tempdir;
 
 	#[test]


### PR DESCRIPTION
Removes a few dependencies which appear to no longer be in use. Also addresses two missed warnings.