### PR TITLE
docs: `profile` comment in `build_parachain`

### DIFF
--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -17,7 +17,7 @@ use std::{
 /// * `path` - The optional path to the parachain manifest, defaulting to the current directory if
 ///   not specified.
 /// * `package` - The optional package to be built.
-/// * `release` - Whether the parachain should be built without any debugging functionality.
+/// * `profile` - Whether the parachain should be built without any debugging functionality.
 /// * `node_path` - An optional path to the node directory. Defaults to the `node` subdirectory of
 ///   the project path if not provided.
 pub fn build_parachain(


### PR DESCRIPTION
Minor fix for the parameter type of `build_parachain`