### PR TITLE
feat: enable `pop test` without project type specification

### DIFF
--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -33,7 +33,7 @@ pub(crate) enum Command {
 	#[clap(alias = "u", about = about_up())]
 	#[cfg(any(feature = "parachain", feature = "contract"))]
 	Up(up::UpArgs),
-	/// Test a project.
+	/// Test a Rust project.
 	#[clap(alias = "t")]
 	#[cfg(any(feature = "parachain", feature = "contract"))]
 	Test(test::TestArgs),
@@ -132,10 +132,7 @@ impl Command {
 				None => test::Command::execute(args).await.map(|t| json!(t)),
 				Some(cmd) => match cmd {
 					#[cfg(feature = "contract")]
-					test::Command::Contract(cmd) => match cmd.execute(&mut Cli).await {
-						Ok(feature) => Ok(json!(feature)),
-						Err(e) => Err(e),
-					},
+					test::Command::Contract(cmd) => cmd.execute(&mut Cli).await.map(|t| json!(t)),
 				},
 			},
 			Self::Clean(args) => match args.command {

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -132,7 +132,7 @@ impl Command {
 				None => test::Command::execute(args).await.map(|t| json!(t)),
 				Some(cmd) => match cmd {
 					#[cfg(feature = "contract")]
-					test::Command::Contract(cmd) => match cmd.execute().await {
+					test::Command::Contract(cmd) => match cmd.execute(&mut Cli).await {
 						Ok(feature) => Ok(json!(feature)),
 						Err(e) => Err(e),
 					},

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -33,9 +33,9 @@ pub(crate) enum Command {
 	#[clap(alias = "u", about = about_up())]
 	#[cfg(any(feature = "parachain", feature = "contract"))]
 	Up(up::UpArgs),
-	/// Test a smart contract.
+	/// Test a project.
 	#[clap(alias = "t")]
-	#[cfg(feature = "contract")]
+	#[cfg(any(feature = "parachain", feature = "contract"))]
 	Test(test::TestArgs),
 	/// Remove generated/cached artifacts.
 	#[clap(alias = "C")]
@@ -128,11 +128,14 @@ impl Command {
 					},
 				},
 			},
-			#[cfg(feature = "contract")]
 			Self::Test(args) => match args.command {
-				test::Command::Contract(cmd) => match cmd.execute().await {
-					Ok(feature) => Ok(json!(feature)),
-					Err(e) => Err(e),
+				None => test::Command::execute(args).await.map(|t| json!(t)),
+				Some(cmd) => match cmd {
+					#[cfg(feature = "contract")]
+					test::Command::Contract(cmd) => match cmd.execute().await {
+						Ok(feature) => Ok(json!(feature)),
+						Err(e) => Err(e),
+					},
 				},
 			},
 			Self::Clean(args) => match args.command {

--- a/crates/pop-cli/src/commands/test/contract.rs
+++ b/crates/pop-cli/src/commands/test/contract.rs
@@ -1,18 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::{
-	cli::{traits::Cli as _, Cli},
-	common::contracts::check_contracts_node_and_prompt,
-};
+use crate::{cli, common::contracts::check_contracts_node_and_prompt};
 use clap::Args;
-use cliclack::{clear_screen, log::warning, outro};
 use pop_common::test_project;
 use pop_contracts::test_e2e_smart_contract;
 use std::path::PathBuf;
 
 const HELP_HEADER: &str = "Smart contract testing options";
 
-#[derive(Args)]
+#[derive(Args, Default)]
 #[clap(next_help_heading = HELP_HEADER)]
 pub(crate) struct TestContractCommand {
 	#[clap(skip)]
@@ -29,14 +25,15 @@ pub(crate) struct TestContractCommand {
 
 impl TestContractCommand {
 	/// Executes the command.
-	pub(crate) async fn execute(mut self) -> anyhow::Result<&'static str> {
-		clear_screen()?;
-
+	pub(crate) async fn execute(
+		mut self,
+		cli: &mut impl cli::traits::Cli,
+	) -> anyhow::Result<&'static str> {
 		if self.e2e {
-			Cli.intro("Starting end-to-end tests")?;
+			cli.intro("Starting end-to-end tests")?;
 
 			self.node = match check_contracts_node_and_prompt(
-				&mut Cli,
+				cli,
 				&crate::cache()?,
 				self.skip_confirm,
 			)
@@ -44,18 +41,18 @@ impl TestContractCommand {
 			{
 				Ok(binary_path) => Some(binary_path),
 				Err(_) => {
-					warning("🚫 substrate-contracts-node is necessary to run e2e tests. Will try to run tests anyway...")?;
+					cli.warning("🚫 substrate-contracts-node is necessary to run e2e tests. Will try to run tests anyway...")?;
 					Some(PathBuf::new())
 				},
 			};
 
 			test_e2e_smart_contract(self.path.as_deref(), self.node.as_deref())?;
-			outro("End-to-end testing complete")?;
+			cli.outro("End-to-end testing complete")?;
 			Ok("e2e")
 		} else {
-			Cli.intro("Starting unit tests")?;
+			cli.intro("Starting unit tests")?;
 			test_project(self.path.as_deref())?;
-			outro("Unit testing complete")?;
+			cli.outro("Unit testing complete")?;
 			Ok("unit")
 		}
 	}

--- a/crates/pop-cli/src/commands/test/contract.rs
+++ b/crates/pop-cli/src/commands/test/contract.rs
@@ -6,13 +6,17 @@ use crate::{
 };
 use clap::Args;
 use cliclack::{clear_screen, log::warning, outro};
-use pop_contracts::{test_e2e_smart_contract, test_smart_contract};
+use pop_common::test_project;
+use pop_contracts::test_e2e_smart_contract;
 use std::path::PathBuf;
 
+const HELP_HEADER: &str = "Smart contract testing options";
+
 #[derive(Args)]
+#[clap(next_help_heading = HELP_HEADER)]
 pub(crate) struct TestContractCommand {
-	#[arg(short, long, help = "Path for the contract project [default: current directory]")]
-	path: Option<PathBuf>,
+	#[clap(skip)]
+	pub(crate) path: Option<PathBuf>,
 	/// Run end-to-end tests
 	#[arg(short, long)]
 	e2e: bool,
@@ -50,7 +54,7 @@ impl TestContractCommand {
 			Ok("e2e")
 		} else {
 			Cli.intro("Starting unit tests")?;
-			test_smart_contract(self.path.as_deref())?;
+			test_project(self.path.as_deref())?;
 			outro("Unit testing complete")?;
 			Ok("unit")
 		}

--- a/crates/pop-cli/src/commands/test/mod.rs
+++ b/crates/pop-cli/src/commands/test/mod.rs
@@ -1,23 +1,21 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use std::path::PathBuf;
-
+use crate::{cli, common::builds::get_project_path};
 use clap::{Args, Subcommand};
 use pop_common::test_project;
-
-use crate::common::builds::get_project_path;
+use std::path::PathBuf;
 
 #[cfg(feature = "contract")]
 pub mod contract;
 
 /// Arguments for testing.
-#[derive(Args)]
+#[derive(Args, Default)]
 #[command(args_conflicts_with_subcommands = true)]
 pub(crate) struct TestArgs {
 	#[command(subcommand)]
 	pub command: Option<Command>,
 	/// Directory path for your project [default: current directory]
-	#[arg(short, long)]
+	#[arg(short, long, global = true)]
 	pub(crate) path: Option<PathBuf>,
 	/// Directory path without flag for your project [default: current directory]
 	#[arg(value_name = "PATH", index = 1, global = true, conflicts_with = "path")]
@@ -37,15 +35,64 @@ pub(crate) enum Command {
 }
 impl Command {
 	pub(crate) async fn execute(args: TestArgs) -> anyhow::Result<&'static str> {
+		Self::test(args, &mut cli::Cli).await
+	}
+
+	async fn test(args: TestArgs, cli: &mut impl cli::traits::Cli) -> anyhow::Result<&'static str> {
 		let project_path = get_project_path(args.path.clone(), args.path_pos.clone());
 
 		#[cfg(feature = "contract")]
 		if pop_contracts::is_supported(project_path.as_deref())? {
 			let mut cmd = args.contract;
 			cmd.path = project_path;
-			return contract::TestContractCommand::execute(cmd).await;
+			return contract::TestContractCommand::execute(cmd, cli).await;
 		}
 		test_project(project_path.as_deref())?;
 		Ok("test")
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::cli::MockCli;
+	use duct::cmd;
+	use pop_contracts::{mock_build_process, new_environment};
+	use std::env;
+
+	fn create_test_args(project_path: PathBuf) -> anyhow::Result<TestArgs> {
+		Ok(TestArgs { path: Some(project_path), ..Default::default() })
+	}
+
+	#[tokio::test]
+	async fn detects_contract_correctly() -> anyhow::Result<()> {
+		let temp_dir = new_environment("testing")?;
+		let mut current_dir = env::current_dir().expect("Failed to get current directory");
+		current_dir.pop();
+		mock_build_process(
+			temp_dir.path().join("testing"),
+			current_dir.join("pop-contracts/tests/files/testing.contract"),
+			current_dir.join("pop-contracts/tests/files/testing.json"),
+		)?;
+		let args = create_test_args(temp_dir.path().join("testing"))?;
+		let mut cli = MockCli::new()
+			.expect_intro("Starting unit tests")
+			.expect_outro("Unit testing complete");
+		assert_eq!(Command::test(args, &mut cli).await?, "unit");
+		cli.verify()
+	}
+
+	#[tokio::test]
+	async fn detects_rust_project_correctly() -> anyhow::Result<()> {
+		let temp_dir = tempfile::tempdir()?;
+		let name = "hello_world";
+		let path = temp_dir.path();
+		let project_path = path.join(name);
+		let args = create_test_args(project_path)?;
+
+		cmd("cargo", ["new", name, "--bin"]).dir(&path).run()?;
+		let mut cli = MockCli::new();
+		assert_eq!(Command::test(args, &mut cli).await?, "test");
+		cli.verify()
 	}
 }

--- a/crates/pop-cli/src/commands/test/mod.rs
+++ b/crates/pop-cli/src/commands/test/mod.rs
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0
 
+use std::path::PathBuf;
+
 use clap::{Args, Subcommand};
+use pop_common::test_project;
+
+use crate::common::builds::get_project_path;
 
 #[cfg(feature = "contract")]
 pub mod contract;
@@ -10,14 +15,37 @@ pub mod contract;
 #[command(args_conflicts_with_subcommands = true)]
 pub(crate) struct TestArgs {
 	#[command(subcommand)]
-	pub command: Command,
+	pub command: Option<Command>,
+	/// Directory path for your project [default: current directory]
+	#[arg(short, long)]
+	pub(crate) path: Option<PathBuf>,
+	/// Directory path without flag for your project [default: current directory]
+	#[arg(value_name = "PATH", index = 1, global = true, conflicts_with = "path")]
+	pub(crate) path_pos: Option<PathBuf>,
+	#[command(flatten)]
+	#[cfg(feature = "contract")]
+	pub(crate) contract: contract::TestContractCommand,
 }
 
-/// Test a smart contract.
+/// Test a project.
 #[derive(Subcommand)]
 pub(crate) enum Command {
-	/// Test a smart contract
+	/// [DEPRECATED] Test a smart contract (will be removed in v0.8.0).
 	#[cfg(feature = "contract")]
 	#[clap(alias = "c")]
 	Contract(contract::TestContractCommand),
+}
+impl Command {
+	pub(crate) async fn execute(args: TestArgs) -> anyhow::Result<&'static str> {
+		let project_path = get_project_path(args.path.clone(), args.path_pos.clone());
+
+		#[cfg(feature = "contract")]
+		if pop_contracts::is_supported(project_path.as_deref())? {
+			let mut cmd = args.contract;
+			cmd.path = project_path;
+			return contract::TestContractCommand::execute(cmd).await;
+		}
+		test_project(project_path.as_deref())?;
+		Ok("test")
+	}
 }

--- a/crates/pop-cli/src/commands/test/mod.rs
+++ b/crates/pop-cli/src/commands/test/mod.rs
@@ -13,7 +13,7 @@ pub mod contract;
 #[command(args_conflicts_with_subcommands = true)]
 pub(crate) struct TestArgs {
 	#[command(subcommand)]
-	pub command: Option<Command>,
+	pub(crate) command: Option<Command>,
 	/// Directory path for your project [default: current directory]
 	#[arg(short, long, global = true)]
 	pub(crate) path: Option<PathBuf>,
@@ -25,7 +25,7 @@ pub(crate) struct TestArgs {
 	pub(crate) contract: contract::TestContractCommand,
 }
 
-/// Test a project.
+/// Test a Rust project.
 #[derive(Subcommand)]
 pub(crate) enum Command {
 	/// [DEPRECATED] Test a smart contract (will be removed in v0.8.0).

--- a/crates/pop-common/src/errors.rs
+++ b/crates/pop-common/src/errors.rs
@@ -29,9 +29,9 @@ pub enum Error {
 	ParseSecretURI(String),
 	#[error("SourceError error: {0}")]
 	SourceError(#[from] sourcing::Error),
-	/// An error occurred while executing a test command.
 	#[error("TemplateError error: {0}")]
 	TemplateError(#[from] templates::Error),
+	/// An error occurred while executing a test command.
 	#[error("Failed to execute test command: {0}")]
 	TestCommand(String),
 	#[error("Unsupported command: {0}")]

--- a/crates/pop-common/src/errors.rs
+++ b/crates/pop-common/src/errors.rs
@@ -29,8 +29,11 @@ pub enum Error {
 	ParseSecretURI(String),
 	#[error("SourceError error: {0}")]
 	SourceError(#[from] sourcing::Error),
+	/// An error occurred while executing a test command.
 	#[error("TemplateError error: {0}")]
 	TemplateError(#[from] templates::Error),
+	#[error("Failed to execute test command: {0}")]
+	TestCommand(String),
 	#[error("Unsupported command: {0}")]
 	UnsupportedCommand(String),
 	#[error("Unsupported platform: {arch} {os}")]

--- a/crates/pop-common/src/lib.rs
+++ b/crates/pop-common/src/lib.rs
@@ -13,6 +13,7 @@ pub use sourcing::set_executable_permission;
 pub use subxt::{Config, PolkadotConfig as DefaultConfig};
 pub use subxt_signer::sr25519::Keypair;
 pub use templates::extractor::extract_template_files;
+pub use test::test_project;
 
 pub mod build;
 pub mod errors;
@@ -26,6 +27,8 @@ pub mod polkadot_sdk;
 pub mod signer;
 pub mod sourcing;
 pub mod templates;
+/// Module for testing utilities and functionality.
+pub mod test;
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 

--- a/crates/pop-common/src/lib.rs
+++ b/crates/pop-common/src/lib.rs
@@ -95,7 +95,7 @@ pub mod call {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
 	use super::*;
 	use anyhow::Result;
 

--- a/crates/pop-common/src/test.rs
+++ b/crates/pop-common/src/test.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0
+
+use crate::errors::Error;
+use duct::cmd;
+use std::path::Path;
+
+/// Run tests of a rust project.
+///
+/// # Arguments
+///
+/// * `path` - location of the smart contract.
+pub fn test_project(path: Option<&Path>) -> Result<(), Error> {
+	// Execute `cargo test` command in the specified directory.
+	cmd("cargo", vec!["test"])
+		.dir(path.unwrap_or_else(|| Path::new("./")))
+		.run()
+		.map_err(|e| Error::TestCommand(format!("Cargo test command failed: {}", e)))?;
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use tempfile;
+
+	#[test]
+	fn test_project_works() -> Result<(), Error> {
+		let temp_dir = tempfile::tempdir()?;
+		cmd("cargo", ["new", "test_contract", "--bin"]).dir(temp_dir.path()).run()?;
+		// Run unit tests for the temporary project directory.
+		test_project(Some(&temp_dir.path().join("test_contract")))?;
+		Ok(())
+	}
+
+	#[test]
+	fn test_project_wrong_directory() -> Result<(), Error> {
+		let temp_dir = tempfile::tempdir()?;
+		assert!(matches!(
+			test_project(Some(&temp_dir.path().join(""))),
+			Err(Error::TestCommand(..))
+		));
+		Ok(())
+	}
+}

--- a/crates/pop-common/src/test.rs
+++ b/crates/pop-common/src/test.rs
@@ -4,11 +4,11 @@ use crate::errors::Error;
 use duct::cmd;
 use std::path::Path;
 
-/// Run tests of a rust project.
+/// Run tests of a Rust project.
 ///
 /// # Arguments
 ///
-/// * `path` - location of the smart contract.
+/// * `path` - location of the project.
 pub fn test_project(path: Option<&Path>) -> Result<(), Error> {
 	// Execute `cargo test` command in the specified directory.
 	cmd("cargo", vec!["test"])
@@ -27,7 +27,6 @@ mod tests {
 	fn test_project_works() -> Result<(), Error> {
 		let temp_dir = tempfile::tempdir()?;
 		cmd("cargo", ["new", "test_contract", "--bin"]).dir(temp_dir.path()).run()?;
-		// Run unit tests for the temporary project directory.
 		test_project(Some(&temp_dir.path().join("test_contract")))?;
 		Ok(())
 	}

--- a/crates/pop-contracts/README.md
+++ b/crates/pop-contracts/README.md
@@ -26,14 +26,15 @@ let result = build_smart_contract(Some(&contract_path), build_release, Verbosity
 
 Test an existing Smart Contract:
 ```rust,no_run
-use pop_contracts::{test_e2e_smart_contract, test_smart_contract};
+use pop_common::test_project;
+use pop_contracts::test_e2e_smart_contract;
 use std::path::Path;
 
 let contract_path = Path::new("./");
 let contracts_node_path = Path::new("./path-to-contracts-node-binary");
 
 //unit testing
-test_smart_contract(Some(contract_path));
+test_project(Some(contract_path));
 //e2e testing
 test_e2e_smart_contract(Some(contract_path), Some(contracts_node_path));
 ```

--- a/crates/pop-contracts/src/lib.rs
+++ b/crates/pop-contracts/src/lib.rs
@@ -20,7 +20,7 @@ pub use call::{
 pub use new::{create_smart_contract, is_valid_contract_name};
 pub use node::{contracts_node_generator, is_chain_alive, run_contracts_node};
 pub use templates::{Contract, ContractType};
-pub use test::{test_e2e_smart_contract, test_smart_contract};
+pub use test::test_e2e_smart_contract;
 pub use testing::{mock_build_process, new_environment};
 pub use up::{
 	dry_run_gas_estimate_instantiate, dry_run_upload, get_code_hash_from_event, get_contract_code,

--- a/crates/pop-contracts/src/test.rs
+++ b/crates/pop-contracts/src/test.rs
@@ -4,20 +4,6 @@ use crate::errors::Error;
 use duct::cmd;
 use std::{env, path::Path};
 
-/// Run unit tests of a smart contract.
-///
-/// # Arguments
-///
-/// * `path` - location of the smart contract.
-pub fn test_smart_contract(path: Option<&Path>) -> Result<(), Error> {
-	// Execute `cargo test` command in the specified directory.
-	cmd("cargo", vec!["test"])
-		.dir(path.unwrap_or_else(|| Path::new("./")))
-		.run()
-		.map_err(|e| Error::TestCommand(format!("Cargo test command failed: {}", e)))?;
-	Ok(())
-}
-
 /// Run e2e tests of a smart contract.
 ///
 /// # Arguments
@@ -41,25 +27,6 @@ pub fn test_e2e_smart_contract(path: Option<&Path>, node: Option<&Path>) -> Resu
 mod tests {
 	use super::*;
 	use tempfile;
-
-	#[test]
-	fn test_smart_contract_works() -> Result<(), Error> {
-		let temp_dir = tempfile::tempdir()?;
-		cmd("cargo", ["new", "test_contract", "--bin"]).dir(temp_dir.path()).run()?;
-		// Run unit tests for the smart contract in the temporary contract directory.
-		test_smart_contract(Some(&temp_dir.path().join("test_contract")))?;
-		Ok(())
-	}
-
-	#[test]
-	fn test_smart_contract_wrong_directory() -> Result<(), Error> {
-		let temp_dir = tempfile::tempdir()?;
-		assert!(matches!(
-			test_smart_contract(Some(&temp_dir.path().join(""))),
-			Err(Error::TestCommand(..))
-		));
-		Ok(())
-	}
 
 	#[test]
 	fn test_e2e_smart_contract_set_env_variable() -> Result<(), Error> {


### PR DESCRIPTION
Enables `pop test` command to run without specifying contract or chain, automatically detecting the project type. 
Previously, pop test was limited to pop test contract; now, it runs tests for all Rust projects, including chains.

**Changes**
- `test_smart_contract`(which basically wrapped `cargo test`) has been renamed to `test_project` and moved from `pop_contracts` to `pop_common` crate for broader use.
- Handles the deprecation of `pop test contract` to simple run `pop test` in your project, keeping `pop test contract`  functional for now but marking them for future removal. Following the same deprecation approach as `pop build` https://github.com/r0gue-io/pop-cli/pull/222 and `pop up` https://github.com/r0gue-io/pop-cli/pull/403 recent refactors ).
- Improved Coverage: Minor changes to have unit tests in the `pop-cli` test module.

**How to test**
```
# In a contract project
pop test
pop test contract
# In a parachain project
pop test
``` 

[sc-2512]