### PR TITLE
build(release): update upload-artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           tar -czf ${{ env.package }} pop pop.sha256
 
       - name: Upload binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries
           path: ${{ env.path }}/${{ env.package }}


### PR DESCRIPTION
As per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ `upload-artifact` action needs to be updated to use v4 instead.

Will test run our release workflow before asking for reviews.
