### PR TITLE
fix: check_contracts_node handles skip_confirm

### DIFF
--- a/crates/pop-cli/tests/contract.rs
+++ b/crates/pop-cli/tests/contract.rs
@@ -10,10 +10,7 @@ use pop_contracts::{
 use serde::{Deserialize, Serialize};
 use std::{path::Path, process::Command as Cmd, time::Duration};
 use strum::VariantArray;
-use subxt::{
-	client::OfflineClientT, config::DefaultExtrinsicParamsBuilder as Params, tx::Payload,
-	utils::to_hex,
-};
+use subxt::{config::DefaultExtrinsicParamsBuilder as Params, tx::Payload, utils::to_hex};
 use subxt_signer::sr25519::dev;
 use tokio::time::sleep;
 use url::Url;

--- a/crates/pop-cli/tests/contract.rs
+++ b/crates/pop-cli/tests/contract.rs
@@ -10,7 +10,10 @@ use pop_contracts::{
 use serde::{Deserialize, Serialize};
 use std::{path::Path, process::Command as Cmd, time::Duration};
 use strum::VariantArray;
-use subxt::{config::DefaultExtrinsicParamsBuilder as Params, tx::Payload, utils::to_hex};
+use subxt::{
+	client::OfflineClientT, config::DefaultExtrinsicParamsBuilder as Params, tx::Payload,
+	utils::to_hex,
+};
 use subxt_signer::sr25519::dev;
 use tokio::time::sleep;
 use url::Url;


### PR DESCRIPTION
There was a small bug where the `skip_confirm` was ignored.
Prompting the user to source `sustrate-contracts-node`.

I have added a very minimal test. It could be improved and made more robust if we were to expand `MockCli` to include checks for certain prompts not being presented in the CLI. But that is another story.

Thanks to @ltfschoen for reporting.

[sc-2094]