### PR TITLE
fix: prevent recursion error with `pallet_collective` metadata

### DIFF
--- a/crates/pop-parachains/src/call/metadata/params.rs
+++ b/crates/pop-parachains/src/call/metadata/params.rs
@@ -50,6 +50,7 @@ fn type_to_param(name: &str, registry: &PortableRegistry, type_id: u32) -> Resul
 	let type_info = registry
 		.resolve(type_id)
 		.ok_or_else(|| Error::MetadataParsingError(name.to_string()))?;
+	// Check for unsupported `RuntimeCall` type
 	if type_info.path.segments.contains(&"RuntimeCall".to_string()) {
 		return Err(Error::FunctionNotSupported);
 	}
@@ -235,13 +236,19 @@ mod tests {
 			field_to_param(&metadata, &function.fields.first().unwrap()),
 			Err(Error::FunctionNotSupported)
 		));
-		// TODO: Uncomment this test once the Pop Network mainnet (or the same runtime in testnet)
-		// is live. let function =
-		// 	metadata.pallet_by_name("Council").unwrap().call_variant_by_name("execute").unwrap();
-		// assert!(matches!(
-		// 	field_to_param(&metadata, &function.fields.first().unwrap()),
-		// 	Err(Error::FunctionNotSupported)
-		// ));
+		// TODO: Use the Pop Network endpoint once the mainnet (or an equivalent testnet with the
+		// same runtime) is available.
+		let client = set_up_client("wss://mythos.ibp.network").await?;
+		let metadata = client.metadata();
+		let function = metadata
+			.pallet_by_name("Council")
+			.unwrap()
+			.call_variant_by_name("execute")
+			.unwrap();
+		assert!(matches!(
+			field_to_param(&metadata, &function.fields.first().unwrap()),
+			Err(Error::FunctionNotSupported)
+		));
 
 		Ok(())
 	}

--- a/crates/pop-parachains/src/call/metadata/params.rs
+++ b/crates/pop-parachains/src/call/metadata/params.rs
@@ -50,6 +50,9 @@ fn type_to_param(name: &str, registry: &PortableRegistry, type_id: u32) -> Resul
 	let type_info = registry
 		.resolve(type_id)
 		.ok_or_else(|| Error::MetadataParsingError(name.to_string()))?;
+	if type_info.path.segments.contains(&"RuntimeCall".to_string()) {
+		return Err(Error::FunctionNotSupported);
+	}
 	for param in &type_info.type_params {
 		if param.name.contains("RuntimeCall") {
 			return Err(Error::FunctionNotSupported);
@@ -232,6 +235,13 @@ mod tests {
 			field_to_param(&metadata, &function.fields.first().unwrap()),
 			Err(Error::FunctionNotSupported)
 		));
+		// TODO: Uncomment this test once the Pop Network mainnet (or the same runtime in testnet)
+		// is live. let function =
+		// 	metadata.pallet_by_name("Council").unwrap().call_variant_by_name("execute").unwrap();
+		// assert!(matches!(
+		// 	field_to_param(&metadata, &function.fields.first().unwrap()),
+		// 	Err(Error::FunctionNotSupported)
+		// ));
 
 		Ok(())
 	}


### PR DESCRIPTION
**Context**
`pop-cli` does not support extrinsics that take another call as a parameter (e.g `Utility.batch`). Instead, when parsing the chain metadata, it returns a `FunctionNotSupported` error for such extrinsics and notifies the user that the function is not supported:
```
 Select the function to call:
│  ○ as_derivative 
│  ● batch (Function Not Supported)
```
**Bug**
A bug was discovered when testing the Pop Network mainnet runtime (https://github.com/r0gue-io/pop-node/pull/448), where metadata retrieval for the Council pallet (`pallet_collective`) caused a recursion error.

The problem is because `pallet_collective` defines type `Proposal = RuntimeCall;` ([see](https://github.com/r0gue-io/pop-node/pull/448/files#diff-8dc2dbcbfe8d024a27a29dea7e603e787a48da78d1194a1cf2914b8bd4f6c635R40)) rather than referencing `RuntimeCall` directly, as other pallets do ([see](https://github.com/r0gue-io/pop-node/pull/448/files#diff-8dc2dbcbfe8d024a27a29dea7e603e787a48da78d1194a1cf2914b8bd4f6c635R48)). 

_To Replicate:_ 
```
pop up parachain -f ./networks/mainnet.toml
pop call chain --url ws://localhost:9944/ 
```

It also can be tested in a live network (Mythos), that has a council governance. 
```
pop call chain --url wss://mythos.ibp.network
``` 

**Fix** 
A new check has been included when parsing metadata to properly identify `RuntimeCall` at any level within the namespace path.  Instead of assuming a direct reference, the system now inspects all segments of the path to detect and handle `RuntimeCall` correctly ([link from scale-info library](https://github.com/paritytech/scale-info/blob/2582cc3ef4c47e26e7bf6b23b424672ea86d33e8/src/ty/path.rs#L49)).

**Note**
I've created a unit test for this issue using a live chain with the same implementation as the Pop Network mainnet. A `TODO` comment is included to update the test once the Pop Network goes live.

[sc-2948]