### PR TITLE
chore: improve deterministic runtime flow

### DIFF
--- a/crates/pop-parachains/src/build/runtime.rs
+++ b/crates/pop-parachains/src/build/runtime.rs
@@ -77,7 +77,7 @@ impl Builder {
 	/// Executes the runtime build process and returns the path of the generated file.
 	pub fn build(&self) -> Result<PathBuf, Error> {
 		let command = self.build_command();
-		cmd("sh", vec!["-c", &command]).stderr_null().run()?;
+		cmd("sh", vec!["-c", &command]).stdout_null().stderr_null().run()?;
 		let wasm_path = self.get_output_path();
 		Ok(wasm_path)
 	}


### PR DESCRIPTION
This PR improves the process of building a deterministic runtime with two minor improvements:
- Includes the file path of the generated deterministic runtime in the list of generated files for better visibility.
<img width="1078" alt="Captura de pantalla 2025-03-12 a las 21 19 31" src="https://github.com/user-attachments/assets/0ea9561c-8b56-42d0-9c52-95229f3cc2d6" />


- Suppresses `srtool` logs, displaying only pop logs for cleaner output.
<img width="562" alt="Captura de pantalla 2025-03-12 a las 21 15 25" src="https://github.com/user-attachments/assets/6a6dbb91-40d4-497f-b348-996895074b54" />
