### PR TITLE
fix: hardcoded test failing in the CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.4"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -5259,15 +5259,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8664,9 +8664,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-configuration"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a7fa0c305764c1dd4d89a007b3438ee0871da3e95d077ec008c9b78d4ed95a"
+checksum = "7941f65dadce0e0d0e55e86ae5e6d04bcc9798544fb47c7dd6f1023339c04dba"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -8685,9 +8685,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-orchestrator"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4438f69612a0ee7d9e1a50a45b36351558610e5401ae08e42c37d17bdd8763d"
+checksum = "8ccf76e4952f3611822c3a2c6e06a8ec80c8d1b29608001be6955645272d35df"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8718,9 +8718,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-prom-metrics-parser"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138a202c7c782f26b1c68de1e5908a8a480930b5da9d6f5b7eb3d19a80672b99"
+checksum = "83fe68ac63e9a5e519da0545e0ca2e074ab5fe8229b86e2a43f639a13c2b58fb"
 dependencies = [
  "pest",
  "pest_derive",
@@ -8729,9 +8729,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-provider"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1199a9114d8b1412c2675adae92dd3b35604ee1f859ece02c1eb0e2c10daa0c2"
+checksum = "aac2749ed001ab31041e8bdd0f06c067e853ab56c2e0358c5df3496f1e033012"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8760,9 +8760,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-sdk"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82587f5171f37758a16f6d58720f18239a6c9021ec3322d50ea2f25ceaf2405c"
+checksum = "ae5fdf40b7d3d51b1b64e8a592b7a2fd01baf82ebf7182e7fb35b5686b526493"
 dependencies = [
  "async-trait",
  "futures",
@@ -8778,9 +8778,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-support"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad986c81eee3c982e63ba54977c265bad9e37ae79ecd93205f3a02078dcf0734"
+checksum = "131c64f2e3e45c8ff96eeabf1909c35031473b3426f541f1c9c286931ed44b93"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ toml_edit = { version = "0.22", features = ["serde"] }
 symlink = "0.1"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
-zombienet-sdk = "0.2.25"
+zombienet-sdk = "0.2.26"
 git2_credentials = "0.13.0"
 
 # pop-cli

--- a/crates/pop-parachains/src/build.rs
+++ b/crates/pop-parachains/src/build.rs
@@ -515,7 +515,6 @@ mod tests {
 		assert!(raw_chain_spec.exists());
 		let content = fs::read_to_string(raw_chain_spec.clone()).expect("Could not read file");
 		assert!(content.contains("\"para_id\": 2001"));
-		assert!(content.contains("\"id\": \"pop-devnet\""));
 		assert!(content.contains("\"bootNodes\": []"));
 		// Test export wasm file
 		let wasm_file = export_wasm_file(&binary_path, &raw_chain_spec, "para-2001-wasm")?;

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,7 @@ ignore = [
     { id = "RUSTSEC-2024-0384", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/437" },
     { id = "RUSTSEC-2020-0163", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/438" },
     { id = "RUSTSEC-2024-0436", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/450" },
+    { id = "RUSTSEC-2025-0012", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/451" }
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,7 @@ ignore = [
     { id = "RUSTSEC-2024-0388", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/436" },
     { id = "RUSTSEC-2024-0384", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/437" },
     { id = "RUSTSEC-2020-0163", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/438" },
+    { id = "RUSTSEC-2024-0436", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/450" },
 ]
 
 [licenses]


### PR DESCRIPTION
After the updates in the `pop-node` release, one test was failing in the CI (https://github.com/r0gue-io/pop-cli/actions/runs/13666853327/job/38359250240?pr=435) due to a hardcoded value for the node name, `pop-devnet` which is no longer applicable in the new release. The hardcoded value has been removed. 

Additionally, this update fixes cargo deny in the CI by bumping dependency versions. It was automatic done by the [dependabot](https://github.com/apps/dependabot) https://github.com/r0gue-io/pop-cli/pull/447. But deny was still failing so had to add a vulnerability in the `deny.toml`.

The PR introduces two new vulnerability dependency: 
- #451 
- #450 