### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ All notable changes to this project will be documented in this file.
 - Replace rococo to paseo name (#333)
 - Replace codeowners (#388)
 
+### Build
+
+- *(deps)* Remove unused dependencies (#369)
+
 ## [0.5.0] - 2024-11-08
 
 ### 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - Wallet integration (#371)
 - Guide user to call a chain (#316)
 - Guide user to call a contract (#306)
-- Call chain events (#372)
+- Output events after calling a chain (#372)
 - Add remark action (#387)
 
 ### 🐛 Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0] - 2024-12-19
+
+### 🚀 Features
+
+- Wallet integration (#371)
+- Guide user to call a chain (#316)
+- Guide user to call a contract (#306)
+- Call chain events (#372)
+- Add remark action (#387)
+
+### 🐛 Fixes
+
+- Build spec experience (#331)
+- HRMP channels (#278)
+
+### 🚜 Refactor
+
+- Ensure short args consistency (#386)
+- Bump fallback versions (#393)
+
+### ⚙️ Miscellaneous Tasks
+
+- Bump zombienet version to `v0.2.18` (#352)
+- Set msrv (#385)
+- Replace rococo to paseo name (#333)
+- Replace codeowners (#388)
+
 ## [0.5.0] - 2024-11-08
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,7 +951,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1247,7 +1247,7 @@ dependencies = [
  "hex",
  "http 1.2.0",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-named-pipe",
  "hyper-util",
  "hyperlocal",
@@ -1258,7 +1258,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror 2.0.6",
+ "thiserror 2.0.8",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -1720,7 +1720,7 @@ dependencies = [
  "semver 1.0.24",
  "serde",
  "serde_json",
- "thiserror 2.0.6",
+ "thiserror 2.0.8",
 ]
 
 [[package]]
@@ -1878,12 +1878,12 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1913,15 +1913,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "unicode-width 0.1.14",
- "windows-sys 0.52.0",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2113,7 +2113,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strsim 0.11.1",
- "thiserror 2.0.6",
+ "thiserror 2.0.8",
  "tracing",
 ]
 
@@ -2275,9 +2275,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -2294,18 +2294,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -2727,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.134"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a32d755fe20281b46118ee4b507233311fb7a48a0cfd42f554b93640521a2f"
+checksum = "4d44ff199ff93242c3afe480ab588d544dd08d72e92885e152ffebc670f076ad"
 dependencies = [
  "cc",
  "cxxbridge-cmd",
@@ -2741,9 +2741,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.134"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11645536ada5d1c8804312cbffc9ab950f2216154de431de930da47ca6955199"
+checksum = "66fd8f17ad454fc1e4f4ab83abffcc88a532e90350d3ffddcb73030220fcbd52"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -2755,9 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.134"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcc9c78e3c7289665aab921a2b394eaffe8bdb369aa18d81ffc0f534fd49385"
+checksum = "4717c9c806a9e07fdcb34c84965a414ea40fafe57667187052cf1eb7f5e8a8a9"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -2768,15 +2768,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.134"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a22a87bd9e78d7204d793261470a4c9d585154fddd251828d8aefbb5f74c3bf"
+checksum = "2f6515329bf3d98f4073101c7866ff2bec4e635a13acb82e3f3753fff0bf43cb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.134"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dfdb020ff8787c5daf6e0dca743005cc8782868faeadfbabb8824ede5cb1c72"
+checksum = "fb93e6a7ce8ec985c02bbb758237a31598b340acbbc3c19c5a4fa6adaaac92ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3251,9 +3251,9 @@ dependencies = [
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -3459,6 +3459,17 @@ name = "fastrlp"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec 0.7.6",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
 dependencies = [
  "arrayvec 0.7.6",
  "auto_impl",
@@ -4313,11 +4324,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4417,9 +4428,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4441,9 +4452,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4467,7 +4478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4483,7 +4494,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -4493,13 +4504,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "f6884a48c6826ec44f524c7456b163cebe9e55a18d7b5e307cb4f100371cc767"
 dependencies = [
  "futures-util",
  "http 1.2.0",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "rustls 0.23.20",
  "rustls-pki-types",
@@ -4514,7 +4525,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -4527,7 +4538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -4541,7 +4552,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -4560,7 +4571,7 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -4576,7 +4587,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5318,7 +5329,7 @@ dependencies = [
  "home",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "hyper-rustls 0.24.2",
  "hyper-timeout",
  "jsonpath-rust",
@@ -5399,9 +5410,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libgit2-sys"
@@ -5872,9 +5883,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
 ]
@@ -5904,7 +5915,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "log",
  "rand",
@@ -8496,7 +8507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.6",
+ "thiserror 2.0.8",
  "ucd-trie",
 ]
 
@@ -9335,7 +9346,7 @@ dependencies = [
 
 [[package]]
 name = "pop-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9371,7 +9382,7 @@ dependencies = [
 
 [[package]]
 name = "pop-common"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -9403,7 +9414,7 @@ dependencies = [
 
 [[package]]
 name = "pop-contracts"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "contract-build",
@@ -9430,7 +9441,7 @@ dependencies = [
 
 [[package]]
 name = "pop-parachains"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -9460,7 +9471,7 @@ dependencies = [
 
 [[package]]
 name = "pop-telemetry"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dirs",
  "env_logger 0.11.5",
@@ -9926,7 +9937,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -9967,8 +9978,8 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
- "hyper-rustls 0.27.3",
+ "hyper 1.5.2",
+ "hyper-rustls 0.27.4",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -10084,16 +10095,18 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
+checksum = "f5ef8fb1dd8de3870cb8400d51b4c2023854bbafd5431a3ac7e7317243e22d2f"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "bytes",
- "fastrlp",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
  "num-bigint",
+ "num-integer",
  "num-traits",
  "parity-scale-codec",
  "primitive-types 0.12.2",
@@ -10891,9 +10904,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -13520,11 +13533,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.6"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
 dependencies = [
- "thiserror-impl 2.0.6",
+ "thiserror-impl 2.0.8",
 ]
 
 [[package]]
@@ -13540,9 +13553,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.6"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
+checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15358,9 +15371,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d52293fc86ea7cf13971b3bb81eb21683636e7ae24c729cdaf1b7c4157a352"
+checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
 dependencies = [
  "arbitrary",
  "crc32fast",
@@ -15368,7 +15381,7 @@ dependencies = [
  "displaydoc",
  "indexmap 2.7.0",
  "memchr",
- "thiserror 2.0.6",
+ "thiserror 2.0.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ documentation = "https://learn.onpop.io/"
 license = "GPL-3.0"
 repository = "https://github.com/r0gue-io/pop-cli"
 rust-version = "1.81.0"
-version = "0.5.0"
+version = "0.6.0"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -33,19 +33,19 @@ strum.workspace = true
 strum_macros.workspace = true
 
 # contracts
-pop-contracts = { path = "../pop-contracts", version = "0.5.0", optional = true }
+pop-contracts = { path = "../pop-contracts", version = "0.6.0", optional = true }
 sp-weights = { workspace = true, optional = true }
 
 # parachains
-pop-parachains = { path = "../pop-parachains", version = "0.5.0", optional = true }
+pop-parachains = { path = "../pop-parachains", version = "0.6.0", optional = true }
 dirs = { workspace = true, optional = true }
 git2.workspace = true
 
 # telemetry
-pop-telemetry = { path = "../pop-telemetry", version = "0.5.0", optional = true }
+pop-telemetry = { path = "../pop-telemetry", version = "0.6.0", optional = true }
 
 # common
-pop-common = { path = "../pop-common", version = "0.5.0" }
+pop-common = { path = "../pop-common", version = "0.6.0" }
 
 # wallet-integration
 axum.workspace = true

--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -4,9 +4,9 @@ use crate::cli;
 use pop_contracts::{build_smart_contract, Verbosity};
 use std::path::PathBuf;
 
-/// Represents the configuration for building a smart contract.
+/// Configuration for building a smart contract.
 pub struct BuildContract {
-	/// Path for the contract project.
+	/// Path of the contract project.
 	pub(crate) path: Option<PathBuf>,
 	/// Build profile: `true` for release mode, `false` for debug mode.
 	pub(crate) release: bool,

--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -4,16 +4,15 @@ use crate::cli;
 use pop_contracts::{build_smart_contract, Verbosity};
 use std::path::PathBuf;
 
-/// Command to build a smart contract with configurable path and release mode.
-pub struct BuildContractCommand {
-	/// Path for the contract project [default: current directory]
+/// Represents the configuration for building a smart contract.
+pub struct BuildContract {
+	/// Path for the contract project.
 	pub(crate) path: Option<PathBuf>,
-	/// The default compilation includes debug functionality, increasing contract size and gas
-	/// usage. For production, always build in release mode to exclude debug features.
+	/// Build profile: `true` for release mode, `false` for debug mode.
 	pub(crate) release: bool,
 }
 
-impl BuildContractCommand {
+impl BuildContract {
 	/// Executes the command.
 	pub(crate) fn execute(self) -> anyhow::Result<&'static str> {
 		self.build(&mut cli::Cli)
@@ -55,7 +54,7 @@ mod tests {
 				.expect_outro("Build completed successfully!");
 
 			assert_eq!(
-				BuildContractCommand { path: Some(path.join(name)), release }.build(&mut cli)?,
+				BuildContract { path: Some(path.join(name)), release }.build(&mut cli)?,
 				"contract"
 			);
 

--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -1,18 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use crate::cli;
-use clap::Args;
 use pop_contracts::{build_smart_contract, Verbosity};
 use std::path::PathBuf;
 
-#[derive(Args)]
+/// Command to build a smart contract with configurable path and release mode.
 pub struct BuildContractCommand {
 	/// Path for the contract project [default: current directory]
-	#[arg(long)]
 	pub(crate) path: Option<PathBuf>,
 	/// The default compilation includes debug functionality, increasing contract size and gas
 	/// usage. For production, always build in release mode to exclude debug features.
-	#[clap(short, long)]
 	pub(crate) release: bool,
 }
 

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -37,7 +37,7 @@ pub(crate) struct BuildArgs {
 	pub(crate) profile: Option<Profile>,
 }
 
-/// Build a chain specification and its genesis artifacts.
+/// Subcommand for building chain artifacts.
 #[derive(Subcommand)]
 pub(crate) enum Command {
 	/// Build a chain specification and its genesis artifacts.

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -35,13 +35,9 @@ pub(crate) struct BuildArgs {
 	/// Build profile [default: debug].
 	#[clap(long, value_enum)]
 	pub(crate) profile: Option<Profile>,
-	/// Parachain ID to be used when generating the chain spec files.
-	#[arg(short = 'i', long = "id")]
-	#[cfg(feature = "parachain")]
-	pub(crate) id: Option<u32>,
 }
 
-/// Build a parachain, smart contract or Rust package.
+/// Build a parachain, smart contract, chain specification or Rust package.
 #[derive(Subcommand)]
 pub(crate) enum Command {
 	/// Build a chain specification and its genesis artifacts.
@@ -74,10 +70,9 @@ impl Command {
 			};
 			// All commands originating from root command are valid
 			BuildParachainCommand {
-				path: args.path,
+				path: args.path.unwrap_or_else(|| PathBuf::from("./")),
 				package: args.package,
-				profile: Some(profile),
-				id: args.id,
+				profile,
 			}
 			.execute()?;
 			return Ok("parachain");
@@ -150,7 +145,6 @@ mod tests {
 								package: package.clone(),
 								release,
 								profile: Some(profile.clone()),
-								id: None,
 							},
 							&mut cli,
 						)?,

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -3,12 +3,12 @@
 use crate::cli::{self, Cli};
 use clap::{Args, Subcommand};
 #[cfg(feature = "contract")]
-use contract::BuildContractCommand;
+use contract::BuildContract;
 use duct::cmd;
 use pop_common::Profile;
 use std::path::PathBuf;
 #[cfg(feature = "parachain")]
-use {parachain::BuildParachainCommand, spec::BuildSpecCommand};
+use {parachain::BuildParachain, spec::BuildSpecCommand};
 
 #[cfg(feature = "contract")]
 pub(crate) mod contract;
@@ -37,7 +37,7 @@ pub(crate) struct BuildArgs {
 	pub(crate) profile: Option<Profile>,
 }
 
-/// Build a parachain, smart contract, chain specification or Rust package.
+/// Build a chain specification and its genesis artifacts.
 #[derive(Subcommand)]
 pub(crate) enum Command {
 	/// Build a chain specification and its genesis artifacts.
@@ -52,12 +52,12 @@ impl Command {
 		// If only contract feature enabled, build as contract
 		#[cfg(feature = "contract")]
 		if pop_contracts::is_supported(args.path.as_deref())? {
-			// All commands originating from root command are valid
+			// All arguments originating from root command are valid
 			let release = match args.profile {
 				Some(profile) => profile.into(),
 				None => args.release,
 			};
-			BuildContractCommand { path: args.path, release }.execute()?;
+			BuildContract { path: args.path, release }.execute()?;
 			return Ok("contract");
 		}
 
@@ -68,8 +68,8 @@ impl Command {
 				Some(profile) => profile,
 				None => args.release.into(),
 			};
-			// All commands originating from root command are valid
-			BuildParachainCommand {
+			// All arguments originating from root command are valid.
+			BuildParachain {
 				path: args.path.unwrap_or_else(|| PathBuf::from("./")),
 				package: args.package,
 				profile,

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -44,15 +44,6 @@ pub(crate) struct BuildArgs {
 /// Build a parachain, smart contract or Rust package.
 #[derive(Subcommand)]
 pub(crate) enum Command {
-	/// [DEPRECATED] Build a parachain
-	#[cfg(feature = "parachain")]
-	#[clap(alias = "p")]
-	Parachain(BuildParachainCommand),
-	/// [DEPRECATED] Build a contract, generate metadata, bundle together in a `<name>.contract`
-	/// file
-	#[cfg(feature = "contract")]
-	#[clap(alias = "c")]
-	Contract(BuildContractCommand),
 	/// Build a chain specification and its genesis artifacts.
 	#[cfg(feature = "parachain")]
 	#[clap(alias = "s")]
@@ -70,7 +61,7 @@ impl Command {
 				Some(profile) => profile.into(),
 				None => args.release,
 			};
-			BuildContractCommand { path: args.path, release, valid: true }.execute()?;
+			BuildContractCommand { path: args.path, release }.execute()?;
 			return Ok("contract");
 		}
 
@@ -87,7 +78,6 @@ impl Command {
 				package: args.package,
 				profile: Some(profile),
 				id: args.id,
-				valid: true,
 			}
 			.execute()?;
 			return Ok("parachain");

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -52,7 +52,6 @@ impl Command {
 		// If only contract feature enabled, build as contract
 		#[cfg(feature = "contract")]
 		if pop_contracts::is_supported(args.path.as_deref())? {
-			// All arguments originating from root command are valid
 			let release = match args.profile {
 				Some(profile) => profile.into(),
 				None => args.release,
@@ -68,7 +67,6 @@ impl Command {
 				Some(profile) => profile,
 				None => args.release.into(),
 			};
-			// All arguments originating from root command are valid.
 			BuildParachain {
 				path: args.path.unwrap_or_else(|| PathBuf::from("./")),
 				package: args.package,

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -7,9 +7,9 @@ use std::path::PathBuf;
 #[cfg(not(test))]
 use std::{thread::sleep, time::Duration};
 
-/// Command to build a parachain with configurable path, package, and profile.
-pub struct BuildParachainCommand {
-	/// Directory path for your project [default: current directory].
+// Represents the configuration for building a parachain.
+pub struct BuildParachain {
+	/// Directory path for your project.
 	pub(crate) path: PathBuf,
 	/// The package to be built.
 	pub(crate) package: Option<String>,
@@ -17,8 +17,8 @@ pub struct BuildParachainCommand {
 	pub(crate) profile: Profile,
 }
 
-impl BuildParachainCommand {
-	/// Executes the command.
+impl BuildParachain {
+	/// Executes the build process.
 	pub(crate) fn execute(self) -> anyhow::Result<&'static str> {
 		self.build(&mut cli::Cli)
 	}
@@ -110,7 +110,7 @@ mod tests {
 				}
 
 				assert_eq!(
-					BuildParachainCommand {
+					BuildParachain {
 						path: project_path.clone(),
 						package: package.clone(),
 						profile: profile.clone(),

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 #[cfg(not(test))]
 use std::{thread::sleep, time::Duration};
 
-// Represents the configuration for building a parachain.
+// Configuration for building a parachain.
 pub struct BuildParachain {
 	/// Directory path for your project.
 	pub(crate) path: PathBuf,

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -89,10 +89,6 @@ impl Command {
 				None => build::Command::execute(args).map(|t| json!(t)),
 				Some(cmd) => match cmd {
 					#[cfg(feature = "parachain")]
-					build::Command::Parachain(cmd) => cmd.execute().map(|_| Value::Null),
-					#[cfg(feature = "contract")]
-					build::Command::Contract(cmd) => cmd.execute().map(|_| Value::Null),
-					#[cfg(feature = "parachain")]
 					build::Command::Spec(cmd) => cmd.execute().await.map(|_| Value::Null),
 				},
 			},

--- a/crates/pop-cli/src/commands/test/contract.rs
+++ b/crates/pop-cli/src/commands/test/contract.rs
@@ -8,16 +8,11 @@ use clap::Args;
 use cliclack::{clear_screen, log::warning, outro};
 use pop_contracts::{test_e2e_smart_contract, test_smart_contract};
 use std::path::PathBuf;
-#[cfg(not(test))]
-use {std::time::Duration, tokio::time::sleep};
 
 #[derive(Args)]
 pub(crate) struct TestContractCommand {
 	#[arg(short, long, help = "Path for the contract project [default: current directory]")]
 	path: Option<PathBuf>,
-	/// [DEPRECATED] Run e2e tests
-	#[arg(short, long, value_parser=["e2e-tests"])]
-	features: Option<String>,
 	/// Run end-to-end tests
 	#[arg(short, long)]
 	e2e: bool,
@@ -33,20 +28,8 @@ impl TestContractCommand {
 	pub(crate) async fn execute(mut self) -> anyhow::Result<&'static str> {
 		clear_screen()?;
 
-		let mut show_deprecated = false;
-		if self.features.is_some() && self.features.clone().unwrap().contains("e2e-tests") {
-			show_deprecated = true;
-			self.e2e = true;
-		}
-
 		if self.e2e {
 			Cli.intro("Starting end-to-end tests")?;
-
-			if show_deprecated {
-				warning("NOTE: --features e2e-tests is deprecated. Use --e2e instead.")?;
-				#[cfg(not(test))]
-				sleep(Duration::from_secs(3)).await;
-			}
 
 			self.node = match check_contracts_node_and_prompt(
 				&mut Cli,

--- a/crates/pop-contracts/Cargo.toml
+++ b/crates/pop-contracts/Cargo.toml
@@ -33,8 +33,8 @@ contract-build.workspace = true
 contract-extrinsics.workspace = true
 contract-transcode.workspace = true
 scale-info.workspace = true
-# pop
-pop-common = { path = "../pop-common", version = "0.5.0" }
+#  pop
+pop-common = { path = "../pop-common", version = "0.6.0" }
 
 [dev-dependencies]
 # Used in doc tests.

--- a/crates/pop-contracts/Cargo.toml
+++ b/crates/pop-contracts/Cargo.toml
@@ -33,7 +33,7 @@ contract-build.workspace = true
 contract-extrinsics.workspace = true
 contract-transcode.workspace = true
 scale-info.workspace = true
-#  pop
+# pop
 pop-common = { path = "../pop-common", version = "0.6.0" }
 
 [dev-dependencies]

--- a/crates/pop-parachains/Cargo.toml
+++ b/crates/pop-parachains/Cargo.toml
@@ -35,7 +35,7 @@ walkdir.workspace = true
 zombienet-sdk.workspace = true
 
 # Pop
-pop-common = { path = "../pop-common", version = "0.5.0" }
+pop-common = { path = "../pop-common", version = "0.6.0" }
 
 [dev-dependencies]
 # Used in doc tests.

--- a/crates/pop-parachains/src/new_parachain.rs
+++ b/crates/pop-parachains/src/new_parachain.rs
@@ -87,12 +87,7 @@ pub fn instantiate_openzeppelin_template(
 	let source = temp_dir.path();
 
 	let tag = Git::clone_and_degit(template.repository_url()?, source, tag_version)?;
-	let mut template_name = template.template_name_without_provider();
-	// Handle deprecated OpenZeppelin template
-	if matches!(template, Parachain::DeprecatedOpenZeppelinGeneric) {
-		template_name = Parachain::OpenZeppelinGeneric.template_name_without_provider();
-	}
-
+	let template_name = template.template_name_without_provider();
 	extract_template_files(template_name, temp_dir.path(), target, None)?;
 	Ok(tag)
 }

--- a/crates/pop-parachains/src/templates.rs
+++ b/crates/pop-parachains/src/templates.rs
@@ -177,23 +177,6 @@ pub enum Parachain {
 		)
 	)]
 	ParityFPT,
-	// OpenZeppelin
-	#[strum(
-		serialize = "polkadot-generic-runtime-template",
-		message = "Generic Runtime Template",
-		detailed_message = "A generic template for Substrate Runtime.",
-		props(
-			Provider = "OpenZeppelin",
-			Repository = "https://github.com/OpenZeppelin/polkadot-runtime-templates",
-			Network = "./zombienet-config/devnet.toml",
-			SupportedVersions = "v1.0.0,v2.0.1",
-			IsAudited = "true",
-			License = "GPL-3.0",
-			IsDeprecated = "true",
-			DeprecatedMessage = "This template is deprecated. Please use openzeppelin/generic-template in the future.",
-		)
-	)]
-	DeprecatedOpenZeppelinGeneric,
 	// templates for unit tests below
 	#[cfg(test)]
 	#[strum(
@@ -273,7 +256,6 @@ mod tests {
 			// openzeppelin
 			("openzeppelin/generic-template".to_string(), OpenZeppelinGeneric),
 			("openzeppelin/evm-template".to_string(), OpenZeppelinEVM),
-			("polkadot-generic-runtime-template".to_string(), DeprecatedOpenZeppelinGeneric),
 			("cpt".to_string(), ParityContracts),
 			("fpt".to_string(), ParityFPT),
 			("test_01".to_string(), TestTemplate01),
@@ -289,7 +271,6 @@ mod tests {
 			(EVM, "evm".to_string()),
 			(OpenZeppelinGeneric, "generic-template".to_string()),
 			(OpenZeppelinEVM, "evm-template".to_string()),
-			(DeprecatedOpenZeppelinGeneric, "polkadot-generic-runtime-template".to_string()),
 			(ParityContracts, "cpt".to_string()),
 			(ParityFPT, "fpt".to_string()),
 			(TestTemplate01, "test_01".to_string()),
@@ -331,7 +312,6 @@ mod tests {
 			(EVM, Some("./network.toml")),
 			(OpenZeppelinGeneric, Some("./zombienet-config/devnet.toml")),
 			(OpenZeppelinEVM, Some("./zombienet-config/devnet.toml")),
-			(DeprecatedOpenZeppelinGeneric, Some("./zombienet-config/devnet.toml")),
 			(ParityContracts, Some("./zombienet.toml")),
 			(ParityFPT, Some("./zombienet-config.toml")),
 			(TestTemplate01, Some("")),
@@ -348,7 +328,6 @@ mod tests {
 			(EVM, Some("Unlicense")),
 			(OpenZeppelinGeneric, Some("GPL-3.0")),
 			(OpenZeppelinEVM, Some("GPL-3.0")),
-			(DeprecatedOpenZeppelinGeneric, Some("GPL-3.0")),
 			(ParityContracts, Some("Unlicense")),
 			(ParityFPT, Some("Unlicense")),
 			(TestTemplate01, Some("Unlicense")),


### PR DESCRIPTION
- [X]  Update crate versions to 0.6.0.
- [X]  Update Changelog file. Run `git cliff --bump`, but fixed manually.
- [X]  Remove Deprecated flags or commands: 
          - Remove the subcommands `parachain` and `contract` in pop build.
          - Old feature to run e2e tests..
          - OpenZeppelin template name changed.
_Note: In this release, a new deprecated flag has been introduced. The release flag is being deprecated in favor of profile (see [source](https://github.com/r0gue-io/pop-cli/blob/main/crates/pop-cli/src/commands/build/spec.rs#L141))._
_Note 2: Parity templates will be addressed in https://github.com/r0gue-io/pop-cli/pull/297_