### PR TITLE
chore: update prompts, refactor profile variants, dim weight path description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15664,17 +15664,15 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.2.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
+checksum = "27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
- "displaydoc",
  "indexmap 2.8.0",
  "memchr",
- "thiserror 2.0.11",
 ]
 
 [[package]]

--- a/crates/pop-cli/src/commands/bench/block.rs
+++ b/crates/pop-cli/src/commands/bench/block.rs
@@ -86,13 +86,12 @@ mod tests {
 	use frame_benchmarking_cli::BlockCmd;
 	use pop_common::Profile;
 	use std::fs::{self, File};
-	use strum::{EnumMessage, VariantArray};
 	use tempfile::tempdir;
 
 	use super::BenchmarkBlock;
 
 	#[test]
-	fn benchmark_storage_works() -> anyhow::Result<()> {
+	fn benchmark_block_works() -> anyhow::Result<()> {
 		let name = "node";
 		let temp_dir = tempdir()?;
 		cmd("cargo", ["new", name, "--bin"]).dir(temp_dir.path()).run()?;
@@ -119,23 +118,13 @@ mod tests {
 		.benchmark(&mut cli, temp_dir.path())?;
 		cli.verify()?;
 
-		// Prompt user to select `profile` if not provided.
-		let profiles = Profile::VARIANTS
-			.iter()
-			.map(|profile| {
-				(
-					profile.get_message().unwrap_or(profile.as_ref()).to_string(),
-					profile.get_detailed_message().unwrap_or_default().to_string(),
-				)
-			})
-			.collect();
 		let mut cli = MockCli::new()
 			.expect_intro("Benchmarking the execution time of historic blocks")
 			.expect_select(
 				"Choose the build profile of the binary that should be used: ",
 				Some(true),
 				true,
-				Some(profiles),
+				Some(Profile::get_variants()),
 				0,
 				None,
 			)

--- a/crates/pop-cli/src/commands/bench/machine.rs
+++ b/crates/pop-cli/src/commands/bench/machine.rs
@@ -87,13 +87,12 @@ mod tests {
 	use frame_benchmarking_cli::MachineCmd;
 	use pop_common::Profile;
 	use std::fs::{self, File};
-	use strum::{EnumMessage, VariantArray};
 	use tempfile::tempdir;
 
 	use super::BenchmarkMachine;
 
 	#[test]
-	fn benchmark_storage_works() -> anyhow::Result<()> {
+	fn benchmark_machine_works() -> anyhow::Result<()> {
 		let name = "node";
 		let temp_dir = tempdir()?;
 		cmd("cargo", ["new", name, "--bin"]).dir(temp_dir.path()).run()?;
@@ -121,23 +120,13 @@ mod tests {
 		.benchmark(&mut cli, temp_dir.path())?;
 		cli.verify()?;
 
-		// Prompt user to select `profile` if not provided.
-		let profiles = Profile::VARIANTS
-			.iter()
-			.map(|profile| {
-				(
-					profile.get_message().unwrap_or(profile.as_ref()).to_string(),
-					profile.get_detailed_message().unwrap_or_default().to_string(),
-				)
-			})
-			.collect();
 		let mut cli = MockCli::new()
 			.expect_intro("Benchmarking the hardware")
 			.expect_select(
 				"Choose the build profile of the binary that should be used: ",
 				Some(true),
 				true,
-				Some(profiles),
+				Some(Profile::get_variants()),
 				0,
 				None,
 			)

--- a/crates/pop-cli/src/commands/bench/overhead.rs
+++ b/crates/pop-cli/src/commands/bench/overhead.rs
@@ -21,7 +21,7 @@ const EXCLUDED_ARGS: [&str; 3] = ["--profile", "--skip-config", "-y"];
 
 #[derive(Args)]
 pub(crate) struct BenchmarkOverhead {
-	/// Commmand to benchmark the execution overhead per-block and per-extrinsic.
+	/// Command to benchmark the execution overhead per-block and per-extrinsic.
 	#[clap(flatten)]
 	pub command: OverheadCmd,
 	/// Build profile.
@@ -229,7 +229,6 @@ mod tests {
 		fs::{self, File},
 		path::PathBuf,
 	};
-	use strum::{EnumMessage, VariantArray};
 	use tempfile::tempdir;
 
 	#[test]
@@ -279,15 +278,6 @@ mod tests {
 			.into_iter()
 			.map(|preset| (preset, String::default()))
 			.collect();
-		let profiles = Profile::VARIANTS
-			.iter()
-			.map(|profile| {
-				(
-					profile.get_message().unwrap_or(profile.as_ref()).to_string(),
-					profile.get_detailed_message().unwrap_or_default().to_string(),
-				)
-			})
-			.collect();
 
 		let mut cli = MockCli::new()
 			.expect_intro("Benchmarking the execution overhead per-block and per-extrinsic")
@@ -295,7 +285,7 @@ mod tests {
 				"Choose the build profile of the binary that should be used: ",
 				Some(true),
 				true,
-				Some(profiles),
+				Some(Profile::get_variants()),
 				0,
 				None,
 			)
@@ -304,7 +294,7 @@ mod tests {
 				cwd.display()
 			))
 			.expect_input(
-				"Please provide the path to the runtime.",
+				"Please specify the path to the runtime project or the runtime binary.",
 				runtime_path.to_str().unwrap().to_string(),
 			)
 			.expect_select(

--- a/crates/pop-cli/src/commands/bench/storage.rs
+++ b/crates/pop-cli/src/commands/bench/storage.rs
@@ -128,7 +128,6 @@ mod tests {
 	use frame_benchmarking_cli::StorageCmd;
 	use pop_common::Profile;
 	use std::fs::{self, File};
-	use strum::{EnumMessage, VariantArray};
 	use tempfile::tempdir;
 
 	use super::BenchmarkStorage;
@@ -162,23 +161,13 @@ mod tests {
 		.benchmark(&mut cli, temp_dir.path())?;
 		cli.verify()?;
 
-		// Prompt user to select `profile` if not provided.
-		let profiles = Profile::VARIANTS
-			.iter()
-			.map(|profile| {
-				(
-					profile.get_message().unwrap_or(profile.as_ref()).to_string(),
-					profile.get_detailed_message().unwrap_or_default().to_string(),
-				)
-			})
-			.collect();
 		let mut cli = MockCli::new()
 			.expect_intro("Benchmarking the storage speed of a chain snapshot")
 			.expect_select(
 				"Choose the build profile of the binary that should be used: ",
 				Some(true),
 				true,
-				Some(profiles),
+				Some(Profile::get_variants()),
 				0,
 				None,
 			)

--- a/crates/pop-cli/src/common/bench.rs
+++ b/crates/pop-cli/src/common/bench.rs
@@ -11,7 +11,7 @@ use pop_parachains::{
 use std::{
 	self,
 	ffi::OsStr,
-	fs::{self, File},
+	fs,
 	path::{Path, PathBuf},
 };
 use strum::{EnumMessage, IntoEnumIterator};

--- a/crates/pop-common/src/build.rs
+++ b/crates/pop-common/src/build.rs
@@ -4,6 +4,7 @@ use std::{
 	fmt,
 	path::{Path, PathBuf},
 };
+use strum::{EnumMessage as _, VariantArray as _};
 use strum_macros::{AsRefStr, EnumMessage, EnumString, VariantArray};
 
 /// Enum representing a build profile.
@@ -37,6 +38,19 @@ impl Profile {
 			Profile::Debug => path.join("target/debug"),
 			Profile::Production => path.join("target/production"),
 		}
+	}
+
+	/// Returns the variants of the enum.
+	pub fn get_variants() -> Vec<(String, String)> {
+		Profile::VARIANTS
+			.iter()
+			.map(|profile| {
+				(
+					profile.get_message().unwrap_or(profile.as_ref()).to_string(),
+					profile.get_detailed_message().unwrap_or_default().to_string(),
+				)
+			})
+			.collect()
 	}
 }
 

--- a/crates/pop-parachains/src/bench/mod.rs
+++ b/crates/pop-parachains/src/bench/mod.rs
@@ -153,9 +153,6 @@ pub fn generate_binary_benchmarks<F>(
 where
 	F: Fn(Vec<String>) -> Vec<String>,
 {
-	let temp_file = NamedTempFile::new()?;
-	let temp_path = temp_file.path().to_owned();
-
 	// Get all arguments of the command and skip the program name.
 	let mut args = update_args(std::env::args().skip(3).collect::<Vec<String>>());
 	args = args
@@ -165,13 +162,8 @@ where
 	let mut cmd_args = vec!["benchmark".to_string(), command.to_string()];
 	cmd_args.append(&mut args);
 
-	if let Err(e) = cmd(binary_path, cmd_args).stderr_path(&temp_path).run() {
-		let mut error_output = String::new();
-		std::fs::File::open(&temp_path).unwrap().read_to_string(&mut error_output)?;
-		return Err(anyhow::anyhow!(
-			"Failed to run benchmarking: {}",
-			if error_output.is_empty() { e.to_string() } else { error_output }
-		));
+	if let Err(e) = cmd(binary_path, cmd_args).stderr_capture().run() {
+		return Err(anyhow::anyhow!("Failed to run benchmarking: {}", e.to_string()));
 	}
 	Ok(())
 }

--- a/deny.toml
+++ b/deny.toml
@@ -16,8 +16,8 @@ ignore = [
     { id = "RUSTSEC-2025-0010", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
     { id = "RUSTSEC-2024-0370", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
     { id = "RUSTSEC-2022-0061", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
-    { id = "RUSTSEC-2025-0014", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
     { id = "RUSTSEC-2020-0168", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
+    { id = "RUSTSEC-2025-0017", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Description
- [x] Update prompt of the “save updated parameter”
- [x] Update prompt of the “parameter menu”
- [x] Fix the weight output path when running pop bench pallet to print the actual path instead of the temp path. 