### PR TITLE
feat: add the filter mode to cli

### DIFF
--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -640,18 +640,21 @@ mod tests {
 						true,
 						Some(chain_types()),
 						chain_type.clone() as usize,
+							None,
 					).expect_select(
 					"Choose the relay your chain will be connecting to: ",
 					Some(false),
 					true,
 					Some(relays()),
 					relay.clone() as usize,
+						None,
 				).expect_select(
 					"Choose the build profile of the binary that should be used: ",
 					Some(false),
 					true,
 					Some(profiles()),
-					profile.clone() as usize
+					profile.clone() as usize,
+					None,
 				).expect_confirm("Would you like to use local host as a bootnode ?", default_bootnode
 				).expect_confirm("Should the genesis state file be generated ?", genesis_state
 				).expect_confirm("Should the genesis code file be generated ?", genesis_code);
@@ -738,6 +741,7 @@ mod tests {
 							true,
 							Some(chain_types()),
 							chain_type.clone() as usize,
+							None,
 						);
 					}
 					if build_spec_cmd.relay.is_none() {
@@ -747,6 +751,7 @@ mod tests {
 							true,
 							Some(relays()),
 							relay.clone() as usize,
+							None,
 						);
 					}
 					if build_spec_cmd.profile.is_none() {
@@ -756,6 +761,7 @@ mod tests {
 							true,
 							Some(profiles()),
 							profile.clone() as usize,
+							None,
 						);
 					}
 					if !build_spec_cmd.default_bootnode {

--- a/crates/pop-cli/src/commands/call/chain.rs
+++ b/crates/pop-cli/src/commands/call/chain.rs
@@ -719,6 +719,7 @@ mod tests {
 				.to_vec(),
 			),
 			5, // "remark" dispatchable function
+				None,
 		)
 		.expect_input("The value for `remark` might be too large to enter. You may enter the path to a file instead.", "0x11".into())
 		.expect_confirm("Would you like to dispatch this function call with `Root` origin?", true)
@@ -768,6 +769,7 @@ mod tests {
 						.collect::<Vec<_>>(),
 				),
 				1, // "Purchase on-demand coretime" action
+				None,
 			)
 			.expect_input("Enter the value for the parameter: max_amount", "10000".into())
 			.expect_input("Enter the value for the parameter: para_id", "2000".into())
@@ -1026,6 +1028,7 @@ mod tests {
 					.collect::<Vec<_>>(),
 			),
 			2, // "Mint an Asset" action
+			None,
 		);
 		let action = prompt_predefined_actions(&pallets, &mut cli)?;
 		assert_eq!(action, Some(Action::MintAsset));
@@ -1056,6 +1059,7 @@ mod tests {
 					.to_vec(),
 				),
 				0, // "Id" action
+				None,
 			)
 			.expect_input(
 				"Enter the value for the parameter: Id",

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -725,6 +725,7 @@ mod tests {
 				true,
 				Some(items),
 				1, // "get" message
+				None
 			)
 			.expect_info(format!(
 			    "pop call contract --path {} --contract 15XausWjFLBBFLDXUSBRfSfZk25warm4wZRV4ZxhZbfvjrJm --message get --url wss://rpc1.paseo.popnetwork.xyz/ --suri //Alice",
@@ -788,6 +789,7 @@ mod tests {
 				true,
 				Some(items),
 				1, // "get" message
+				None
 			)
 			.expect_input(
 				"Where is your contract deployed?",
@@ -874,6 +876,7 @@ mod tests {
 				true,
 				Some(items),
 				2, // "specific_flip" message
+				None
 			)
 			.expect_input("Enter the value for the parameter: new_value", "true".into()) // Args for specific_flip
 			.expect_input("Enter the value for the parameter: number", "2".into()) // Args for specific_flip
@@ -953,6 +956,7 @@ mod tests {
 				true,
 				Some(items),
 				2, // "specific_flip" message
+				None
 			)
 			.expect_input(
 				"Where is your contract deployed?",

--- a/crates/pop-cli/src/commands/clean.rs
+++ b/crates/pop-cli/src/commands/clean.rs
@@ -217,6 +217,7 @@ mod tests {
 			Some(false),
 			true,
 			Some(items),
+			None,
 		);
 
 		CleanCacheCommand { cli: &mut cli, cache, all: false }.execute()?;
@@ -238,6 +239,7 @@ mod tests {
 				"Select the artifacts you wish to remove:",
 				Some(false),
 				false,
+				None,
 				None,
 			)
 			.expect_outro("ℹ️ No artifacts removed");
@@ -263,6 +265,7 @@ mod tests {
 				"Select the artifacts you wish to remove:",
 				None,
 				true,
+				None,
 				None,
 			)
 			.expect_confirm("Are you sure you want to remove the selected artifact?", false)
@@ -353,6 +356,7 @@ mod tests {
 				"Select the artifacts you wish to remove:",
 				None,
 				true,
+				None,
 				None,
 			)
 			.expect_confirm("Are you sure you want to remove the 3 selected artifacts?", true)


### PR DESCRIPTION
Add the new method `filter_mode()` to the `Cli` struct that enables the filter mode to the `Select` and `MultiSelect`. We need this feature for the #420 

The implementation PR of the [filter mode in cliclack](https://github.com/fadeevab/cliclack/pull/52) that includes images of how the feature looks like. 
