### PR TITLE
chore: improve pop up flow

### DIFF
--- a/crates/pop-cli/src/cli.rs
+++ b/crates/pop-cli/src/cli.rs
@@ -150,7 +150,7 @@ impl traits::Cli for Cli {
 	fn warning(&mut self, message: impl Display) -> Result<()> {
 		cliclack::log::warning(message)?;
 		#[cfg(not(test))]
-		sleep(Duration::from_secs(2));
+		sleep(Duration::from_secs(1));
 		Ok(())
 	}
 }

--- a/crates/pop-cli/src/cli.rs
+++ b/crates/pop-cli/src/cli.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use std::{fmt::Display, io::Result};
+#[cfg(not(test))]
+use std::{thread::sleep, time::Duration};
 #[cfg(test)]
 pub(crate) use tests::MockCli;
 
@@ -146,7 +148,10 @@ impl traits::Cli for Cli {
 
 	/// Prints a warning message.
 	fn warning(&mut self, message: impl Display) -> Result<()> {
-		cliclack::log::warning(message)
+		cliclack::log::warning(message)?;
+		#[cfg(not(test))]
+		sleep(Duration::from_secs(2));
+		Ok(())
 	}
 }
 

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -4,8 +4,6 @@ use crate::{cli, style::style};
 use pop_common::Profile;
 use pop_parachains::build_parachain;
 use std::path::PathBuf;
