### PR TITLE
fix: increase `DefaultBodyLimit` to prevent large payload failures

### DIFF
--- a/crates/pop-cli/src/wallet_integration.rs
+++ b/crates/pop-cli/src/wallet_integration.rs
@@ -1,4 +1,5 @@
 use axum::{
+	extract::DefaultBodyLimit,
 	http::HeaderValue,
 	response::Html,
 	routing::{get, post},
@@ -116,7 +117,8 @@ impl WalletIntegrationManager {
 			.route("/error", post(routes::error_handler).with_state(state.clone()))
 			.route("/terminate", post(routes::terminate_handler).with_state(state.clone()))
 			.merge(frontend.serve_content()) // Custom route for serving frontend.
-			.layer(cors);
+			.layer(cors)
+			.layer(DefaultBodyLimit::max(15 * 1024 * 1024));
 
 		let url_owned = server_url.to_string();
 
@@ -545,6 +547,19 @@ mod tests {
 
 		assert_eq!(actual_payload.chain_rpc, expected_payload.chain_rpc);
 		assert_eq!(actual_payload.call_data, call_data_5mb);
+
+		let encoded_payload: String = call_data_5mb.iter().map(|b| format!("{:02x}", b)).collect();
+		let client = reqwest::Client::new();
+		let response = client
+			.post(&format!("{}/submit", addr))
+			.json(&encoded_payload)
+			.send()
+			.await
+			.expect("Failed to send large payload");
+
+		assert!(response.status().is_success());
+		let error = wim.take_error().await;
+		assert!(error.is_none());
 
 		wim.terminate().await.expect("Termination should not fail.");
 		assert!(wim.task_handle.await.is_ok());

--- a/crates/pop-cli/src/wallet_integration.rs
+++ b/crates/pop-cli/src/wallet_integration.rs
@@ -14,6 +14,8 @@ use tokio::{
 };
 use tower_http::{cors::Any, services::ServeDir};
 
+const MAX_PAYLOAD_SIZE: usize = 15 * 1024 * 1024;
+
 /// Make frontend sourcing more flexible by allowing a custom route to be defined.
 pub trait Frontend {
 	/// Serves the content via a [Router].
@@ -118,7 +120,7 @@ impl WalletIntegrationManager {
 			.route("/terminate", post(routes::terminate_handler).with_state(state.clone()))
 			.merge(frontend.serve_content()) // Custom route for serving frontend.
 			.layer(cors)
-			.layer(DefaultBodyLimit::max(15 * 1024 * 1024));
+			.layer(DefaultBodyLimit::max(MAX_PAYLOAD_SIZE));
 
 		let url_owned = server_url.to_string();
 
@@ -560,6 +562,20 @@ mod tests {
 		assert!(response.status().is_success());
 		let error = wim.take_error().await;
 		assert!(error.is_none());
+
+		let call_data_15mb = vec![99u8; MAX_PAYLOAD_SIZE + 1];
+		let encoded_oversized_payload: String =
+			call_data_15mb.iter().map(|b| format!("{:02x}", b)).collect();
+		let response = client
+			.post(&format!("{}/submit", addr))
+			.json(&encoded_oversized_payload)
+			.send()
+			.await;
+
+		assert!(
+			response.is_err() ||
+				response.unwrap().status() == reqwest::StatusCode::PAYLOAD_TOO_LARGE
+		);
 
 		wim.terminate().await.expect("Termination should not fail.");
 		assert!(wim.task_handle.await.is_ok());


### PR DESCRIPTION
When attempting to register a parachain using the wallet to sign the transaction, an error appeared in the frontend:
```
Error: Unable to submit. Is the server closed?
```
This was caused by the request body limit being too low, resulting in a `413 (Payload Too Large)` error.

This PR increases DefaultBodyLimit to handle larger payloads and adds a test to verify large transaction support. The 15MB limit is a bit arbitrary but ensures stability, providing enough room for 5MB transactions while accounting for potential encoding overhead.

Resource: https://stackoverflow.com/questions/75205271/rust-axum-multipart-length-limit-exceeded.