### PR TITLE
fix: display events when wallet signing

### DIFF
--- a/crates/pop-cli/src/common/wallet.rs
+++ b/crates/pop-cli/src/common/wallet.rs
@@ -7,7 +7,10 @@ use crate::{
 use anyhow::{anyhow, Result};
 use cliclack::{log, spinner};
 #[cfg(feature = "parachain")]
-use pop_parachains::{submit_signed_extrinsic, ExtrinsicEvents, OnlineClient, SubstrateConfig};
+use pop_parachains::{
+	parse_and_format_events, submit_signed_extrinsic, ExtrinsicEvents, OnlineClient,
+	SubstrateConfig,
+};
 use url::Url;
 
 /// The prompt to ask the user if they want to use the wallet for signing.
@@ -88,6 +91,11 @@ pub(crate) async fn submit_extrinsic(
 		.await
 		.map_err(anyhow::Error::from)?;
 
-	spinner.stop(format!("Extrinsic submitted with hash: {:?}", result.extrinsic_hash()));
+	let events = parse_and_format_events(client, url, &result).await?;
+	spinner.stop(format!(
+		"Extrinsic submitted with hash: {:?}\n{}",
+		result.extrinsic_hash(),
+		events
+	));
 	Ok(result)
 }

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -28,7 +28,8 @@ pub use call::{
 		params::Param,
 		parse_chain_metadata, Function, Pallet,
 	},
-	set_up_client, sign_and_submit_extrinsic, submit_signed_extrinsic, CallData,
+	parse_and_format_events, set_up_client, sign_and_submit_extrinsic, submit_signed_extrinsic,
+	CallData,
 };
 pub use errors::Error;
 pub use indexmap::IndexSet;


### PR DESCRIPTION
In `pop call chain`, when signing an extrinsic using `--suri`, we displayed the list of extrinsics. However, when done via `--use-wallet`, the events were not shown. This PR fixes that by reusing the same logic from `sign_and_submit_extrinsic` in `wallet::submit_extrinsic`. The only change in the code is to ensure consistency in event display.

**Output**
```
⚙  pop call chain --pallet Registrar --function reserve --url ws://127.0.0.1:54778/ --use-wallet
│  
⚙  Encoded call data: 0x4605
│  
◇  Wallet signing portal started at http://127.0.0.1:9090.
│  
◆  Signed payload received.
│  
◇  Extrinsic submitted with hash: 0x068609ed0132ae17289a3e7aa1411367b9c639e19cbee1185e4ddbbff0b3b5d4
      Events
       Event Balances ➜ Withdraw
         who: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
         amount: 13.8547607mUNIT
       Event Balances ➜ Reserved
         who: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
         amount: 100UNIT
       Event Registrar ➜ Reserved
         para_id: Id(2001)
         who: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
       Event Balances ➜ Deposit
         who: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
         amount: 0UNIT
       Event Balances ➜ Deposit
         who: 5EYCAe5ijiYfyeZ2JJCGq56LmPyNRAKzpG4QkoQkkQNB5e6Z
         amount: 11.0838085mUNIT
       Event Balances ➜ Deposit
         who: 5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY
         amount: 2.7709522mUNIT
       Event TransactionPayment ➜ TransactionFeePaid
         who: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
         actual_fee: 13.8547607mUNIT
         tip: 0UNIT
       Event System ➜ ExtrinsicSuccess
         dispatch_info: DispatchInfo { weight: Weight { ref_time: 385674000, proof_size: 3562 }, class: Normal, pays_fee: Yes }
```

**How to test**
Run 
```
pop up network -f ./tests/networks/paseo.toml
```
And run a pop call to this local chain, to for example reserve a `para_id` (Any extrinsic):
```
pop call chain --pallet Registrar --function reserve --url ws://127.0.0.1:54778/ --use-wallet
```