### PR TITLE
feat: deploy parachain

### DIFF
--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -55,9 +55,9 @@ fn about_build() -> &'static str {
 /// Help message for the up command.
 fn about_up() -> &'static str {
 	#[cfg(all(feature = "parachain", feature = "contract"))]
-	return "Deploy a smart contract or launch a local network.";
+	return "Deploy a parachain, deploy a smart contract or launch a local network.";
 	#[cfg(all(feature = "parachain", not(feature = "contract")))]
-	return "Launch a local network.";
+	return "Deploy a parachain or launch a local network.";
 	#[cfg(all(feature = "contract", not(feature = "parachain")))]
 	return "Deploy a smart contract.";
 }

--- a/crates/pop-cli/src/commands/up/mod.rs
+++ b/crates/pop-cli/src/commands/up/mod.rs
@@ -71,7 +71,13 @@ impl Command {
 			cmd.execute().await?;
 			return Ok("contract");
 		}
-		cli.warning("No contract detected. Ensure you are in a valid project directory.")?;
+		if pop_parachains::is_supported(project_path.as_deref())? {
+			cli.warning("Parachain deployment is currently not implemented.")?;
+			return Ok("parachain");
+		}
+		cli.warning(
+			"No contract or parachain detected. Ensure you are in a valid project directory.",
+		)?;
 		Ok("")
 	}
 }
@@ -83,6 +89,7 @@ mod tests {
 	use cli::MockCli;
 	use duct::cmd;
 	use pop_contracts::{mock_build_process, new_environment};
+	use pop_parachains::{instantiate_template_dir, Config, Parachain};
 	use std::env;
 	use url::Url;
 
@@ -122,14 +129,30 @@ mod tests {
 		assert_eq!(Command::execute_project_deployment(args.clone(), &mut cli).await?, "contract");
 		cli.verify()?;
 
+		// Parachain
+		let name = "parachain";
+		let project_path = temp_dir.path().join(name);
+		let config = Config {
+			symbol: "DOT".to_string(),
+			decimals: 18,
+			initial_endowment: "1000000".to_string(),
+		};
+		instantiate_template_dir(&Parachain::Standard, &project_path, None, config)?;
+
+		args.path = Some(project_path);
+		cli = MockCli::new().expect_warning("Parachain deployment is currently not implemented.");
+		assert_eq!(Command::execute_project_deployment(args.clone(), &mut cli).await?, "parachain");
+		cli.verify()?;
+
 		// Rust project
 		let name = "hello_world";
 		let path = temp_dir.path();
 		let project_path = path.join(name);
 		cmd("cargo", ["new", name, "--bin"]).dir(&path).run()?;
 		args.path = Some(project_path);
-		cli = MockCli::new()
-			.expect_warning("No contract detected. Ensure you are in a valid project directory.");
+		cli = MockCli::new().expect_warning(
+			"No contract or parachain detected. Ensure you are in a valid project directory.",
+		);
 		assert_eq!(Command::execute_project_deployment(args, &mut cli).await?, "");
 		cli.verify()
 	}


### PR DESCRIPTION
Add functionality to deploy a parachain:

- [ ] Parse event to retrieve ID when reserving paraID
- [ ] Logic in pop up to reserve paraId, generate specs and register parachain.
- [ ] Use a proxy to the logic above.
- [ ] Build deterministic release.