### PR TITLE
refactor: rename parachain with chain as the primary command and retain parachain as an alias

### DIFF
--- a/crates/pop-cli/src/commands/call/chain.rs
+++ b/crates/pop-cli/src/commands/call/chain.rs
@@ -95,9 +95,8 @@ impl CallChainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call
-				|| !cli
-					.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call ||
+				!cli.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -196,9 +195,8 @@ impl CallChainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None => {
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
-				},
+				None =>
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 			};
 
 			return Ok(CallParachain {
@@ -224,9 +222,8 @@ impl CallChainCommand {
 			None => &cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 		};
 		cli.info(format!("Encoded call data: {}", call_data))?;
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -254,7 +251,7 @@ impl CallChainCommand {
 	// execute the call via `sudo`.
 	fn configure_sudo(&mut self, chain: &Chain, cli: &mut impl Cli) -> Result<()> {
 		match find_dispatchable_by_name(&chain.pallets, "Sudo", "sudo") {
-			Ok(_) => {
+			Ok(_) =>
 				if !self.sudo {
 					self.sudo = cli
 						.confirm(
@@ -262,16 +259,14 @@ impl CallChainCommand {
 						)
 						.initial_value(false)
 						.interact()?;
-				}
-			},
-			Err(_) => {
+				},
+			Err(_) =>
 				if self.sudo {
 					cli.warning(
 						"NOTE: sudo is not supported by the chain. Ignoring `--sudo` flag.",
 					)?;
 					self.sudo = false;
-				}
-			},
+				},
 		}
 		Ok(())
 	}
@@ -286,11 +281,11 @@ impl CallChainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none()
-			|| self.function.is_none()
-			|| self.args.is_empty()
-			|| self.url.is_none()
-			|| self.suri.is_none()
+		self.pallet.is_none() ||
+			self.function.is_none() ||
+			self.args.is_empty() ||
+			self.url.is_none() ||
+			self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -369,9 +364,8 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm
-			&& !cli
-				.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm &&
+			!cli.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{

--- a/crates/pop-cli/src/commands/call/chain.rs
+++ b/crates/pop-cli/src/commands/call/chain.rs
@@ -136,7 +136,7 @@ impl CallChainCommand {
 	}
 
 	// Configure the call based on command line arguments/call UI.
-	fn configure_call(&mut self, chain: &Chain, cli: &mut impl Cli) -> Result<CallParachain> {
+	fn configure_call(&mut self, chain: &Chain, cli: &mut impl Cli) -> Result<Call> {
 		loop {
 			// Resolve pallet.
 			let pallet = match self.pallet {
@@ -199,7 +199,7 @@ impl CallChainCommand {
 					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 			};
 
-			return Ok(CallParachain {
+			return Ok(Call {
 				function: function.clone(),
 				args,
 				suri,
@@ -317,7 +317,7 @@ struct Chain {
 /// Represents a configured dispatchable function call, including the pallet, function, arguments,
 /// and signing options.
 #[derive(Clone)]
-struct CallParachain {
+struct Call {
 	/// The dispatchable function to execute.
 	function: Function,
 	/// The dispatchable function arguments, encoded as strings.
@@ -334,7 +334,7 @@ struct CallParachain {
 	sudo: bool,
 }
 
-impl CallParachain {
+impl Call {
 	// Prepares the extrinsic.
 	fn prepare_extrinsic(
 		&self,
@@ -700,7 +700,7 @@ mod tests {
 	#[tokio::test]
 	async fn prepare_extrinsic_works() -> Result<()> {
 		let client = set_up_client(POP_NETWORK_TESTNET_URL).await?;
-		let mut call_config = CallParachain {
+		let mut call_config = Call {
 			function: Function {
 				pallet: "WrongName".to_string(),
 				name: "WrongName".to_string(),
@@ -743,7 +743,7 @@ mod tests {
 	async fn user_cancel_submit_extrinsic_works() -> Result<()> {
 		let client = set_up_client(POP_NETWORK_TESTNET_URL).await?;
 		let pallets = parse_chain_metadata(&client)?;
-		let mut call_config = CallParachain {
+		let mut call_config = Call {
 			function: find_dispatchable_by_name(&pallets, "System", "remark")?.clone(),
 			args: vec!["0x11".to_string()].to_vec(),
 			suri: DEFAULT_URI.to_string(),

--- a/crates/pop-cli/src/commands/call/chain.rs
+++ b/crates/pop-cli/src/commands/call/chain.rs
@@ -20,7 +20,7 @@ const ENCODED_CALL_DATA_MAX_LEN: usize = 500; // Maximum length of encoded call 
 /// Command to construct and execute extrinsics with configurable pallets, functions, arguments, and
 /// signing options.
 #[derive(Args, Clone, Default)]
-pub struct CallParachainCommand {
+pub struct CallChainCommand {
 	/// The pallet containing the dispatchable function to execute.
 	#[arg(short, long, value_parser = parse_pallet_name)]
 	pallet: Option<String>,
@@ -51,7 +51,7 @@ pub struct CallParachainCommand {
 	skip_confirm: bool,
 }
 
-impl CallParachainCommand {
+impl CallChainCommand {
 	/// Executes the command.
 	pub(crate) async fn execute(mut self) -> Result<()> {
 		let mut cli = cli::Cli;
@@ -600,7 +600,7 @@ mod tests {
 	#[tokio::test]
 	async fn configure_chain_works() -> Result<()> {
 		let call_config =
-			CallParachainCommand { suri: Some(DEFAULT_URI.to_string()), ..Default::default() };
+			CallChainCommand { suri: Some(DEFAULT_URI.to_string()), ..Default::default() };
 		let mut cli = MockCli::new().expect_intro("Call a chain").expect_input(
 			"Which chain would you like to interact with?",
 			POP_NETWORK_TESTNET_URL.into(),
@@ -611,9 +611,9 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn guide_user_to_call_parachain_works() -> Result<()> {
+	async fn guide_user_to_call_chain_works() -> Result<()> {
 		let mut call_config =
-			CallParachainCommand { pallet: Some("System".to_string()), ..Default::default() };
+			CallChainCommand { pallet: Some("System".to_string()), ..Default::default() };
 
 		let mut cli = MockCli::new()
 		.expect_intro("Call a chain")
@@ -647,19 +647,19 @@ mod tests {
 		let chain = call_config.configure_chain(&mut cli).await?;
 		assert_eq!(chain.url, Url::parse(POP_NETWORK_TESTNET_URL)?);
 
-		let call_parachain = call_config.configure_call(&chain, &mut cli)?;
-		assert_eq!(call_parachain.function.pallet, "System");
-		assert_eq!(call_parachain.function.name, "remark");
-		assert_eq!(call_parachain.args, ["0x11".to_string()].to_vec());
-		assert_eq!(call_parachain.suri, "//Bob");
-		assert!(call_parachain.sudo);
-		assert_eq!(call_parachain.display(&chain), "pop call chain --pallet System --function remark --args \"0x11\" --url wss://rpc1.paseo.popnetwork.xyz/ --suri //Bob --sudo");
+		let call_chain = call_config.configure_call(&chain, &mut cli)?;
+		assert_eq!(call_chain.function.pallet, "System");
+		assert_eq!(call_chain.function.name, "remark");
+		assert_eq!(call_chain.args, ["0x11".to_string()].to_vec());
+		assert_eq!(call_chain.suri, "//Bob");
+		assert!(call_chain.sudo);
+		assert_eq!(call_chain.display(&chain), "pop call chain --pallet System --function remark --args \"0x11\" --url wss://rpc1.paseo.popnetwork.xyz/ --suri //Bob --sudo");
 		cli.verify()
 	}
 
 	#[tokio::test]
 	async fn guide_user_to_configure_predefined_action_works() -> Result<()> {
-		let mut call_config = CallParachainCommand::default();
+		let mut call_config = CallChainCommand::default();
 
 		let mut cli = MockCli::new().expect_intro("Call a chain").expect_input(
 			"Which chain would you like to interact with?",
@@ -692,14 +692,14 @@ mod tests {
 			.expect_input("Enter the value for the parameter: para_id", "2000".into())
 			.expect_input("Signer of the extrinsic:", BOB_SURI.into());
 
-		let call_parachain = call_config.configure_call(&chain, &mut cli)?;
+		let call_chain = call_config.configure_call(&chain, &mut cli)?;
 
-		assert_eq!(call_parachain.function.pallet, "OnDemand");
-		assert_eq!(call_parachain.function.name, "place_order_allow_death");
-		assert_eq!(call_parachain.args, ["10000".to_string(), "2000".to_string()].to_vec());
-		assert_eq!(call_parachain.suri, "//Bob");
-		assert!(!call_parachain.sudo);
-		assert_eq!(call_parachain.display(&chain), "pop call chain --pallet OnDemand --function place_order_allow_death --args \"10000\" \"2000\" --url wss://polkadot-rpc.publicnode.com/ --suri //Bob");
+		assert_eq!(call_chain.function.pallet, "OnDemand");
+		assert_eq!(call_chain.function.name, "place_order_allow_death");
+		assert_eq!(call_chain.args, ["10000".to_string(), "2000".to_string()].to_vec());
+		assert_eq!(call_chain.suri, "//Bob");
+		assert!(!call_chain.sudo);
+		assert_eq!(call_chain.display(&chain), "pop call chain --pallet OnDemand --function place_order_allow_death --args \"10000\" \"2000\" --url wss://polkadot-rpc.publicnode.com/ --suri //Bob");
 		cli.verify()
 	}
 
@@ -768,7 +768,7 @@ mod tests {
 	#[tokio::test]
 	async fn user_cancel_submit_extrinsic_from_call_data_works() -> Result<()> {
 		let client = set_up_client("wss://rpc1.paseo.popnetwork.xyz").await?;
-		let call_config = CallParachainCommand {
+		let call_config = CallChainCommand {
 			pallet: None,
 			function: None,
 			args: vec![].to_vec(),
@@ -792,7 +792,7 @@ mod tests {
 	#[tokio::test]
 	async fn configure_sudo_works() -> Result<()> {
 		// Test when sudo pallet doesn't exist.
-		let mut call_config = CallParachainCommand {
+		let mut call_config = CallChainCommand {
 			pallet: None,
 			function: None,
 			args: vec![].to_vec(),
@@ -824,7 +824,7 @@ mod tests {
 
 	#[test]
 	fn reset_for_new_call_works() -> Result<()> {
-		let mut call_config = CallParachainCommand {
+		let mut call_config = CallChainCommand {
 			pallet: Some("System".to_string()),
 			function: Some("remark".to_string()),
 			args: vec!["0x11".to_string()].to_vec(),
@@ -844,7 +844,7 @@ mod tests {
 
 	#[test]
 	fn requires_user_input_works() -> Result<()> {
-		let mut call_config = CallParachainCommand {
+		let mut call_config = CallChainCommand {
 			pallet: Some("System".to_string()),
 			function: Some("remark".to_string()),
 			args: vec!["0x11".to_string()].to_vec(),
@@ -862,7 +862,7 @@ mod tests {
 
 	#[test]
 	fn expand_file_arguments_works() -> Result<()> {
-		let mut call_config = CallParachainCommand {
+		let mut call_config = CallChainCommand {
 			pallet: Some("Registrar".to_string()),
 			function: Some("register".to_string()),
 			args: vec!["2000".to_string(), "0x1".to_string(), "0x12".to_string()].to_vec(),

--- a/crates/pop-cli/src/commands/call/mod.rs
+++ b/crates/pop-cli/src/commands/call/mod.rs
@@ -15,13 +15,13 @@ pub(crate) struct CallArgs {
 	pub command: Command,
 }
 
-/// Call a smart contract.
+/// Call a chain or a smart contract.
 #[derive(Subcommand)]
 pub(crate) enum Command {
-	/// Call a parachain.
+	/// Call a chain
 	#[cfg(feature = "parachain")]
-	#[clap(alias = "p")]
-	Parachain(parachain::CallParachainCommand),
+	#[clap(aliases = ["p"], visible_aliases = ["parachain"])]
+	Chain(parachain::CallParachainCommand),
 	/// Call a contract
 	#[cfg(feature = "contract")]
 	#[clap(alias = "c")]

--- a/crates/pop-cli/src/commands/call/mod.rs
+++ b/crates/pop-cli/src/commands/call/mod.rs
@@ -2,10 +2,10 @@
 
 use clap::{Args, Subcommand};
 
+#[cfg(feature = "parachain")]
+pub(crate) mod chain;
 #[cfg(feature = "contract")]
 pub(crate) mod contract;
-#[cfg(feature = "parachain")]
-pub(crate) mod parachain;
 
 /// Arguments for calling a smart contract.
 #[derive(Args)]
@@ -21,7 +21,7 @@ pub(crate) enum Command {
 	/// Call a chain
 	#[cfg(feature = "parachain")]
 	#[clap(aliases = ["p"], visible_aliases = ["parachain"])]
-	Chain(parachain::CallParachainCommand),
+	Chain(chain::CallChainCommand),
 	/// Call a contract
 	#[cfg(feature = "contract")]
 	#[clap(alias = "c")]

--- a/crates/pop-cli/src/commands/call/mod.rs
+++ b/crates/pop-cli/src/commands/call/mod.rs
@@ -20,7 +20,7 @@ pub(crate) struct CallArgs {
 pub(crate) enum Command {
 	/// Call a chain
 	#[cfg(feature = "parachain")]
-	#[clap(aliases = ["p"], visible_aliases = ["parachain"])]
+	#[clap(alias = "p", visible_aliases = ["parachain"])]
 	Chain(chain::CallChainCommand),
 	/// Call a contract
 	#[cfg(feature = "contract")]

--- a/crates/pop-cli/src/commands/call/parachain.rs
+++ b/crates/pop-cli/src/commands/call/parachain.rs
@@ -95,8 +95,9 @@ impl CallParachainCommand {
 				break;
 			}
 
-			if !prompt_to_repeat_call ||
-				!cli.confirm("Do you want to perform another call?")
+			if !prompt_to_repeat_call
+				|| !cli
+					.confirm("Do you want to perform another call?")
 					.initial_value(false)
 					.interact()?
 			{
@@ -110,7 +111,7 @@ impl CallParachainCommand {
 
 	// Configures the chain by resolving the URL and fetching its metadata.
 	async fn configure_chain(&self, cli: &mut impl Cli) -> Result<Chain> {
-		cli.intro("Call a parachain")?;
+		cli.intro("Call a chain")?;
 		// Resolve url.
 		let url = match &self.url {
 			Some(url) => url.clone(),
@@ -195,8 +196,9 @@ impl CallParachainCommand {
 			// Resolve who is signing the extrinsic.
 			let suri = match self.suri.as_ref() {
 				Some(suri) => suri.clone(),
-				None =>
-					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
+				None => {
+					cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?
+				},
 			};
 
 			return Ok(CallParachain {
@@ -222,8 +224,9 @@ impl CallParachainCommand {
 			None => &cli.input("Signer of the extrinsic:").default_input(DEFAULT_URI).interact()?,
 		};
 		cli.info(format!("Encoded call data: {}", call_data))?;
-		if !self.skip_confirm &&
-			!cli.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm
+			&& !cli
+				.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -251,7 +254,7 @@ impl CallParachainCommand {
 	// execute the call via `sudo`.
 	fn configure_sudo(&mut self, chain: &Chain, cli: &mut impl Cli) -> Result<()> {
 		match find_dispatchable_by_name(&chain.pallets, "Sudo", "sudo") {
-			Ok(_) =>
+			Ok(_) => {
 				if !self.sudo {
 					self.sudo = cli
 						.confirm(
@@ -259,14 +262,16 @@ impl CallParachainCommand {
 						)
 						.initial_value(false)
 						.interact()?;
-				},
-			Err(_) =>
+				}
+			},
+			Err(_) => {
 				if self.sudo {
 					cli.warning(
 						"NOTE: sudo is not supported by the chain. Ignoring `--sudo` flag.",
 					)?;
 					self.sudo = false;
-				},
+				}
+			},
 		}
 		Ok(())
 	}
@@ -281,11 +286,11 @@ impl CallParachainCommand {
 
 	// Function to check if all required fields are specified.
 	fn requires_user_input(&self) -> bool {
-		self.pallet.is_none() ||
-			self.function.is_none() ||
-			self.args.is_empty() ||
-			self.url.is_none() ||
-			self.suri.is_none()
+		self.pallet.is_none()
+			|| self.function.is_none()
+			|| self.args.is_empty()
+			|| self.url.is_none()
+			|| self.suri.is_none()
 	}
 
 	/// Replaces file arguments with their contents, leaving other arguments unchanged.
@@ -364,8 +369,9 @@ impl CallParachain {
 		tx: DynamicPayload,
 		cli: &mut impl Cli,
 	) -> Result<()> {
-		if !self.skip_confirm &&
-			!cli.confirm("Do you want to submit the extrinsic?")
+		if !self.skip_confirm
+			&& !cli
+				.confirm("Do you want to submit the extrinsic?")
 				.initial_value(true)
 				.interact()?
 		{
@@ -387,7 +393,7 @@ impl CallParachain {
 	}
 
 	fn display(&self, chain: &Chain) -> String {
-		let mut full_message = "pop call parachain".to_string();
+		let mut full_message = "pop call chain".to_string();
 		full_message.push_str(&format!(" --pallet {}", self.function.pallet));
 		full_message.push_str(&format!(" --function {}", self.function));
 		if !self.args.is_empty() {
@@ -595,7 +601,7 @@ mod tests {
 	async fn configure_chain_works() -> Result<()> {
 		let call_config =
 			CallParachainCommand { suri: Some(DEFAULT_URI.to_string()), ..Default::default() };
-		let mut cli = MockCli::new().expect_intro("Call a parachain").expect_input(
+		let mut cli = MockCli::new().expect_intro("Call a chain").expect_input(
 			"Which chain would you like to interact with?",
 			POP_NETWORK_TESTNET_URL.into(),
 		);
@@ -610,7 +616,7 @@ mod tests {
 			CallParachainCommand { pallet: Some("System".to_string()), ..Default::default() };
 
 		let mut cli = MockCli::new()
-		.expect_intro("Call a parachain")
+		.expect_intro("Call a chain")
 		.expect_input("Which chain would you like to interact with?", POP_NETWORK_TESTNET_URL.into())
 		.expect_select(
 			"Select the function to call:",
@@ -647,7 +653,7 @@ mod tests {
 		assert_eq!(call_parachain.args, ["0x11".to_string()].to_vec());
 		assert_eq!(call_parachain.suri, "//Bob");
 		assert!(call_parachain.sudo);
-		assert_eq!(call_parachain.display(&chain), "pop call parachain --pallet System --function remark --args \"0x11\" --url wss://rpc1.paseo.popnetwork.xyz/ --suri //Bob --sudo");
+		assert_eq!(call_parachain.display(&chain), "pop call chain --pallet System --function remark --args \"0x11\" --url wss://rpc1.paseo.popnetwork.xyz/ --suri //Bob --sudo");
 		cli.verify()
 	}
 
@@ -655,7 +661,7 @@ mod tests {
 	async fn guide_user_to_configure_predefined_action_works() -> Result<()> {
 		let mut call_config = CallParachainCommand::default();
 
-		let mut cli = MockCli::new().expect_intro("Call a parachain").expect_input(
+		let mut cli = MockCli::new().expect_intro("Call a chain").expect_input(
 			"Which chain would you like to interact with?",
 			POLKADOT_NETWORK_URL.into(),
 		);
@@ -693,7 +699,7 @@ mod tests {
 		assert_eq!(call_parachain.args, ["10000".to_string(), "2000".to_string()].to_vec());
 		assert_eq!(call_parachain.suri, "//Bob");
 		assert!(!call_parachain.sudo);
-		assert_eq!(call_parachain.display(&chain), "pop call parachain --pallet OnDemand --function place_order_allow_death --args \"10000\" \"2000\" --url wss://polkadot-rpc.publicnode.com/ --suri //Bob");
+		assert_eq!(call_parachain.display(&chain), "pop call chain --pallet OnDemand --function place_order_allow_death --args \"10000\" \"2000\" --url wss://polkadot-rpc.publicnode.com/ --suri //Bob");
 		cli.verify()
 	}
 
@@ -797,7 +803,7 @@ mod tests {
 			sudo: true,
 		};
 		let mut cli = MockCli::new()
-			.expect_intro("Call a parachain")
+			.expect_intro("Call a chain")
 			.expect_warning("NOTE: sudo is not supported by the chain. Ignoring `--sudo` flag.");
 		let chain = call_config.configure_chain(&mut cli).await?;
 		call_config.configure_sudo(&chain, &mut cli)?;
@@ -805,7 +811,7 @@ mod tests {
 		cli.verify()?;
 
 		// Test when sudo pallet exist.
-		cli = MockCli::new().expect_intro("Call a parachain").expect_confirm(
+		cli = MockCli::new().expect_intro("Call a chain").expect_confirm(
 			"Would you like to dispatch this function call with `Root` origin?",
 			true,
 		);

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -26,7 +26,7 @@ pub(crate) enum Command {
 	#[clap(alias = "b", about = about_build())]
 	#[cfg(any(feature = "parachain", feature = "contract"))]
 	Build(build::BuildArgs),
-	/// Call a parachain or a smart contract.
+	/// Call a chain or a smart contract.
 	#[clap(alias = "c")]
 	#[cfg(any(feature = "parachain", feature = "contract"))]
 	Call(call::CallArgs),
@@ -99,7 +99,7 @@ impl Command {
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::Call(args) => match args.command {
 				#[cfg(feature = "parachain")]
-				call::Command::Parachain(cmd) => cmd.execute().await.map(|_| Value::Null),
+				call::Command::Chain(cmd) => cmd.execute().await.map(|_| Value::Null),
 				#[cfg(feature = "contract")]
 				call::Command::Contract(cmd) => cmd.execute().await.map(|_| Value::Null),
 			},

--- a/crates/pop-cli/tests/parachain.rs
+++ b/crates/pop-cli/tests/parachain.rs
@@ -133,13 +133,13 @@ name = "collator-01"
 	// Wait for the networks to initialize. Increased timeout to accommodate CI environment delays.
 	sleep(Duration::from_secs(50)).await;
 
-	// `pop call parachain --pallet System --function remark --args "0x11" --url
+	// `pop call chain --pallet System --function remark --args "0x11" --url
 	// ws://127.0.0.1:random_port --suri //Alice --skip-confirm`
 	Command::cargo_bin("pop")
 		.unwrap()
 		.args(&[
 			"call",
-			"parachain",
+			"chain",
 			"--pallet",
 			"System",
 			"--function",
@@ -155,13 +155,13 @@ name = "collator-01"
 		.assert()
 		.success();
 
-	// pop call parachain --call 0x00000411 --url ws://127.0.0.1:random_port --suri //Alice
+	// pop call chain --call 0x00000411 --url ws://127.0.0.1:random_port --suri //Alice
 	// --skip-confirm
 	Command::cargo_bin("pop")
 		.unwrap()
 		.args(&[
 			"call",
-			"parachain",
+			"chain",
 			"--call",
 			"0x00000411",
 			"--url",


### PR DESCRIPTION
Simple renaming to use `chain` instead of `parachain` as the primary command for `pop call chain` but retainining `parachain` as an alias.

Example help output:
```
Call a chain or a smart contract

Usage: pop call
       pop call <COMMAND>

Commands:
  chain     Call a chain [aliases: parachain]
  contract  Call a contract
  help      Print this message or the help of the given subcommand(s)
```