### PR TITLE
fix: improve build spec error messaging

### DIFF
--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -200,7 +200,7 @@ impl BuildSpecCommand {
 		if is_supported(None)? {
 			let build_spec = self.configure_build_spec(&mut cli).await?;
 			if let Err(e) = build_spec.build(&mut cli) {
-				cli.outro_cancel(&format!("{}", e))?;
+				cli.outro_cancel(e.to_string())?;
 			}
 		} else {
 			cli.outro_cancel(

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -199,7 +199,9 @@ impl BuildSpecCommand {
 		// Checks for appchain project in `./`.
 		if is_supported(None)? {
 			let build_spec = self.configure_build_spec(&mut cli).await?;
-			build_spec.build(&mut cli)?;
+			if let Err(e) = build_spec.build(&mut cli) {
+				cli.outro_cancel(&format!("{}", e))?;
+			}
 		} else {
 			cli.outro_cancel(
 				"🚫 Can't build a specification for target. Maybe not a chain project ?",

--- a/crates/pop-parachains/src/errors.rs
+++ b/crates/pop-parachains/src/errors.rs
@@ -81,3 +81,44 @@ pub enum Error {
 	#[error("Failed to locate the workspace")]
 	WorkspaceLocate,
 }
+
+// Handles command execution errors by extracting and returning the stderr message using the
+// provided error constructor.
+pub(crate) fn handle_command_error<F>(
+	output: &std::process::Output,
+	custom_error: F,
+) -> Result<(), Error>
+where
+	F: FnOnce(String) -> Error,
+{
+	if !output.status.success() {
+		let stderr_msg = String::from_utf8_lossy(&output.stderr);
+		return Err(custom_error(stderr_msg.to_string()));
+	}
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+	use std::{
+		os::unix::process::ExitStatusExt,
+		process::{ExitStatus, Output},
+	};
+
+	#[test]
+	fn handle_command_error_failure() -> Result<()> {
+		let output = Output {
+			status: ExitStatus::from_raw(1),
+			stdout: Vec::new(),
+			stderr: Vec::from("Error message".as_bytes()),
+		};
+		assert!(matches!(
+			handle_command_error(&output, Error::BuildSpecError),
+			Err(Error::BuildSpecError(message))
+			if message == "Error message"
+		));
+		Ok(())
+	}
+}

--- a/crates/pop-parachains/src/errors.rs
+++ b/crates/pop-parachains/src/errors.rs
@@ -10,6 +10,9 @@ pub enum Error {
 	Aborted,
 	#[error("Anyhow error: {0}")]
 	AnyhowError(#[from] anyhow::Error),
+	/// An error occurred while generating the chain specification.
+	#[error("Failed to build the chain spec: {0}")]
+	BuildSpecError(String),
 	/// An error occurred while decoding the call data.
 	#[error("Failed to decode call data. {0}")]
 	CallDataDecodingError(String),

--- a/crates/pop-parachains/src/errors.rs
+++ b/crates/pop-parachains/src/errors.rs
@@ -11,7 +11,7 @@ pub enum Error {
 	#[error("Anyhow error: {0}")]
 	AnyhowError(#[from] anyhow::Error),
 	/// An error occurred while generating the chain specification.
-	#[error("Failed to build the chain spec: {0}")]
+	#[error("Failed to build the chain spec. {0}")]
 	BuildSpecError(String),
 	/// An error occurred while decoding the call data.
 	#[error("Failed to decode call data. {0}")]


### PR DESCRIPTION
This PR improves the error message when building specs fails, making it clearer and more aligned with the output of the underlying command.

**Before:**

Running `pop build spec --chain ./wrong-chain-spec`:
```
Error: IO error: command ["/templates_test/evm/target/release/parachain-template-node", "build-spec", "--chain", "./wrong-chain-spec", "--disable-default-bootnode"] exited with code 1

Caused by:
    command ["templates_test/evm/target/release/parachain-template-node", "build-spec", "--chain", "./wrong-chain-spec", "--disable-default-bootnode"] exited with code 1
```
This error message was not very informative and did not clearly indicate the root cause of the failure.
**Now:**
```
 Failed to build the chain spec. Error: Input("Error opening spec file `./wrong-chain-spec`: No such file or directory (os error 2)")
```
This message explicitly states the failure reason and matches the output of the underlying command:
```
./target/release/parachain-template-node build-spec --chain ./wrong-chain-spec
```
```
Error: Input("Error opening spec file `./c`: No such file or directory (os error 2)")
```

Closes https://github.com/r0gue-io/pop-cli/issues/475

[sc-3371]