### PR TITLE
fix: excluded custom arguments

### DIFF
--- a/crates/pop-cli/src/commands/bench/block.rs
+++ b/crates/pop-cli/src/commands/bench/block.rs
@@ -14,6 +14,8 @@ use std::{
 	path::{Path, PathBuf},
 };
 
+const EXCLUDED_ARGS: [&str; 1] = ["--profile"];
+
 #[derive(Args)]
 pub(crate) struct BenchmarkBlock {
 	/// Command to benchmark the execution time of historic blocks.
@@ -48,8 +50,12 @@ impl BenchmarkBlock {
 
 		cli.warning("NOTE: this may take some time...")?;
 
-		let result =
-			generate_binary_benchmarks(&binary_path, BenchmarkingCliCommand::Block, |args| args);
+		let result = generate_binary_benchmarks(
+			&binary_path,
+			BenchmarkingCliCommand::Block,
+			|args| args,
+			&EXCLUDED_ARGS,
+		);
 
 		// Display the benchmarking command.
 		cliclack::log::remark("\n")?;

--- a/crates/pop-cli/src/commands/bench/machine.rs
+++ b/crates/pop-cli/src/commands/bench/machine.rs
@@ -14,6 +14,8 @@ use std::{
 	path::{Path, PathBuf},
 };
 
+const EXCLUDED_ARGS: [&str; 1] = ["--profile"];
+
 #[derive(Args)]
 pub(crate) struct BenchmarkMachine {
 	/// Command to benchmark the hardware.
@@ -49,8 +51,12 @@ impl BenchmarkMachine {
 		cli.warning("NOTE: this may take some time...")?;
 		cli.info("Benchmarking your hardware performance...")?;
 
-		let result =
-			generate_binary_benchmarks(&binary_path, BenchmarkingCliCommand::Machine, |args| args);
+		let result = generate_binary_benchmarks(
+			&binary_path,
+			BenchmarkingCliCommand::Machine,
+			|args| args,
+			&EXCLUDED_ARGS,
+		);
 
 		// Display the benchmarking command.
 		cliclack::log::remark("\n")?;

--- a/crates/pop-cli/src/commands/bench/pallet.rs
+++ b/crates/pop-cli/src/commands/bench/pallet.rs
@@ -406,6 +406,9 @@ impl BenchmarkPallet {
 		if self.skip_menu {
 			arguments.push("--skip".to_string());
 		}
+		if self.skip_confirm {
+			arguments.push("-y".to_string());
+		}
 		args.extend(arguments);
 		args
 	}
@@ -524,7 +527,7 @@ impl BenchmarkPallet {
 	) -> anyhow::Result<()> {
 		if registry.is_empty() {
 			let runtime_path = self.runtime()?;
-			let binary_path = check_omni_bencher_and_prompt(cli, true).await?;
+			let binary_path = check_omni_bencher_and_prompt(cli, self.skip_confirm).await?;
 
 			let spinner = spinner();
 			spinner.start("Loading pallets and extrinsics from your runtime...");

--- a/crates/pop-cli/src/commands/bench/storage.rs
+++ b/crates/pop-cli/src/commands/bench/storage.rs
@@ -16,6 +16,8 @@ use std::{
 };
 use tempfile::tempdir;
 
+const EXCLUDED_ARGS: [&str; 1] = ["--profile"];
+
 #[derive(Args)]
 pub(crate) struct BenchmarkStorage {
 	/// Command to benchmark the storage speed of a chain snapshot.
@@ -75,17 +77,22 @@ impl BenchmarkStorage {
 		self.command.params.weight_params.weight_path = Some(temp_dir.path().to_path_buf());
 
 		// Run the benchmark with updated arguments.
-		generate_binary_benchmarks(&binary_path, BenchmarkingCliCommand::Storage, |args| {
-			args.into_iter()
-				.map(|arg| {
-					if arg.starts_with("--weight-path") {
-						format!("--weight-path={}", temp_dir.path().display())
-					} else {
-						arg
-					}
-				})
-				.collect()
-		})?;
+		generate_binary_benchmarks(
+			&binary_path,
+			BenchmarkingCliCommand::Storage,
+			|args| {
+				args.into_iter()
+					.map(|arg| {
+						if arg.starts_with("--weight-path") {
+							format!("--weight-path={}", temp_dir.path().display())
+						} else {
+							arg
+						}
+					})
+					.collect()
+			},
+			&EXCLUDED_ARGS,
+		)?;
 
 		// Restore the original weight path.
 		self.command.params.weight_params.weight_path = Some(original_weight_path.clone());

--- a/crates/pop-parachains/src/bench/mod.rs
+++ b/crates/pop-parachains/src/bench/mod.rs
@@ -143,10 +143,12 @@ pub fn generate_pallet_benchmarks(args: Vec<String>) -> anyhow::Result<()> {
 /// * `binary_path` - Path to the binary of FRAME Omni Bencher.
 /// * `command` - Command to run for benchmarking.
 /// * `update_args` - Function to update the arguments before running the benchmark.
+/// * `excluded_args` - Arguments to exclude from the benchmarking command.
 pub fn generate_binary_benchmarks<F>(
 	binary_path: &PathBuf,
 	command: BenchmarkingCliCommand,
 	update_args: F,
+	excluded_args: &[&str],
 ) -> anyhow::Result<()>
 where
 	F: Fn(Vec<String>) -> Vec<String>,
@@ -156,6 +158,10 @@ where
 
 	// Get all arguments of the command and skip the program name.
 	let mut args = update_args(std::env::args().skip(3).collect::<Vec<String>>());
+	args = args
+		.into_iter()
+		.filter(|arg| !excluded_args.iter().any(|a| arg.starts_with(a)))
+		.collect::<Vec<String>>();
 	let mut cmd_args = vec!["benchmark".to_string(), command.to_string()];
 	cmd_args.append(&mut args);
 


### PR DESCRIPTION
Exclude custom arguments from the actual command arguments run with `frame-omni-bencher` or node binary. 