-#[cfg(not(test))]
-use std::{thread::sleep, time::Duration};
 
 // Configuration for building a parachain.
 pub struct BuildParachain {
@@ -33,8 +31,6 @@ impl BuildParachain {
 
 		if self.profile == Profile::Debug {
 			cli.warning("NOTE: this command now defaults to DEBUG builds. Please use `--release` (or simply `-r`) for a release build...")?;
-			#[cfg(not(test))]
-			sleep(Duration::from_secs(3))
 		}
 
 		// Build parachain.

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -21,8 +21,6 @@ use std::{
 	fs::{self, create_dir_all},
 	path::{Path, PathBuf},
 };
-#[cfg(not(test))]
-use std::{thread::sleep, time::Duration};
 use strum::{EnumMessage, VariantArray};
 use strum_macros::{AsRefStr, Display, EnumString};
 
@@ -488,8 +486,6 @@ impl BuildSpecCommand {
 
 		if release {
 			cli.warning("NOTE: release flag is deprecated. Use `--profile` instead.")?;
-			#[cfg(not(test))]
-			sleep(Duration::from_secs(3));
 			profile = Profile::Release;
 		}
 

--- a/crates/pop-cli/src/commands/up/mod.rs
+++ b/crates/pop-cli/src/commands/up/mod.rs
@@ -168,7 +168,15 @@ mod tests {
 			Some(
 				DeploymentProvider::VARIANTS
 					.into_iter()
-					.map(|action| (action.name().to_string(), format!("{}", style(format!("{}", action.base_url())).bold().underlined())))
+					.map(|action| {
+						(
+							action.name().to_string(),
+							format!(
+								"{}",
+								style(format!("{}", action.base_url())).bold().underlined()
+							),
+						)
+					})
 					.chain(std::iter::once((
 						"Register".to_string(),
 						"Register the rollup on the relay chain without deploying with a provider"

--- a/crates/pop-cli/src/commands/up/mod.rs
+++ b/crates/pop-cli/src/commands/up/mod.rs
@@ -94,7 +94,7 @@ impl Command {
 #[cfg(test)]
 mod tests {
 	use super::{contract::UpContractCommand, *};
-	use crate::style::style;
+	use crate::style::{format_url, style};
 	use cli::MockCli;
 	use duct::cmd;
 	use pop_contracts::{mock_build_process, new_environment};
@@ -168,12 +168,7 @@ mod tests {
 			Some(
 				DeploymentProvider::VARIANTS
 					.into_iter()
-					.map(|action| {
-						(
-							action.name().to_string(),
-							format!("{}", style(action.base_url().to_string()).bold().underlined()),
-						)
-					})
+					.map(|action| (action.name().to_string(), format_url(action.base_url())))
 					.chain(std::iter::once((
 						"Register".to_string(),
 						"Register the rollup on the relay chain without deploying with a provider"

--- a/crates/pop-cli/src/commands/up/mod.rs
+++ b/crates/pop-cli/src/commands/up/mod.rs
@@ -94,7 +94,7 @@ impl Command {
 #[cfg(test)]
 mod tests {
 	use super::{contract::UpContractCommand, *};
-
+	use crate::style::style;
 	use cli::MockCli;
 	use duct::cmd;
 	use pop_contracts::{mock_build_process, new_environment};
@@ -168,7 +168,7 @@ mod tests {
 			Some(
 				DeploymentProvider::VARIANTS
 					.into_iter()
-					.map(|action| (action.name().to_string(), action.description().to_string()))
+					.map(|action| (action.name().to_string(), format!("{}", style(format!("{}", action.base_url())).bold().underlined())))
 					.chain(std::iter::once((
 						"Register".to_string(),
 						"Register the rollup on the relay chain without deploying with a provider"

--- a/crates/pop-cli/src/commands/up/mod.rs
+++ b/crates/pop-cli/src/commands/up/mod.rs
@@ -171,10 +171,7 @@ mod tests {
 					.map(|action| {
 						(
 							action.name().to_string(),
-							format!(
-								"{}",
-								style(format!("{}", action.base_url())).bold().underlined()
-							),
+							format!("{}", style(action.base_url().to_string()).bold().underlined()),
 						)
 					})
 					.chain(std::iter::once((

--- a/crates/pop-cli/src/commands/up/rollup.rs
+++ b/crates/pop-cli/src/commands/up/rollup.rs
@@ -11,7 +11,7 @@ use crate::{
 		wallet::submit_extrinsic,
 	},
 	deployment_api::{DeployRequest, DeployResponse, DeploymentApi},
-	style::style,
+	style::{format_url, style},
 };
 use anyhow::Result;
 use clap::Args;
@@ -451,7 +451,7 @@ fn prompt_provider(
 		predefined_action = predefined_action.item(
 			Some(action.clone()),
 			action.name(),
-			format!("{}", style(action.base_url().to_string()).bold().underlined()),
+			format_url(action.base_url()),
 		);
 	}
 	if !skip_registration {
@@ -619,12 +619,7 @@ mod tests {
 			Some(
 				DeploymentProvider::VARIANTS
 					.into_iter()
-					.map(|action| {
-						(
-							action.name().to_string(),
-							format!("{}", style(action.base_url().to_string()).bold().underlined()),
-						)
-					})
+					.map(|action| (action.name().to_string(), format_url(action.base_url())))
 					.chain(std::iter::once((
 						"Register".to_string(),
 						"Register the rollup on the relay chain without deploying with a provider"
@@ -744,7 +739,7 @@ mod tests {
                 Some(
                     DeploymentProvider::VARIANTS
                         .into_iter()
-                        .map(|action| (action.name().to_string(), format!("{}", style(action.base_url().to_string()).bold().underlined())))
+                        .map(|action| (action.name().to_string(), format_url(action.base_url())))
                         .chain(std::iter::once((
                             "Register".to_string(),
                             "Register the rollup on the relay chain without deploying with a provider".to_string(),
@@ -783,7 +778,7 @@ mod tests {
                 Some(
                     DeploymentProvider::VARIANTS
                         .into_iter()
-                        .map(|action| (action.name().to_string(), format!("{}", style(action.base_url().to_string()).bold().underlined())))
+                        .map(|action| (action.name().to_string(), format_url(action.base_url())))
                         .chain(std::iter::once((
                             "Register".to_string(),
                             "Register the rollup on the relay chain without deploying with a provider".to_string(),
@@ -940,7 +935,7 @@ mod tests {
 			..Default::default()
 		};
 		// Nothing provided, should show steps.
-		assert!(UpCommand { ..Default::default() }.should_show_deployment_steps(&deployment));
+		assert!(UpCommand::default().should_show_deployment_steps(&deployment));
 		// skip_registration is true, should not show steps.
 		assert!(!UpCommand { id: Some(2000), skip_registration: true, ..Default::default() }
 			.should_show_deployment_steps(&deployment));

--- a/crates/pop-cli/src/commands/up/rollup.rs
+++ b/crates/pop-cli/src/commands/up/rollup.rs
@@ -16,7 +16,7 @@ use crate::{
 use anyhow::Result;
 use clap::Args;
 use cliclack::spinner;
-use pop_common::{parse_account, templates::Template};
+use pop_common::{parse_account, templates::Template, Profile};
 use pop_parachains::{
 	construct_proxy_extrinsic, find_dispatchable_by_name, Action, DeploymentProvider, Parachain,
 	Payload, Reserved, SupportedChains,
@@ -64,6 +64,9 @@ pub struct UpCommand {
 	/// account.
 	#[arg(long = "proxy")]
 	pub(crate) proxied_address: Option<String>,
+	/// Build profile [default: release].
+	#[clap(long, value_enum)]
+	pub(crate) profile: Option<Profile>,
 }
 
 impl UpCommand {
@@ -216,6 +219,7 @@ impl UpCommand {
 			deployment_config,
 			id,
 			self.path.as_deref(),
+			self.profile.clone(),
 			cli,
 		)
 		.await
@@ -329,6 +333,7 @@ async fn generate_spec_files(
 	deployment_config: &mut Deployment,
 	id: u32,
 	path: Option<&Path>,
+	profile: Option<Profile>,
 	cli: &mut impl Cli,
 ) -> anyhow::Result<GenesisArtifacts> {
 	let chain_spec_path = chain_spec
@@ -348,6 +353,7 @@ async fn generate_spec_files(
 			.api
 			.as_ref()
 			.and_then(|api| RelayChain::from_str(&api.relay_chain_name.to_lowercase()).ok()),
+		profile: profile.or(Some(Profile::Release)),
 		..Default::default()
 	}
 	.configure_build_spec(cli)

--- a/crates/pop-cli/src/commands/up/rollup.rs
+++ b/crates/pop-cli/src/commands/up/rollup.rs
@@ -659,7 +659,7 @@ mod tests {
 		assert_eq!(proxied_address, Some(format!("Id({})", MOCK_PROXIED_ADDRESS)));
 		cli.verify()?;
 
-		cli = MockCli::new().expect_info(format!("Step 1/5: The provider {} requires registration via a pure proxy for security and best practices.", DeploymentProvider::PDP.name()))
+		cli = MockCli::new().expect_info(format!("[1/5]: The provider {} requires registration via a pure proxy for security and best practices.", DeploymentProvider::PDP.name()))
 		.expect_input(
 			"Enter the pure proxy account used for the registration",
 			MOCK_PROXIED_ADDRESS.into(),

--- a/crates/pop-cli/src/commands/up/rollup.rs
+++ b/crates/pop-cli/src/commands/up/rollup.rs
@@ -11,7 +11,7 @@ use crate::{
 		wallet::submit_extrinsic,
 	},
 	deployment_api::{DeployRequest, DeployResponse, DeploymentApi},
-	style::{format_url, style},
+	style::{format_step_prefix, format_url, style},
 };
 use anyhow::Result;
 use clap::Args;
@@ -182,7 +182,7 @@ impl UpCommand {
 		}
 		if let Some(api) = api {
 			if api.provider == DeploymentProvider::PDP {
-				cli.info(format!("{}The provider {} requires registration via a pure proxy for security and best practices.", if show_deployment_steps { "Step 1/5: " } else {""} , api.provider.name()))?;
+				cli.info(format!("{}The provider {} requires registration via a pure proxy for security and best practices.", format_step_prefix(1,5, show_deployment_steps), api.provider.name()))?;
 				return Ok(Some(prompt_for_proxy_address(
 					self.skip_registration,
 					relay_chain_url,
@@ -207,7 +207,7 @@ impl UpCommand {
 		match self.id {
 			Some(id) => Ok(id),
 			None => {
-				cli.info(format!("{}You will need to sign a transaction to reserve an ID on {} using the `Registrar::reserve` function.", if show_deployment_steps { "Step 2/5: " } else {""}, chain.url))?;
+				cli.info(format!("{}You will need to sign a transaction to reserve an ID on {} using the `Registrar::reserve` function.", format_step_prefix(2,5, show_deployment_steps), chain.url))?;
 				reserve(chain, proxy, cli).await
 			},
 		}
@@ -234,7 +234,7 @@ impl UpCommand {
 		}
 		cli.info(format!(
 			"{}Generating the chain spec for your project",
-			if show_deployment_steps { "Step 3/5: " } else { "" }
+			format_step_prefix(3, 5, show_deployment_steps)
 		))?;
 		generate_spec_files(
 			self.chain_spec.as_deref(),
@@ -287,7 +287,7 @@ impl Deployment {
 		}
 		cli.info(format!(
 			"{}Starting deployment with {}",
-			if show_deployment_steps { "Step 5/5: " } else { "" },
+			format_step_prefix(5, 5, show_deployment_steps),
 			api.provider.name()
 		))?;
 		api.deploy(config.id, request).await
@@ -304,7 +304,7 @@ struct Registration {
 impl Registration {
 	// Registers by submitting an extrinsic.
 	async fn register(&self, show_deployment_steps: bool, cli: &mut impl Cli) -> Result<()> {
-		cli.info(format!("{}You will need to sign a transaction to register on {}, using the `Registrar::register` function.", if show_deployment_steps { "Step 4/5: " } else {""}, self.chain.url))?;
+		cli.info(format!("{}You will need to sign a transaction to register on {}, using the `Registrar::register` function.",format_step_prefix(4,5, show_deployment_steps), self.chain.url))?;
 		let call_data = self.prepare_register_call_data(cli)?;
 		submit_extrinsic(&self.chain.client, &self.chain.url, call_data, cli)
 			.await

--- a/crates/pop-cli/src/commands/up/rollup.rs
+++ b/crates/pop-cli/src/commands/up/rollup.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use anyhow::Result;
 use clap::Args;
+use cliclack::spinner;
 use pop_common::{parse_account, templates::Template};
 use pop_parachains::{
 	construct_proxy_extrinsic, find_dispatchable_by_name, Action, DeploymentProvider, Parachain,
@@ -354,14 +355,16 @@ async fn generate_spec_files(
 
 	let mut genesis_artifacts = build_spec.clone().build(cli)?;
 	if let Some(api) = &deployment_config.api {
-		cli.info("Fetching collator keys...")?;
+		let spinner = spinner();
+		spinner.start("Fetching collator keys...");
 		let keys = api.get_collator_keys(id).await?;
-		cli.info("Rebuilding chain spec with updated collator keys...")?;
+		spinner.set_message("Rebuilding chain spec with updated collator keys...");
 		build_spec
 			.update_chain_spec_with_keys(keys.collator_keys, &genesis_artifacts.chain_spec)?;
 		build_spec.enable_existing_plain_spec();
 		genesis_artifacts = build_spec.build(cli)?;
 		deployment_config.collator_file_id = Some(keys.collator_file_id);
+		spinner.stop("Collator keys successfully fetched and chain spec updated.");
 	}
 	Ok(genesis_artifacts)
 }

--- a/crates/pop-cli/src/deployment_api.rs
+++ b/crates/pop-cli/src/deployment_api.rs
@@ -285,7 +285,7 @@ mod tests {
 			json!({
 				"name": "Development",
 				"properties": {
-					"basedOn": "r0gue-io/standard",
+					"basedOn": "r0gue-io/base-parachain",
 				},
 				"genesis": {
 					"runtimeGenesis": {

--- a/crates/pop-cli/src/deployment_api.rs
+++ b/crates/pop-cli/src/deployment_api.rs
@@ -285,7 +285,7 @@ mod tests {
 			json!({
 				"name": "Development",
 				"properties": {
-					"basedOn": "standard",
+					"basedOn": "r0gue-io/standard",
 				},
 				"genesis": {
 					"runtimeGenesis": {

--- a/crates/pop-cli/src/style.rs
+++ b/crates/pop-cli/src/style.rs
@@ -47,14 +47,25 @@ pub(crate) fn format_url(url: &str) -> String {
 	format!("{}", style(url).bold().underlined())
 }
 
+/// Formats the step label if steps should be shown.
+pub(crate) fn format_step_prefix(current: usize, total: usize, show: bool) -> String {
+	show.then(|| format!("[{}/{}]: ", current, total)).unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use console::Style;
 
 	#[test]
-	fn test_format_provider_url() {
+	fn format_provider_url_works() {
 		let url = "https://example.com";
 		assert_eq!(format_url(url), format!("{}", Style::new().bold().underlined().apply_to(url)));
+	}
+
+	#[test]
+	fn format_step_prefix_works() {
+		assert_eq!(format_step_prefix(2, 5, true), "[2/5]: ");
+		assert_eq!(format_step_prefix(2, 5, false), "");
 	}
 }

--- a/crates/pop-cli/src/style.rs
+++ b/crates/pop-cli/src/style.rs
@@ -41,3 +41,20 @@ impl cliclack::Theme for Theme {
 		"⚙".into()
 	}
 }
+
+/// Formats an URL with bold and underlined style.
+pub(crate) fn format_url(url: &str) -> String {
+	format!("{}", style(url).bold().underlined())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use console::Style;
+
+	#[test]
+	fn test_format_provider_url() {
+		let url = "https://example.com";
+		assert_eq!(format_url(url), format!("{}", Style::new().bold().underlined().apply_to(url)));
+	}
+}

--- a/crates/pop-parachains/src/templates.rs
+++ b/crates/pop-parachains/src/templates.rs
@@ -70,7 +70,7 @@ pub enum Parachain {
 	/// Minimalist parachain template.
 	#[default]
 	#[strum(
-		serialize = "r0gue-io/standard",
+		serialize = "r0gue-io/base-parachain",
 		message = "Standard",
 		detailed_message = "A standard parachain",
 		props(
@@ -84,7 +84,7 @@ pub enum Parachain {
 	Standard,
 	/// Parachain configured with fungible and non-fungible asset functionalities.
 	#[strum(
-		serialize = "r0gue-io/assets",
+		serialize = "r0gue-io/assets-parachain",
 		message = "Assets",
 		detailed_message = "Parachain configured with fungible and non-fungible asset functionalities.",
 		props(
@@ -98,7 +98,7 @@ pub enum Parachain {
 	Assets,
 	/// Parachain configured to support WebAssembly smart contracts.
 	#[strum(
-		serialize = "r0gue-io/contracts",
+		serialize = "r0gue-io/contracts-parachain",
 		message = "Contracts",
 		detailed_message = "Parachain configured to support WebAssembly smart contracts.",
 		props(
@@ -113,7 +113,7 @@ pub enum Parachain {
 	/// Parachain configured with Frontier, enabling compatibility with the Ethereum Virtual
 	/// Machine (EVM).
 	#[strum(
-		serialize = "r0gue-io/evm",
+		serialize = "r0gue-io/evm-parachain",
 		message = "EVM",
 		detailed_message = "Parachain configured with Frontier, enabling compatibility with the Ethereum Virtual Machine (EVM).",
 		props(
@@ -278,10 +278,10 @@ mod tests {
 
 	fn templates_names() -> HashMap<String, Parachain> {
 		HashMap::from([
-			("r0gue-io/standard".to_string(), Standard),
-			("r0gue-io/assets".to_string(), Assets),
-			("r0gue-io/contracts".to_string(), Contracts),
-			("r0gue-io/evm".to_string(), EVM),
+			("r0gue-io/base-parachain".to_string(), Standard),
+			("r0gue-io/assets-parachain".to_string(), Assets),
+			("r0gue-io/contracts-parachain".to_string(), Contracts),
+			("r0gue-io/evm-parachain".to_string(), EVM),
 			// openzeppelin
 			("openzeppelin/generic-template".to_string(), OpenZeppelinGeneric),
 			("openzeppelin/evm-template".to_string(), OpenZeppelinEVM),
@@ -295,10 +295,10 @@ mod tests {
 
 	fn templates_names_without_providers() -> HashMap<Parachain, String> {
 		HashMap::from([
-			(Standard, "standard".to_string()),
-			(Assets, "assets".to_string()),
-			(Contracts, "contracts".to_string()),
-			(EVM, "evm".to_string()),
+			(Standard, "base-parachain".to_string()),
+			(Assets, "assets-parachain".to_string()),
+			(Contracts, "contracts-parachain".to_string()),
+			(EVM, "evm-parachain".to_string()),
 			(OpenZeppelinGeneric, "generic-template".to_string()),
 			(OpenZeppelinEVM, "evm-template".to_string()),
 			(ParityGeneric, "polkadot-sdk-parachain-template".to_string()),
@@ -310,10 +310,16 @@ mod tests {
 
 	fn templates_urls() -> HashMap<String, &'static str> {
 		HashMap::from([
-			("r0gue-io/standard".to_string(), "https://github.com/r0gue-io/base-parachain"),
-			("r0gue-io/assets".to_string(), "https://github.com/r0gue-io/assets-parachain"),
-			("r0gue-io/contracts".to_string(), "https://github.com/r0gue-io/contracts-parachain"),
-			("r0gue-io/evm".to_string(), "https://github.com/r0gue-io/evm-parachain"),
+			("r0gue-io/base-parachain".to_string(), "https://github.com/r0gue-io/base-parachain"),
+			(
+				"r0gue-io/assets-parachain".to_string(),
+				"https://github.com/r0gue-io/assets-parachain",
+			),
+			(
+				"r0gue-io/contracts-parachain".to_string(),
+				"https://github.com/r0gue-io/contracts-parachain",
+			),
+			("r0gue-io/evm-parachain".to_string(), "https://github.com/r0gue-io/evm-parachain"),
 			// openzeppelin
 			(
 				"openzeppelin/generic-template".to_string(),

--- a/crates/pop-parachains/src/templates.rs
+++ b/crates/pop-parachains/src/templates.rs
@@ -70,7 +70,7 @@ pub enum Parachain {
 	/// Minimalist parachain template.
 	#[default]
 	#[strum(
-		serialize = "standard",
+		serialize = "r0gue-io/standard",
 		message = "Standard",
 		detailed_message = "A standard parachain",
 		props(
@@ -84,7 +84,7 @@ pub enum Parachain {
 	Standard,
 	/// Parachain configured with fungible and non-fungible asset functionalities.
 	#[strum(
-		serialize = "assets",
+		serialize = "r0gue-io/assets",
 		message = "Assets",
 		detailed_message = "Parachain configured with fungible and non-fungible asset functionalities.",
 		props(
@@ -98,7 +98,7 @@ pub enum Parachain {
 	Assets,
 	/// Parachain configured to support WebAssembly smart contracts.
 	#[strum(
-		serialize = "contracts",
+		serialize = "r0gue-io/contracts",
 		message = "Contracts",
 		detailed_message = "Parachain configured to support WebAssembly smart contracts.",
 		props(
@@ -113,7 +113,7 @@ pub enum Parachain {
 	/// Parachain configured with Frontier, enabling compatibility with the Ethereum Virtual
 	/// Machine (EVM).
 	#[strum(
-		serialize = "evm",
+		serialize = "r0gue-io/evm",
 		message = "EVM",
 		detailed_message = "Parachain configured with Frontier, enabling compatibility with the Ethereum Virtual Machine (EVM).",
 		props(
@@ -278,10 +278,10 @@ mod tests {
 
 	fn templates_names() -> HashMap<String, Parachain> {
 		HashMap::from([
-			("standard".to_string(), Standard),
-			("assets".to_string(), Assets),
-			("contracts".to_string(), Contracts),
-			("evm".to_string(), EVM),
+			("r0gue-io/standard".to_string(), Standard),
+			("r0gue-io/assets".to_string(), Assets),
+			("r0gue-io/contracts".to_string(), Contracts),
+			("r0gue-io/evm".to_string(), EVM),
 			// openzeppelin
 			("openzeppelin/generic-template".to_string(), OpenZeppelinGeneric),
 			("openzeppelin/evm-template".to_string(), OpenZeppelinEVM),
@@ -310,10 +310,10 @@ mod tests {
 
 	fn templates_urls() -> HashMap<String, &'static str> {
 		HashMap::from([
-			("standard".to_string(), "https://github.com/r0gue-io/base-parachain"),
-			("assets".to_string(), "https://github.com/r0gue-io/assets-parachain"),
-			("contracts".to_string(), "https://github.com/r0gue-io/contracts-parachain"),
-			("evm".to_string(), "https://github.com/r0gue-io/evm-parachain"),
+			("r0gue-io/standard".to_string(), "https://github.com/r0gue-io/base-parachain"),
+			("r0gue-io/assets".to_string(), "https://github.com/r0gue-io/assets-parachain"),
+			("r0gue-io/contracts".to_string(), "https://github.com/r0gue-io/contracts-parachain"),
+			("r0gue-io/evm".to_string(), "https://github.com/r0gue-io/evm-parachain"),
 			// openzeppelin
 			(
 				"openzeppelin/generic-template".to_string(),

--- a/crates/pop-parachains/src/utils/helpers.rs
+++ b/crates/pop-parachains/src/utils/helpers.rs
@@ -110,7 +110,7 @@ mod tests {
 			.contains("properties.insert(\"tokenDecimals\".into(), 6.into());"));
 		assert!(generated_file_content.contains("1000000"));
 		assert!(generated_file_content
-			.contains("properties.insert(\"basedOn\".into(), \"standard\".into());"));
+			.contains("properties.insert(\"basedOn\".into(), \"r0gue-io/standard\".into());"));
 
 		Ok(())
 	}

--- a/crates/pop-parachains/src/utils/helpers.rs
+++ b/crates/pop-parachains/src/utils/helpers.rs
@@ -109,8 +109,9 @@ mod tests {
 		assert!(generated_file_content
 			.contains("properties.insert(\"tokenDecimals\".into(), 6.into());"));
 		assert!(generated_file_content.contains("1000000"));
-		assert!(generated_file_content
-			.contains("properties.insert(\"basedOn\".into(), \"r0gue-io/standard\".into());"));
+		assert!(generated_file_content.contains(
+			"properties.insert(\"basedOn\".into(), \"r0gue-io/base-parachain\".into());"
+		));
 
 		Ok(())
 	}


### PR DESCRIPTION
This PR introduces several UX enhancements and minor improvements gathered from the recent demo.

**Changes:**
-  Pause warning messages briefly for clarity.
- Added direct links to the Portal provider at various points in the flow.
- Improved messaging, when fetching collator keys using a spinner.
-  Prefixed `r0gue` templates for easier identification.
-  Added a `--profile` flag (default: Release) allowing users to specify the profile used when building the chain spec, reducing interactive prompts.
- User guidance: Included numbered steps throughout the flow to better assist first-time users.

![flow](https://github.com/user-attachments/assets/4fc60ac7-5414-4ecc-8b50-2addc56014dc)
