### PR TITLE
fix(build spec): default bootnode prompt

### DIFF
--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -965,10 +965,10 @@ mod tests {
 				}
 				let build_spec = build_spec_cmd.configure_build_spec(&mut cli).await?;
 				if !changes && no_flags_used {
-					assert_eq!(build_spec.id, para_id);
-					assert_eq!(build_spec.chain_type, chain_type);
-					assert_eq!(build_spec.relay, relay);
-					assert_eq!(build_spec.protocol_id, protocol_id);
+					assert_eq!(build_spec.id, 2000);
+					assert_eq!(build_spec.chain_type, Development);
+					assert_eq!(build_spec.relay, PaseoLocal);
+					assert_eq!(build_spec.protocol_id, "my-protocol");
 					assert_eq!(build_spec.genesis_state, genesis_state);
 					assert_eq!(build_spec.genesis_code, genesis_code);
 					assert_eq!(build_spec.deterministic, deterministic);

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -410,7 +410,7 @@ impl BuildSpecCommand {
 		};
 
 		// Prompt for default bootnode if not provided and chain type is Local or Live.
-		let default_bootnode = if !default_bootnode {
+		let default_bootnode = if !default_bootnode && prompt {
 			match chain_type {
 				ChainType::Development => true,
 				_ => cli
@@ -942,9 +942,39 @@ mod tests {
 						).expect_input("Enter the directory path where the runtime is located:", runtime_dir.display().to_string())
 						.expect_input("Enter the runtime package name:", package.to_string());
 					}
+				} else if !changes && no_flags_used {
+					if !build_spec_cmd.genesis_state {
+						cli = cli.expect_confirm(
+							"Should the genesis state file be generated ?",
+							genesis_state,
+						);
+					}
+					if !build_spec_cmd.genesis_code {
+						cli = cli.expect_confirm(
+							"Should the genesis code file be generated ?",
+							genesis_code,
+						);
+					}
+					if !build_spec_cmd.deterministic {
+						cli = cli.expect_confirm(
+							"Would you like to build the runtime deterministically? This requires a containerization solution (Docker/Podman) and is recommended for production builds.",
+							deterministic,
+						).expect_input("Enter the directory path where the runtime is located:", runtime_dir.display().to_string())
+						.expect_input("Enter the runtime package name:", package.to_string());
+					}
 				}
 				let build_spec = build_spec_cmd.configure_build_spec(&mut cli).await?;
-				if changes && no_flags_used {
+				if !changes && no_flags_used {
+					assert_eq!(build_spec.id, para_id);
+					assert_eq!(build_spec.chain_type, chain_type);
+					assert_eq!(build_spec.relay, relay);
+					assert_eq!(build_spec.protocol_id, protocol_id);
+					assert_eq!(build_spec.genesis_state, genesis_state);
+					assert_eq!(build_spec.genesis_code, genesis_code);
+					assert_eq!(build_spec.deterministic, deterministic);
+					assert_eq!(build_spec.package, package);
+					assert_eq!(build_spec.runtime_dir, runtime_dir);
+				} else if changes && no_flags_used {
 					assert_eq!(build_spec.id, para_id);
 					assert_eq!(build_spec.profile, profile);
 					assert_eq!(build_spec.default_bootnode, default_bootnode);


### PR DESCRIPTION
When the user doesn't want to make changes to the spec that it provides, no prompt for the default bootnode.

Closes https://github.com/r0gue-io/pop-cli/issues/444