### PR TITLE
feat: overwrite executed command in weight files

### DIFF
--- a/crates/pop-cli/src/commands/bench/block.rs
+++ b/crates/pop-cli/src/commands/bench/block.rs
@@ -48,7 +48,7 @@ impl BenchmarkBlock {
 
 		cli.warning("NOTE: this may take some time...")?;
 
-		let result = generate_binary_benchmarks(&binary_path, "block");
+		let result = generate_binary_benchmarks(&binary_path, "block", |args| args);
 
 		// Display the benchmarking command.
 		cliclack::log::remark("\n")?;

--- a/crates/pop-cli/src/commands/bench/block.rs
+++ b/crates/pop-cli/src/commands/bench/block.rs
@@ -8,7 +8,7 @@ use crate::{
 use clap::Args;
 use frame_benchmarking_cli::BlockCmd;
 use pop_common::Profile;
-use pop_parachains::generate_binary_benchmarks;
+use pop_parachains::{generate_binary_benchmarks, BenchmarkingCliCommand};
 use std::{
 	env::current_dir,
 	path::{Path, PathBuf},
@@ -48,7 +48,8 @@ impl BenchmarkBlock {
 
 		cli.warning("NOTE: this may take some time...")?;
 
-		let result = generate_binary_benchmarks(&binary_path, "block", |args| args);
+		let result =
+			generate_binary_benchmarks(&binary_path, BenchmarkingCliCommand::Block, |args| args);
 
 		// Display the benchmarking command.
 		cliclack::log::remark("\n")?;

--- a/crates/pop-cli/src/commands/bench/machine.rs
+++ b/crates/pop-cli/src/commands/bench/machine.rs
@@ -49,7 +49,7 @@ impl BenchmarkMachine {
 		cli.warning("NOTE: this may take some time...")?;
 		cli.info("Benchmarking your hardware performance...")?;
 
-		let result = generate_binary_benchmarks(&binary_path, "machine");
+		let result = generate_binary_benchmarks(&binary_path, "machine", |args| args);
 
 		// Display the benchmarking command.
 		cliclack::log::remark("\n")?;

--- a/crates/pop-cli/src/commands/bench/machine.rs
+++ b/crates/pop-cli/src/commands/bench/machine.rs
@@ -8,7 +8,7 @@ use crate::{
 use clap::Args;
 use frame_benchmarking_cli::MachineCmd;
 use pop_common::Profile;
-use pop_parachains::generate_binary_benchmarks;
+use pop_parachains::{generate_binary_benchmarks, BenchmarkingCliCommand};
 use std::{
 	env::current_dir,
 	path::{Path, PathBuf},
@@ -49,7 +49,8 @@ impl BenchmarkMachine {
 		cli.warning("NOTE: this may take some time...")?;
 		cli.info("Benchmarking your hardware performance...")?;
 
-		let result = generate_binary_benchmarks(&binary_path, "machine", |args| args);
+		let result =
+			generate_binary_benchmarks(&binary_path, BenchmarkingCliCommand::Machine, |args| args);
 
 		// Display the benchmarking command.
 		cliclack::log::remark("\n")?;

--- a/crates/pop-cli/src/commands/bench/overhead.rs
+++ b/crates/pop-cli/src/commands/bench/overhead.rs
@@ -13,7 +13,7 @@ use clap::{Args, Parser};
 use cliclack::spinner;
 use frame_benchmarking_cli::OverheadCmd;
 use pop_common::Profile;
-use pop_parachains::{generate_omni_bencher_benchmarks, OmniBencherCommand};
+use pop_parachains::{generate_omni_bencher_benchmarks, BenchmarkingCliCommand};
 use std::{env::current_dir, path::PathBuf};
 use tempfile::tempdir;
 
@@ -126,7 +126,7 @@ impl BenchmarkOverhead {
 		let binary_path = check_omni_bencher_and_prompt(cli, self.skip_confirm).await?;
 		generate_omni_bencher_benchmarks(
 			binary_path.as_path(),
-			OmniBencherCommand::Overhead,
+			BenchmarkingCliCommand::Overhead,
 			self.collect_arguments(),
 			false,
 		)?;

--- a/crates/pop-cli/src/commands/bench/pallet.rs
+++ b/crates/pop-cli/src/commands/bench/pallet.rs
@@ -9,6 +9,7 @@ use crate::{
 		bench::{
 			check_omni_bencher_and_prompt, ensure_runtime_binary_exists,
 			guide_user_to_select_genesis_policy, guide_user_to_select_genesis_preset,
+			overwrite_weight_file_command,
 		},
 		builds::guide_user_to_select_profile,
 		prompt::display_message,
@@ -28,6 +29,7 @@ use std::{
 };
 use strum::{EnumMessage, IntoEnumIterator};
 use strum_macros::{EnumIter, EnumMessage as EnumMessageDerive};
+use tempfile::tempdir;
 
 const ALL_SELECTED: &str = "*";
 
@@ -342,18 +344,43 @@ impl BenchmarkPallet {
 		Ok(())
 	}
 
-	fn run(&self) -> anyhow::Result<()> {
-		generate_pallet_benchmarks(self.collect_arguments())
+	fn run(&mut self) -> anyhow::Result<()> {
+		match self.output.clone() {
+			Some(original_weight_path) => {
+				let temp_dir = tempdir()?;
+				let temp_file_path = temp_dir.path().join("temp_weights.rs");
+				self.output = Some(temp_file_path.clone());
+
+				generate_pallet_benchmarks(self.collect_arguments())?;
+
+				// Restore the original weight path.
+				self.output = Some(original_weight_path.clone());
+				// Overwrite the weight files with the correct executed command.
+				overwrite_weight_file_command(
+					&temp_file_path,
+					&original_weight_path,
+					&self.collect_display_arguments(),
+				)?;
+			},
+			None => {
+				generate_pallet_benchmarks(self.collect_arguments())?;
+			},
+		}
+		Ok(())
 	}
 
 	fn display(&self) -> String {
-		let mut args = vec!["pop bench pallet".to_string()];
+		self.collect_display_arguments().join(" ")
+	}
+
+	fn collect_display_arguments(&self) -> Vec<String> {
+		let mut args = vec!["pop".to_string(), "bench".to_string(), "pallet".to_string()];
 		let mut arguments = self.collect_arguments();
 		if self.skip_menu {
 			arguments.push("--skip".to_string());
 		}
 		args.extend(arguments);
-		args.join(" ")
+		args
 	}
 
 	fn collect_arguments(&self) -> Vec<String> {
@@ -932,11 +959,11 @@ mod tests {
 	use super::*;
 	use crate::{
 		cli::MockCli,
-		common::bench::{get_mock_runtime, source_omni_bencher_binary},
+		common::bench::{get_mock_runtime, source_omni_bencher_binary, EXECUTED_COMMAND_COMMENT},
 	};
 	use anyhow::Ok;
 	use pop_common::Profile;
-	use std::env::current_dir;
+	use std::{env::current_dir, fs};
 	use strum::{EnumMessage, VariantArray};
 
 	#[tokio::test]
@@ -996,6 +1023,41 @@ mod tests {
 		// Verify the printed command.
 		cli = cli.expect_info(cmd.display()).expect_outro("Benchmark completed successfully!");
 		cmd.execute(&mut cli).await?;
+		cli.verify()
+	}
+
+	#[tokio::test]
+	async fn benchmark_pallet_weight_file_works() -> anyhow::Result<()> {
+		let temp_dir = tempfile::tempdir()?;
+		let output_path = temp_dir.path().join("weights.rs");
+		let mut cli = expect_pallet_benchmarking_intro(MockCli::new())
+			.expect_warning("NOTE: this may take some time...")
+			.expect_info("Benchmarking extrinsic weights of selected pallets...")
+			.expect_input(
+				"Provide the output file path for benchmark results (optional).",
+				output_path.to_str().unwrap().to_string(),
+			)
+			.expect_outro("Benchmark completed successfully!");
+
+		let mut cmd = BenchmarkPallet {
+			skip_menu: true,
+			skip_confirm: true,
+			runtime: Some(get_mock_runtime(true)),
+			genesis_builder: Some(GenesisBuilderPolicy::Runtime),
+			genesis_builder_preset: "development".to_string(),
+			pallet: Some("pallet_timestamp".to_string()),
+			extrinsic: Some(ALL_SELECTED.to_string()),
+			..Default::default()
+		};
+		cmd.execute(&mut cli).await?;
+
+		let content = fs::read_to_string(&output_path)?;
+		let mut command_block = format!("{EXECUTED_COMMAND_COMMENT}\n");
+		for argument in cmd.collect_display_arguments() {
+			command_block.push_str(&format!("//  {argument}\n"));
+		}
+		assert!(content.contains(&command_block));
+		assert!(output_path.exists());
 		cli.verify()
 	}
 

--- a/crates/pop-cli/src/commands/bench/pallet.rs
+++ b/crates/pop-cli/src/commands/bench/pallet.rs
@@ -345,26 +345,23 @@ impl BenchmarkPallet {
 	}
 
 	fn run(&mut self) -> anyhow::Result<()> {
-		match self.output.clone() {
-			Some(original_weight_path) => {
-				let temp_dir = tempdir()?;
-				let temp_file_path = temp_dir.path().join("temp_weights.rs");
-				self.output = Some(temp_file_path.clone());
+		if let Some(original_weight_path) = self.output.clone() {
+			let temp_dir = tempdir()?;
+			let temp_file_path = temp_dir.path().join("temp_weights.rs");
+			self.output = Some(temp_file_path.clone());
 
-				generate_pallet_benchmarks(self.collect_arguments())?;
+			generate_pallet_benchmarks(self.collect_arguments())?;
 
-				// Restore the original weight path.
-				self.output = Some(original_weight_path.clone());
-				// Overwrite the weight files with the correct executed command.
-				overwrite_weight_file_command(
-					&temp_file_path,
-					&original_weight_path,
-					&self.collect_display_arguments(),
-				)?;
-			},
-			None => {
-				generate_pallet_benchmarks(self.collect_arguments())?;
-			},
+			// Restore the original weight path.
+			self.output = Some(original_weight_path.clone());
+			// Overwrite the weight files with the correct executed command.
+			overwrite_weight_file_command(
+				&temp_file_path,
+				&original_weight_path,
+				&self.collect_display_arguments(),
+			)?;
+		} else {
+			generate_pallet_benchmarks(self.collect_arguments())?;
 		}
 		Ok(())
 	}

--- a/crates/pop-cli/src/commands/bench/storage.rs
+++ b/crates/pop-cli/src/commands/bench/storage.rs
@@ -9,7 +9,7 @@ use crate::{
 use clap::Args;
 use frame_benchmarking_cli::StorageCmd;
 use pop_common::Profile;
-use pop_parachains::generate_binary_benchmarks;
+use pop_parachains::{generate_binary_benchmarks, BenchmarkingCliCommand};
 use std::{
 	env::current_dir,
 	path::{Path, PathBuf},
@@ -75,7 +75,7 @@ impl BenchmarkStorage {
 		self.command.params.weight_params.weight_path = Some(temp_dir.path().to_path_buf());
 
 		// Run the benchmark with updated arguments.
-		generate_binary_benchmarks(&binary_path, "storage", |args| {
+		generate_binary_benchmarks(&binary_path, BenchmarkingCliCommand::Storage, |args| {
 			args.into_iter()
 				.map(|arg| {
 					if arg.starts_with("--weight-path") {

--- a/crates/pop-cli/src/common/bench.rs
+++ b/crates/pop-cli/src/common/bench.rs
@@ -287,7 +287,7 @@ pub(crate) fn overwrite_weight_dir_command(
 /// Overwrites the weight file's executed command with the given arguments.
 ///
 /// # Arguments
-/// * `temp_file` - The path to the temporary.
+/// * `temp_file` - The path to the temporary file.
 /// * `dest_file` - The path to the destination file.
 /// * `arguments` - The arguments to write to the file.
 pub(crate) fn overwrite_weight_file_command(

--- a/crates/pop-cli/src/common/bench.rs
+++ b/crates/pop-cli/src/common/bench.rs
@@ -9,14 +9,15 @@ use pop_parachains::{
 	GenesisBuilderPolicy,
 };
 use std::{
+	self,
 	ffi::OsStr,
-	fs::{self, File},
-	io::{BufRead, BufReader},
+	fs,
 	path::{Path, PathBuf},
 };
 use strum::{EnumMessage, IntoEnumIterator};
 
 const DEFAULT_RUNTIME_DIR: &str = "./runtime";
+pub(crate) const EXECUTED_COMMAND_COMMENT: &str = "// Executed Command:";
 
 /// Checks the status of the `frame-omni-bencher` binary, using the local version if available.
 /// If the binary is missing, it is sourced as needed, and if an outdated version exists in cache,
@@ -268,7 +269,7 @@ pub(crate) fn get_mock_runtime(with_benchmark_features: bool) -> PathBuf {
 pub(crate) fn overwrite_weight_dir_command(
 	temp_path: &Path,
 	dest_path: &Path,
-	arguments: &Vec<String>,
+	arguments: &[String],
 ) -> anyhow::Result<()> {
 	// Read and print contents of all files in the temporary directory.
 	for entry in temp_path.read_dir()? {
@@ -277,9 +278,8 @@ pub(crate) fn overwrite_weight_dir_command(
 			continue;
 		}
 
-		let file = File::open(&path)?;
 		let destination = dest_path.join(path.file_name().unwrap());
-		overwrite_weight_file_command(file, destination.as_path(), arguments)?;
+		overwrite_weight_file_command(&path, destination.as_path(), arguments)?;
 	}
 	Ok(())
 }
@@ -287,21 +287,22 @@ pub(crate) fn overwrite_weight_dir_command(
 /// Overwrites the weight file's executed command with the given arguments.
 ///
 /// # Arguments
-/// * `temp_file` - The file to overwrite.
-/// * `dest_file_path` - The path to the destination file.
+/// * `temp_file` - The path to the temporary.
+/// * `dest_file` - The path to the destination file.
 /// * `arguments` - The arguments to write to the file.
 pub(crate) fn overwrite_weight_file_command(
-	temp_file: File,
-	dest_file_path: &Path,
-	arguments: &Vec<String>,
+	temp_file: &Path,
+	dest_file: &Path,
+	arguments: &[String],
 ) -> anyhow::Result<()> {
-	let reader = BufReader::new(temp_file);
-	let mut lines = reader.lines();
+	let contents = fs::read_to_string(temp_file)?;
+	let lines: Vec<&str> = contents.split("\n").collect();
+	let mut iter = lines.iter();
 	let mut new_lines: Vec<String> = vec![];
 
 	let mut inside_command_block = false;
-	while let Some(Ok(line)) = lines.next() {
-		if line.starts_with("// Executed Command:") {
+	for line in iter.by_ref() {
+		if line.starts_with(EXECUTED_COMMAND_COMMENT) {
 			inside_command_block = true;
 			continue;
 		} else if inside_command_block {
@@ -309,23 +310,23 @@ pub(crate) fn overwrite_weight_file_command(
 				continue;
 			} else if line.trim().is_empty() {
 				// Write new command block to the generated weight file.
-				new_lines.push("// Executed Command:".to_string());
-				for argument in arguments.to_vec() {
+				new_lines.push(EXECUTED_COMMAND_COMMENT.to_string());
+				for argument in arguments {
 					new_lines.push(format!("//  {}", argument));
 				}
 				new_lines.push(String::new());
 				break;
 			}
 		}
-		new_lines.push(line);
+		new_lines.push(line.to_string());
 	}
 
 	// Write the rest of the file to the destination file.
-	while let Some(Ok(line)) = lines.next() {
-		new_lines.push(line);
+	for line in iter {
+		new_lines.push(line.to_string());
 	}
 
-	std::fs::write(dest_file_path, new_lines.join("\n"))?;
+	std::fs::write(dest_file, new_lines.join("\n"))?;
 	Ok(())
 }
 
@@ -501,6 +502,74 @@ mod tests {
 		cli = expect_select_genesis_preset(cli, &runtime_path, 0);
 		guide_user_to_select_genesis_preset(&mut cli, &runtime_path, "development")?;
 		cli.verify()
+	}
+
+	#[test]
+	fn overwrite_weight_dir_command_works() -> anyhow::Result<()> {
+		let temp_dir = tempdir()?;
+		let dest_dir = tempdir()?;
+		let files = ["weights-1.rs", "weights-2.rs", "weights-3.rs"];
+
+		for file in files {
+			let temp_file = temp_dir.path().join(file);
+			fs::write(temp_file.clone(), "// Executed Command:\n// command\n// should\n// be\n// replaced\n\nThis line should not be replaced.")?;
+		}
+
+		overwrite_weight_dir_command(
+			temp_dir.path(),
+			dest_dir.path(),
+			&vec!["new".to_string(), "command".to_string(), "replaced".to_string()],
+		)?;
+
+		for file in files {
+			let dest_file = dest_dir.path().join(file);
+			assert_eq!(fs::read_to_string(dest_file)?, "// Executed Command:\n//  new\n//  command\n//  replaced\n\nThis line should not be replaced.");
+		}
+
+		Ok(())
+	}
+
+	#[test]
+	fn overwrite_weight_file_command_works() -> anyhow::Result<()> {
+		for (original, expected) in [
+			(
+				"// Executed Command:\n// command\n// should\n// be\n// replaced\n\nThis line should not be replaced.",
+				"// Executed Command:\n//  new\n//  command\n//  replaced\n\nThis line should not be replaced."
+			),
+			// Not replace because not "Executed Commnad" comment block found.
+			(
+				"// command\n// should\n// be\n// replaced\n\nThis line should not be replaced.",
+				"// command\n// should\n// be\n// replaced\n\nThis line should not be replaced.",
+			),
+			// Not replacing contents before the "Executed Command" comment block.
+			(
+    			"Before line should not be replaced\n\n// Executed Command:\n// command\n// should\n// be\n// replaced\n\nAfter line should not be replaced.",
+    			"Before line should not be replaced\n\n// Executed Command:\n//  new\n//  command\n//  replaced\n\nAfter line should not be replaced.",
+			),
+		] {
+			let temp_dir = tempdir()?;
+			let dest_dir = tempdir()?;
+			let temp_file = temp_dir.path().join("weights.rs");
+			fs::write(
+    			temp_file.clone(),
+    			original
+    		)?;
+			let dest_file = dest_dir.path().join("dest_weights.rs");
+			File::create(dest_file.clone())?;
+
+			overwrite_weight_file_command(
+				&temp_file,
+				dest_file.as_path(),
+				&vec!["new".to_string(), "command".to_string(), "replaced".to_string()],
+			)?;
+
+			let content = fs::read_to_string(dest_file)?;
+			assert_eq!(
+    			content,
+    			expected
+    		);
+		}
+		Ok(())
 	}
 
 	fn expect_select_genesis_policy(cli: MockCli, item: usize) -> MockCli {

--- a/crates/pop-parachains/src/bench/mod.rs
+++ b/crates/pop-parachains/src/bench/mod.rs
@@ -121,12 +121,20 @@ pub fn generate_pallet_benchmarks(args: Vec<String>) -> anyhow::Result<()> {
 /// # Arguments
 /// * `binary_path` - Path to the binary of FRAME Omni Bencher.
 /// * `command` - Command to run for benchmarking.
-pub fn generate_binary_benchmarks(binary_path: &PathBuf, command: &str) -> anyhow::Result<()> {
+/// * `update_args` - Function to update the arguments before running the benchmark.
+pub fn generate_binary_benchmarks<F>(
+	binary_path: &PathBuf,
+	command: &str,
+	update_args: F,
+) -> anyhow::Result<()>
+where
+	F: Fn(Vec<String>) -> Vec<String>,
+{
 	let temp_file = NamedTempFile::new()?;
 	let temp_path = temp_file.path().to_owned();
 
 	// Get all arguments of the command and skip the program name.
-	let mut args = std::env::args().skip(3).collect::<Vec<String>>();
+	let mut args = update_args(std::env::args().skip(3).collect::<Vec<String>>());
 	let mut cmd_args = vec!["benchmark".to_string(), command.to_string()];
 	cmd_args.append(&mut args);
 

--- a/crates/pop-parachains/src/bench/mod.rs
+++ b/crates/pop-parachains/src/bench/mod.rs
@@ -33,19 +33,28 @@ type HostFunctions = (
 /// extrinsics.
 pub type PalletExtrinsicsRegistry = BTreeMap<String, Vec<String>>;
 
-/// Commands that can be executed by the `frame-omni-bencher` CLI.
-pub enum OmniBencherCommand {
+/// Commands that can be executed by the `frame-benchmarking-cli` CLI.
+pub enum BenchmarkingCliCommand {
 	/// Execute a pallet benchmark.
 	Pallet,
 	/// Execute an overhead benchmark.
 	Overhead,
+	/// Execute a storage benchmark.
+	Storage,
+	/// Execute a machine benchmark.
+	Machine,
+	/// Execute a block benchmark.
+	Block,
 }
 
-impl Display for OmniBencherCommand {
+impl Display for BenchmarkingCliCommand {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		let s = match self {
-			OmniBencherCommand::Pallet => "pallet",
-			OmniBencherCommand::Overhead => "overhead",
+			BenchmarkingCliCommand::Pallet => "pallet",
+			BenchmarkingCliCommand::Overhead => "overhead",
+			BenchmarkingCliCommand::Storage => "storage",
+			BenchmarkingCliCommand::Machine => "machine",
+			BenchmarkingCliCommand::Block => "block",
 		};
 		write!(f, "{}", s)
 	}
@@ -124,7 +133,7 @@ pub fn generate_pallet_benchmarks(args: Vec<String>) -> anyhow::Result<()> {
 /// * `update_args` - Function to update the arguments before running the benchmark.
 pub fn generate_binary_benchmarks<F>(
 	binary_path: &PathBuf,
-	command: &str,
+	command: BenchmarkingCliCommand,
 	update_args: F,
 ) -> anyhow::Result<()>
 where
@@ -160,7 +169,7 @@ pub async fn load_pallet_extrinsics(
 ) -> anyhow::Result<PalletExtrinsicsRegistry> {
 	let output = generate_omni_bencher_benchmarks(
 		binary_path,
-		OmniBencherCommand::Pallet,
+		BenchmarkingCliCommand::Pallet,
 		vec![
 			format!("--runtime={}", runtime_path.display()),
 			"--genesis-builder=none".to_string(),
@@ -202,7 +211,7 @@ fn process_pallet_extrinsics(output: String) -> anyhow::Result<PalletExtrinsicsR
 /// * `log_enabled` - Whether to enable logging.
 pub fn generate_omni_bencher_benchmarks(
 	binary_path: &Path,
-	command: OmniBencherCommand,
+	command: BenchmarkingCliCommand,
 	args: Vec<String>,
 	log_enabled: bool,
 ) -> anyhow::Result<String> {

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -17,7 +17,8 @@ mod utils;
 pub use bench::{
 	binary::*, generate_binary_benchmarks, generate_omni_bencher_benchmarks,
 	generate_pallet_benchmarks, get_preset_names, get_runtime_path, load_pallet_extrinsics,
-	GenesisBuilderPolicy, OmniBencherCommand, PalletExtrinsicsRegistry, GENESIS_BUILDER_DEV_PRESET,
+	BenchmarkingCliCommand, GenesisBuilderPolicy, PalletExtrinsicsRegistry,
+	GENESIS_BUILDER_DEV_PRESET,
 };
 pub use build::{
 	binary_path, build_parachain, build_project, export_wasm_file, generate_genesis_state_file,


### PR DESCRIPTION
Overwrites the `// Executed Command:` comment block of the generated weight files. As we run the command with `omni-bencher` or `frame-benchmarking-cli`, the generated command will be something like: 

```
// Executed Command: 
//  /user/cache/pop/frame-omni-bencher
// v1
// benchmark
// pallet
// --pallet=
// --extrinsic
```

The PR will overwrites the `Executed Command` with `pop bench command`: 

```
// Executed Command: 
//  pop
//  bench
//  pallet
//  --pallet=
//  --extrinsic=
```

Another issue is with the interactive UI, we prompt user to update the command arguments. With the current weight file, it does not display the updated arguments. 

[sc-2888]