### PR TITLE
test: improve coverage

### DIFF
--- a/crates/pop-cli/src/commands/test/contract.rs
+++ b/crates/pop-cli/src/commands/test/contract.rs
@@ -48,7 +48,13 @@ impl TestContractCommand {
 				sleep(Duration::from_secs(3)).await;
 			}
 
-			self.node = match check_contracts_node_and_prompt(&mut Cli, self.skip_confirm).await {
+			self.node = match check_contracts_node_and_prompt(
+				&mut Cli,
+				&crate::cache()?,
+				self.skip_confirm,
+			)
+			.await
+			{
 				Ok(binary_path) => Some(binary_path),
 				Err(_) => {
 					warning("🚫 substrate-contracts-node is necessary to run e2e tests. Will try to run tests anyway...")?;

--- a/crates/pop-cli/src/commands/test/contract.rs
+++ b/crates/pop-cli/src/commands/test/contract.rs
@@ -48,7 +48,7 @@ impl TestContractCommand {
 				sleep(Duration::from_secs(3)).await;
 			}
 
-			self.node = match check_contracts_node_and_prompt(self.skip_confirm).await {
+			self.node = match check_contracts_node_and_prompt(&mut Cli, self.skip_confirm).await {
 				Ok(binary_path) => Some(binary_path),
 				Err(_) => {
 					warning("🚫 substrate-contracts-node is necessary to run e2e tests. Will try to run tests anyway...")?;

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -139,15 +139,16 @@ impl UpContractCommand {
 			let log = NamedTempFile::new()?;
 
 			// uses the cache location
-			let binary_path = match check_contracts_node_and_prompt(self.skip_confirm).await {
-				Ok(binary_path) => binary_path,
-				Err(_) => {
-					Cli.outro_cancel(
-						"🚫 You need to specify an accessible endpoint to deploy the contract.",
-					)?;
-					return Ok(());
-				},
-			};
+			let binary_path =
+				match check_contracts_node_and_prompt(&mut Cli, self.skip_confirm).await {
+					Ok(binary_path) => binary_path,
+					Err(_) => {
+						Cli.outro_cancel(
+							"🚫 You need to specify an accessible endpoint to deploy the contract.",
+						)?;
+						return Ok(());
+					},
+				};
 
 			let spinner = spinner();
 			spinner.start("Starting local node...");
@@ -181,7 +182,7 @@ impl UpContractCommand {
 				Ok(data) => data,
 				Err(e) => {
 					error(format!("An error occurred getting the call data: {e}"))?;
-					terminate_node(process)?;
+					terminate_node(&mut Cli, process)?;
 					Cli.outro_cancel(FAILED)?;
 					return Ok(());
 				},
@@ -200,7 +201,7 @@ impl UpContractCommand {
 						Err(e) => {
 							spinner
 								.error(format!("An error occurred uploading your contract: {e}"));
-							terminate_node(process)?;
+							terminate_node(&mut Cli, process)?;
 							Cli.outro_cancel(FAILED)?;
 							return Ok(());
 						},
@@ -223,7 +224,7 @@ impl UpContractCommand {
 								spinner.error(format!(
 									"An error occurred uploading your contract: {e}"
 								));
-								terminate_node(process)?;
+								terminate_node(&mut Cli, process)?;
 								Cli.outro_cancel(FAILED)?;
 								return Ok(());
 							},
@@ -243,11 +244,11 @@ impl UpContractCommand {
 				}
 			} else {
 				Cli.outro_cancel("Signed payload doesn't exist.")?;
-				terminate_node(process)?;
+				terminate_node(&mut Cli, process)?;
 				return Ok(());
 			}
 
-			terminate_node(process)?;
+			terminate_node(&mut Cli, process)?;
 			Cli.outro(COMPLETE)?;
 			return Ok(());
 		}
@@ -255,7 +256,7 @@ impl UpContractCommand {
 		// Check for upload only.
 		if self.upload_only {
 			let result = self.upload_contract().await;
-			terminate_node(process)?;
+			terminate_node(&mut Cli, process)?;
 			match result {
 				Ok(_) => {
 					Cli.outro(COMPLETE)?;
@@ -272,7 +273,7 @@ impl UpContractCommand {
 			Ok(i) => i,
 			Err(e) => {
 				error(format!("An error occurred instantiating the contract: {e}"))?;
-				terminate_node(process)?;
+				terminate_node(&mut Cli, process)?;
 				Cli.outro_cancel(FAILED)?;
 				return Ok(());
 			},
@@ -290,7 +291,7 @@ impl UpContractCommand {
 				},
 				Err(e) => {
 					spinner.error(format!("{e}"));
-					terminate_node(process)?;
+					terminate_node(&mut Cli, process)?;
 					Cli.outro_cancel(FAILED)?;
 					return Ok(());
 				},
@@ -308,7 +309,7 @@ impl UpContractCommand {
 				contract_info.code_hash,
 			);
 
-			terminate_node(process)?;
+			terminate_node(&mut Cli, process)?;
 			Cli.outro(COMPLETE)?;
 		}
 

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -139,16 +139,21 @@ impl UpContractCommand {
 			let log = NamedTempFile::new()?;
 
 			// uses the cache location
-			let binary_path =
-				match check_contracts_node_and_prompt(&mut Cli, self.skip_confirm).await {
-					Ok(binary_path) => binary_path,
-					Err(_) => {
-						Cli.outro_cancel(
-							"🚫 You need to specify an accessible endpoint to deploy the contract.",
-						)?;
-						return Ok(());
-					},
-				};
+			let binary_path = match check_contracts_node_and_prompt(
+				&mut Cli,
+				&crate::cache()?,
+				self.skip_confirm,
+			)
+			.await
+			{
+				Ok(binary_path) => binary_path,
+				Err(_) => {
+					Cli.outro_cancel(
+						"🚫 You need to specify an accessible endpoint to deploy the contract.",
+					)?;
+					return Ok(());
+				},
+			};
 
 			let spinner = spinner();
 			spinner.start("Starting local node...");

--- a/crates/pop-cli/src/common/contracts.rs
+++ b/crates/pop-cli/src/common/contracts.rs
@@ -164,5 +164,4 @@ mod tests {
 			.expect_warning("NOTE: The node is running in the background with process ID 0. Please terminate it manually when done.");
 		Ok(())
 	}
-
 }

--- a/crates/pop-cli/src/common/contracts.rs
+++ b/crates/pop-cli/src/common/contracts.rs
@@ -163,7 +163,7 @@ mod tests {
 			.expect_warning("⚠️ The substrate-contracts-node binary is not found.");
 
 		let node_path = check_contracts_node_and_prompt(&mut cli, false).await?;
-		// Binary path is at least equals cache path + "substrate-contracts-node".
+		// Binary path is at least equals to the cache path + "substrate-contracts-node".
 		assert!(node_path
 			.to_str()
 			.unwrap()

--- a/crates/pop-cli/src/common/contracts.rs
+++ b/crates/pop-cli/src/common/contracts.rs
@@ -128,11 +128,7 @@ mod tests {
 	use duct::cmd;
 	use pop_common::find_free_port;
 	use pop_contracts::{is_chain_alive, run_contracts_node};
-	use std::{
-		fs::{self, File},
-		thread::sleep,
-		time::Duration,
-	};
+	use std::fs::{self, File};
 	use url::Url;
 
 	#[test]
@@ -158,7 +154,9 @@ mod tests {
 
 	#[tokio::test]
 	async fn check_contracts_node_and_prompt_works() -> anyhow::Result<()> {
-		let cache_path: PathBuf = crate::cache()?;
+		//let cache_path: PathBuf = crate::cache()?;
+
+		let cache_path = tempfile::tempdir().expect("Could create temp dir");
 		let mut cli = MockCli::new()
 			.expect_warning("⚠️ The substrate-contracts-node binary is not found.")
 			.expect_confirm("📦 Would you like to source it automatically now?", true)
@@ -169,9 +167,8 @@ mod tests {
 		assert!(node_path
 			.to_str()
 			.unwrap()
-			.starts_with(&cache_path.join("substrate-contracts-node").to_str().unwrap()));
-		cli.verify()?;
-		Ok(())
+			.starts_with(&cache_path.path().join("substrate-contracts-node").to_str().unwrap()));
+		cli.verify()
 	}
 
 	#[tokio::test]
@@ -187,8 +184,7 @@ mod tests {
 		let mut cli =
 			MockCli::new().expect_confirm("Would you like to terminate the local node?", true);
 		assert!(terminate_node(&mut cli, Some((process, log))).is_ok());
-		cli.verify()?;
 		assert_eq!(is_chain_alive(Url::parse(&format!("ws://localhost:{}", port))?).await?, false);
-		Ok(())
+		cli.verify()
 	}
 }

--- a/crates/pop-cli/src/common/contracts.rs
+++ b/crates/pop-cli/src/common/contracts.rs
@@ -14,6 +14,8 @@ use tempfile::NamedTempFile;
 /// prompts the user to update it if the existing binary is not the latest version.
 ///
 /// # Arguments
+/// * `cli`: Command line interface.
+/// * `cache_path`: The cache directory path.
 /// * `skip_confirm`: A boolean indicating whether to skip confirmation prompts.
 pub async fn check_contracts_node_and_prompt(
 	cli: &mut impl Cli,
@@ -78,6 +80,9 @@ pub async fn check_contracts_node_and_prompt(
 }
 
 /// Handles the optional termination of a local running node.
+/// # Arguments
+/// * `cli`: Command line interface.
+/// * `process`: Tuple identifying the child process to terminate and its log file.
 pub fn terminate_node(
 	cli: &mut impl Cli,
 	process: Option<(Child, NamedTempFile)>,

--- a/crates/pop-cli/src/common/contracts.rs
+++ b/crates/pop-cli/src/common/contracts.rs
@@ -17,10 +17,10 @@ use tempfile::NamedTempFile;
 /// * `skip_confirm`: A boolean indicating whether to skip confirmation prompts.
 pub async fn check_contracts_node_and_prompt(
 	cli: &mut impl Cli,
+	cache_path: &Path,
 	skip_confirm: bool,
 ) -> anyhow::Result<PathBuf> {
-	let cache_path: PathBuf = crate::cache()?;
-	let mut binary = contracts_node_generator(cache_path, None).await?;
+	let mut binary = contracts_node_generator(PathBuf::from(cache_path), None).await?;
 	let mut node_path = binary.path();
 	if !binary.exists() {
 		cli.warning("⚠️ The substrate-contracts-node binary is not found.")?;
@@ -154,15 +154,13 @@ mod tests {
 
 	#[tokio::test]
 	async fn check_contracts_node_and_prompt_works() -> anyhow::Result<()> {
-		//let cache_path: PathBuf = crate::cache()?;
-
 		let cache_path = tempfile::tempdir().expect("Could create temp dir");
 		let mut cli = MockCli::new()
 			.expect_warning("⚠️ The substrate-contracts-node binary is not found.")
 			.expect_confirm("📦 Would you like to source it automatically now?", true)
 			.expect_warning("⚠️ The substrate-contracts-node binary is not found.");
 
-		let node_path = check_contracts_node_and_prompt(&mut cli, false).await?;
+		let node_path = check_contracts_node_and_prompt(&mut cli, cache_path.path(), false).await?;
 		// Binary path is at least equals to the cache path + "substrate-contracts-node".
 		assert!(node_path
 			.to_str()

--- a/crates/pop-cli/src/common/contracts.rs
+++ b/crates/pop-cli/src/common/contracts.rs
@@ -166,7 +166,7 @@ mod tests {
 			.expect_warning("⚠️ The substrate-contracts-node binary is not found.");
 
 		let node_path = check_contracts_node_and_prompt(&mut cli, cache_path.path(), false).await?;
-		// Binary path is at least equals to the cache path + "substrate-contracts-node".
+		// Binary path is at least equal to the cache path + "substrate-contracts-node".
 		assert!(node_path
 			.to_str()
 			.unwrap()

--- a/crates/pop-cli/src/common/contracts.rs
+++ b/crates/pop-cli/src/common/contracts.rs
@@ -188,7 +188,7 @@ mod tests {
 			MockCli::new().expect_confirm("Would you like to terminate the local node?", true);
 		assert!(terminate_node(&mut cli, Some((process, log))).is_ok());
 		cli.verify()?;
-		assert_eq!(is_chain_alive(Url::parse(&format!("ws:localhost:{}", port))?).await?, false);
+		assert_eq!(is_chain_alive(Url::parse(&format!("ws://localhost:{}", port))?).await?, false);
 		Ok(())
 	}
 }


### PR DESCRIPTION
Improves coverage for
- `terminate_node`
- `check_contracts_node_and_prompt`

In `pop-cli/common/contracts.rs`

Refactors a few functions so that they receive the Cli as a parameter following the changes in #315  to facilitate testing.