### PR TITLE
feat: canonical command names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tracing-subscriber = "0.3.19"
 
 # networking
 reqwest = { version = "0.12", features = ["json", "multipart", "stream"] }
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "process"] }
 url = "2.5.4"
 
 # contracts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tracing-subscriber = "0.3.19"
 
 # networking
 reqwest = { version = "0.12", features = ["json", "multipart", "stream"] }
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "process"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 url = "2.5.4"
 
 # contracts

--- a/crates/pop-cli/src/commands/bench/mod.rs
+++ b/crates/pop-cli/src/commands/bench/mod.rs
@@ -6,7 +6,7 @@ use clap::{Args, Subcommand};
 use machine::BenchmarkMachine;
 use overhead::BenchmarkOverhead;
 use pallet::BenchmarkPallet;
-use std::fmt;
+use std::fmt::{Display, Formatter, Result};
 use storage::BenchmarkStorage;
 
 mod block;
@@ -56,15 +56,15 @@ impl Command {
 	}
 }
 
-impl fmt::Display for Command {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Display for Command {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
 		use Command::*;
 		match self {
-			Block(_) => write!(f, "bench block"),
-			Machine(_) => write!(f, "bench machine"),
-			Overhead(_) => write!(f, "bench overhead"),
-			Pallet(_) => write!(f, "bench pallet"),
-			Storage(_) => write!(f, "bench storage"),
+			Block(_) => write!(f, "block"),
+			Machine(_) => write!(f, "machine"),
+			Overhead(_) => write!(f, "overhead"),
+			Pallet(_) => write!(f, "pallet"),
+			Storage(_) => write!(f, "storage"),
 		}
 	}
 }
@@ -76,6 +76,6 @@ mod tests {
 	// Others can not be tested yet due to private external types.
 	#[test]
 	fn command_display_works() {
-		assert_eq!(Command::Pallet(Default::default()).to_string(), "bench pallet");
+		assert_eq!(Command::Pallet(Default::default()).to_string(), "pallet");
 	}
 }

--- a/crates/pop-cli/src/commands/bench/mod.rs
+++ b/crates/pop-cli/src/commands/bench/mod.rs
@@ -76,6 +76,6 @@ mod tests {
 	// Others can not be tested yet due to private external types.
 	#[test]
 	fn command_display_works() {
-		assert_eq!(Command::Pallet(Default::default()).to_string(), "pallet");
+		assert_eq!(Command::Pallet(Default::default()).to_string(), "bench pallet");
 	}
 }

--- a/crates/pop-cli/src/commands/bench/mod.rs
+++ b/crates/pop-cli/src/commands/bench/mod.rs
@@ -6,6 +6,7 @@ use clap::{Args, Subcommand};
 use machine::BenchmarkMachine;
 use overhead::BenchmarkOverhead;
 use pallet::BenchmarkPallet;
+use std::fmt;
 use storage::BenchmarkStorage;
 
 mod block;
@@ -16,7 +17,6 @@ mod storage;
 
 /// Arguments for benchmarking a project.
 #[derive(Args)]
-#[command(args_conflicts_with_subcommands = true)]
 pub struct BenchmarkArgs {
 	#[command(subcommand)]
 	pub command: Command,
@@ -53,5 +53,29 @@ impl Command {
 			Command::Pallet(mut cmd) => cmd.execute(&mut cli).await,
 			Command::Storage(mut cmd) => cmd.execute(&mut cli),
 		}
+	}
+}
+
+impl fmt::Display for Command {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		use Command::*;
+		match self {
+			Block(_) => write!(f, "bench block"),
+			Machine(_) => write!(f, "bench machine"),
+			Overhead(_) => write!(f, "bench overhead"),
+			Pallet(_) => write!(f, "bench pallet"),
+			Storage(_) => write!(f, "bench storage"),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// Others can not be tested yet due to private external types.
+	#[test]
+	fn command_display_works() {
+		assert_eq!(Command::Pallet(Default::default()).to_string(), "pallet");
 	}
 }

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -13,7 +13,10 @@ use clap::{Args, Subcommand};
 use contract::BuildContract;
 use duct::cmd;
 use pop_common::Profile;
-use std::{fmt::{Display, Formatter, Result}, path::PathBuf};
+use std::{
+	fmt::{Display, Formatter, Result},
+	path::PathBuf,
+};
 #[cfg(feature = "parachain")]
 use {parachain::BuildParachain, spec::BuildSpecCommand};
 

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -13,7 +13,7 @@ use clap::{Args, Subcommand};
 use contract::BuildContract;
 use duct::cmd;
 use pop_common::Profile;
-use std::path::PathBuf;
+use std::{fmt::{Display, Formatter, Result}, path::PathBuf};
 #[cfg(feature = "parachain")]
 use {parachain::BuildParachain, spec::BuildSpecCommand};
 
@@ -170,6 +170,16 @@ impl Command {
 	}
 }
 
+impl Display for Command {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		match self {
+			#[cfg(feature = "parachain")]
+			Command::Spec(_) => write!(f, "spec"),
+			_ => Ok(()),
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -265,5 +275,10 @@ mod tests {
 		)
 		.is_ok());
 		cli.verify()
+	}
+
+	#[test]
+	fn command_display_works() {
+		assert_eq!(Command::Spec(Default::default()).to_string(), "spec");
 	}
 }

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -191,7 +191,7 @@ pub struct BuildSpecCommand {
 
 impl BuildSpecCommand {
 	/// Executes the build spec command.
-	pub(crate) async fn execute(self) -> anyhow::Result<&'static str> {
+	pub(crate) async fn execute(self) -> anyhow::Result<()> {
 		let mut cli = Cli;
 		cli.intro("Generate your chain spec")?;
 		// Checks for appchain project in `./`.
@@ -205,7 +205,7 @@ impl BuildSpecCommand {
 				"🚫 Can't build a specification for target. Maybe not a chain project ?",
 			)?;
 		}
-		Ok("spec")
+		Ok(())
 	}
 
 	/// Configure chain specification requirements by prompting for missing inputs, validating

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -84,6 +84,7 @@ pub struct CallContractCommand {
 	#[arg(name = "dev", short, long, default_value = "false")]
 	dev_mode: bool,
 }
+
 impl CallContractCommand {
 	/// Executes the command.
 	pub(crate) async fn execute(mut self) -> Result<()> {
@@ -547,6 +548,28 @@ impl CallContractCommand {
 		self.gas_limit = None;
 		self.proof_size = None;
 		self.use_wallet = false;
+	}
+}
+
+#[cfg(test)]
+impl Default for CallContractCommand {
+	fn default() -> Self {
+		Self {
+			path: None,
+			path_pos: None,
+			contract: None,
+			message: None,
+			args: vec![],
+			value: DEFAULT_PAYABLE_VALUE.to_string(),
+			gas_limit: None,
+			proof_size: None,
+			url: url::Url::parse("wss://rpc1.paseo.popnetwork.xyz").unwrap(),
+			suri: "//Alice".to_string(),
+			use_wallet: false,
+			execute: false,
+			dry_run: false,
+			dev_mode: false,
+		}
 	}
 }
 

--- a/crates/pop-cli/src/commands/call/mod.rs
+++ b/crates/pop-cli/src/commands/call/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use clap::{Args, Subcommand};
-
+use std::fmt::{Display, Formatter, Result};
 #[cfg(feature = "parachain")]
 pub(crate) mod chain;
 #[cfg(feature = "contract")]
@@ -26,4 +26,26 @@ pub(crate) enum Command {
 	#[cfg(feature = "contract")]
 	#[clap(alias = "c")]
 	Contract(contract::CallContractCommand),
+}
+
+impl Display for Command {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		match self {
+			#[cfg(feature = "parachain")]
+			Command::Chain(_) => write!(f, "chain"),
+			#[cfg(feature = "contract")]
+			Command::Contract(_) => write!(f, "contract"),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn command_display_works() {
+		assert_eq!(Command::Chain(Default::default()).to_string(), "chain");
+		assert_eq!(Command::Contract(Default::default()).to_string(), "contract");
+	}
 }

--- a/crates/pop-cli/src/commands/clean.rs
+++ b/crates/pop-cli/src/commands/clean.rs
@@ -151,6 +151,13 @@ fn contents(path: &PathBuf) -> Result<Vec<(String, PathBuf, u64)>> {
 }
 
 #[cfg(test)]
+impl Default for CleanArgs {
+	fn default() -> Self {
+		Self { command: Command::Cache(CleanCommandArgs { all: false }) }
+	}
+}
+
+#[cfg(test)]
 mod tests {
 	use super::*;
 	use crate::cli::MockCli;

--- a/crates/pop-cli/src/commands/install/mod.rs
+++ b/crates/pop-cli/src/commands/install/mod.rs
@@ -58,7 +58,7 @@ pub enum Dependencies {
 pub(crate) struct InstallArgs {
 	/// Automatically install all dependencies required without prompting for confirmation.
 	#[clap(short = 'y', long)]
-	pub(crate) skip_confirm: bool,
+	skip_confirm: bool,
 }
 
 /// Setup user environment for development

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -204,11 +204,41 @@ mod tests {
 			(Command::Clean(Default::default()), "clean"),
 			// Test.
 			(Command::Test(test::TestArgs::default()), "test"),
-			(Command::Test(test::TestArgs { command: Some(test::Command::Contract(Default::default())), ..Default::default() }), "test contract"),
-			(Command::Test(test::TestArgs { command: Some(test::Command::OnRuntimeUpgrade(Default::default())), ..Default::default() }), "test on runtime upgrade"),
-			(Command::Test(test::TestArgs { command: Some(test::Command::ExecuteBlock(Default::default())), ..Default::default() }), "test execute block"),
-			(Command::Test(test::TestArgs { command: Some(test::Command::CreateSnapshot(Default::default())), ..Default::default() }), "test create snapshot"),
-			(Command::Test(test::TestArgs { command: Some(test::Command::FastForward(Default::default())), ..Default::default() }), "test fast forward"),
+			(
+				Command::Test(test::TestArgs {
+					command: Some(test::Command::Contract(Default::default())),
+					..Default::default()
+				}),
+				"test contract",
+			),
+			(
+				Command::Test(test::TestArgs {
+					command: Some(test::Command::OnRuntimeUpgrade(Default::default())),
+					..Default::default()
+				}),
+				"test on runtime upgrade",
+			),
+			(
+				Command::Test(test::TestArgs {
+					command: Some(test::Command::ExecuteBlock(Default::default())),
+					..Default::default()
+				}),
+				"test execute block",
+			),
+			(
+				Command::Test(test::TestArgs {
+					command: Some(test::Command::CreateSnapshot(Default::default())),
+					..Default::default()
+				}),
+				"test create snapshot",
+			),
+			(
+				Command::Test(test::TestArgs {
+					command: Some(test::Command::FastForward(Default::default())),
+					..Default::default()
+				}),
+				"test fast forward",
+			),
 			// Build.
 			(Command::Build(build::BuildArgs { command: None, ..Default::default() }), "build"),
 			(

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -79,7 +79,7 @@ impl Command {
 	pub(crate) async fn execute(self) -> anyhow::Result<Data> {
 		match self {
 			#[cfg(any(feature = "parachain", feature = "contract"))]
-			Self::Install(args) => install::Command.execute(args).await.map(|os| Install(os)),
+			Self::Install(args) => install::Command.execute(args).await.map(Install),
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::New(args) => match args.command {
 				#[cfg(feature = "parachain")]

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -5,8 +5,8 @@ use crate::{
 	cli::Cli,
 	common::{
 		builds::get_project_path,
+		Data::{self, *},
 		Project::{self, Network},
-		Telemetry::{self, *},
 		Template::*,
 	},
 };
@@ -76,7 +76,7 @@ fn about_up() -> &'static str {
 
 impl Command {
 	/// Executes the command.
-	pub(crate) async fn execute(self) -> anyhow::Result<Telemetry> {
+	pub(crate) async fn execute(self) -> anyhow::Result<Data> {
 		match self {
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::Install(args) => install::Command.execute(args).await.map(|os| Install(os)),
@@ -93,7 +93,7 @@ impl Command {
 			Self::Bench(args) => bench::Command::execute(args).await.map(|_| Null),
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::Build(args) => match args.command {
-				None => build::Command::execute(args).map(|project| Build(project)),
+				None => build::Command::execute(args).map(Build),
 				Some(cmd) => match cmd {
 					#[cfg(feature = "parachain")]
 					build::Command::Spec(cmd) => cmd.execute().await.map(|_| Null),
@@ -108,7 +108,7 @@ impl Command {
 			},
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::Up(args) => match args.command {
-				None => up::Command::execute(args).await.map(|project| Up(project)),
+				None => up::Command::execute(args).await.map(Up),
 				Some(cmd) => match cmd {
 					#[cfg(feature = "parachain")]
 					up::Command::Network(mut cmd) => {
@@ -167,8 +167,11 @@ impl Display for Command {
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::New(args) => {
 				let new = match &args.command {
+					#[cfg(feature = "parachain")]
 					new::Command::Parachain(_) => "new chain",
+					#[cfg(feature = "parachain")]
 					new::Command::Pallet(_) => "new pallet",
+					#[cfg(feature = "contract")]
 					new::Command::Contract(_) => "new contract",
 				};
 				write!(f, "{}", new)
@@ -176,15 +179,18 @@ impl Display for Command {
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::Build(args) => {
 				let build = match &args.command {
+					#[cfg(feature = "parachain")]
 					Some(build::Command::Spec(_)) => "build spec",
-					None => "build",
+					_ => "build",
 				};
 				write!(f, "{}", build)
 			},
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::Call(args) => {
 				let call = match &args.command {
+					#[cfg(feature = "parachain")]
 					call::Command::Chain(_) => "call chain",
+					#[cfg(feature = "contract")]
 					call::Command::Contract(_) => "call contract",
 				};
 				write!(f, "{}", call)
@@ -192,8 +198,11 @@ impl Display for Command {
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::Up(args) => {
 				let up = match &args.command {
+					#[cfg(feature = "parachain")]
 					Some(up::Command::Network(_)) => "up network",
+					#[cfg(feature = "parachain")]
 					Some(up::Command::Parachain(_)) => "up chain",
+					#[cfg(feature = "contract")]
 					Some(up::Command::Contract(_)) => "up contract",
 					_ => "up",
 				};

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::{cache, cli::Cli, common::builds::get_project_path};
+use crate::{
+	cache,
+	cli::Cli,
+	common::{
+		builds::get_project_path,
+		Project::{self, Network},
+		Telemetry::{self, *},
+		Template::*,
+	},
+};
 use clap::Subcommand;
-use pop_common::templates::Template;
-use serde_json::{json, Value};
-
+use std::fmt::{Display, Formatter, Result};
 #[cfg(feature = "parachain")]
 pub(crate) mod bench;
 pub(crate) mod build;
@@ -69,77 +76,67 @@ fn about_up() -> &'static str {
 
 impl Command {
 	/// Executes the command.
-	pub(crate) async fn execute(self) -> anyhow::Result<Value> {
+	pub(crate) async fn execute(self) -> anyhow::Result<Telemetry> {
 		match self {
 			#[cfg(any(feature = "parachain", feature = "contract"))]
-			Self::Install(args) => install::Command.execute(args).await.map(|_| Value::Null),
+			Self::Install(args) => install::Command.execute(args).await.map(|os| Install(os)),
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::New(args) => match args.command {
 				#[cfg(feature = "parachain")]
-				new::Command::Parachain(cmd) => match cmd.execute().await {
-					Ok(template) => {
-						// telemetry should never cause a panic or early exit
-						Ok(
-							json!({template.template_type().unwrap_or("provider-missing"): template.name()}),
-						)
-					},
-					Err(e) => Err(e),
-				},
+				new::Command::Parachain(cmd) => cmd.execute().await.map(|p| New(Chain(p))),
 				#[cfg(feature = "parachain")]
-				new::Command::Pallet(cmd) => {
-					// When more contract selections are added the tel data will likely need to go
-					// deeper in the stack
-					cmd.execute().await.map(|_| json!("template"))
-				},
+				new::Command::Pallet(cmd) => cmd.execute().await.map(|_| New(Pallet)),
 				#[cfg(feature = "contract")]
-				new::Command::Contract(cmd) => {
-					// When more contract selections are added, the tel data will likely need to go
-					// deeper in the stack
-					cmd.execute().await.map(|_| json!("default"))
-				},
+				new::Command::Contract(cmd) => cmd.execute().await.map(|c| New(Contract(c))),
 			},
 			#[cfg(feature = "parachain")]
-			Self::Bench(args) => bench::Command::execute(args).await.map(|_| Value::Null),
+			Self::Bench(args) => bench::Command::execute(args).await.map(|_| Null),
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::Build(args) => match args.command {
-				None => build::Command::execute(args).map(|t| json!(t)),
+				None => build::Command::execute(args).map(|project| Build(project)),
 				Some(cmd) => match cmd {
 					#[cfg(feature = "parachain")]
-					build::Command::Spec(cmd) => cmd.execute().await.map(|_| Value::Null),
+					build::Command::Spec(cmd) => cmd.execute().await.map(|_| Null),
 				},
 			},
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::Call(args) => match args.command {
 				#[cfg(feature = "parachain")]
-				call::Command::Chain(cmd) => cmd.execute().await.map(|_| Value::Null),
+				call::Command::Chain(cmd) => cmd.execute().await.map(|_| Null),
 				#[cfg(feature = "contract")]
-				call::Command::Contract(cmd) => cmd.execute().await.map(|_| Value::Null),
+				call::Command::Contract(cmd) => cmd.execute().await.map(|_| Null),
 			},
 			#[cfg(any(feature = "parachain", feature = "contract"))]
 			Self::Up(args) => match args.command {
-				None => up::Command::execute(args).await.map(|t| json!(t)),
+				None => up::Command::execute(args).await.map(|project| Up(project)),
 				Some(cmd) => match cmd {
 					#[cfg(feature = "parachain")]
 					up::Command::Network(mut cmd) => {
 						cmd.valid = true;
-						cmd.execute().await.map(|_| Value::Null)
+						cmd.execute().await.map(|_| Up(Network))
 					},
 					// TODO: Deprecated, will be removed in v0.8.0.
 					#[cfg(feature = "parachain")]
-					up::Command::Parachain(cmd) => cmd.execute().await.map(|_| Value::Null),
+					up::Command::Parachain(cmd) => cmd.execute().await.map(|_| Null),
 					// TODO: Deprecated, will be removed in v0.8.0.
 					#[cfg(feature = "contract")]
 					up::Command::Contract(mut cmd) => {
 						cmd.path = get_project_path(args.path, args.path_pos);
-						cmd.execute().await.map(|_| Value::Null)
+						cmd.execute().await.map(|_| Null)
 					},
 				},
 			},
 			Self::Test(args) => match args.command {
-				None => test::Command::execute(args).await.map(|t| json!(t)),
+				None => test::Command::execute(args)
+					.await
+					.map(|(project, feature)| Test { project, feature }),
+				// TODO: Deprecated, will be removed in v0.8.0.
 				Some(cmd) => match cmd {
 					#[cfg(feature = "contract")]
-					test::Command::Contract(cmd) => cmd.execute(&mut Cli).await.map(|t| json!(t)),
+					test::Command::Contract(cmd) => cmd
+						.execute(&mut Cli)
+						.await
+						.map(|feature| Test { project: Project::Contract, feature }),
 					#[cfg(feature = "parachain")]
 					test::Command::OnRuntimeUpgrade(cmd) => cmd.execute(&mut Cli).await.map(|t| json!(t)),
 					#[cfg(feature = "parachain")]
@@ -155,9 +152,145 @@ impl Command {
 					// Initialize command and execute
 					clean::CleanCacheCommand { cli: &mut Cli, cache: cache()?, all: cmd_args.all }
 						.execute()
-						.map(|_| Value::Null)
+						.map(|_| Null)
 				},
 			},
+		}
+	}
+}
+
+impl Display for Command {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		match self {
+			#[cfg(any(feature = "parachain", feature = "contract"))]
+			Self::Install(_) => write!(f, "install"),
+			#[cfg(any(feature = "parachain", feature = "contract"))]
+			Self::New(args) => {
+				let new = match &args.command {
+					new::Command::Parachain(_) => "new chain",
+					new::Command::Pallet(_) => "new pallet",
+					new::Command::Contract(_) => "new contract",
+				};
+				write!(f, "{}", new)
+			},
+			#[cfg(any(feature = "parachain", feature = "contract"))]
+			Self::Build(args) => {
+				let build = match &args.command {
+					Some(build::Command::Spec(_)) => "build spec",
+					None => "build",
+				};
+				write!(f, "{}", build)
+			},
+			#[cfg(any(feature = "parachain", feature = "contract"))]
+			Self::Call(args) => {
+				let call = match &args.command {
+					call::Command::Chain(_) => "call chain",
+					call::Command::Contract(_) => "call contract",
+				};
+				write!(f, "{}", call)
+			},
+			#[cfg(any(feature = "parachain", feature = "contract"))]
+			Self::Up(args) => {
+				let up = match &args.command {
+					Some(up::Command::Network(_)) => "up network",
+					Some(up::Command::Parachain(_)) => "up chain",
+					Some(up::Command::Contract(_)) => "up contract",
+					_ => "up",
+				};
+				write!(f, "{}", up)
+			},
+			#[cfg(any(feature = "parachain", feature = "contract"))]
+			Self::Test(_) => write!(f, "test"),
+			Self::Clean(_) => write!(f, "clean"),
+			#[cfg(feature = "parachain")]
+			Self::Bench(args) => {
+				write!(f, "{}", args.command)
+			},
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[cfg(all(feature = "parachain", feature = "contract"))]
+	#[test]
+	fn command_display_works() {
+		let test_cases = vec![
+			// Install.
+			(Command::Install(Default::default()), "install"),
+			// Clean.
+			(Command::Clean(Default::default()), "clean"),
+			// Test.
+			(Command::Test(test::TestArgs::default()), "test"),
+			// Build.
+			(Command::Build(build::BuildArgs { command: None, ..Default::default() }), "build"),
+			(
+				Command::Build(build::BuildArgs {
+					command: Some(build::Command::Spec(Default::default())),
+					..Default::default()
+				}),
+				"build spec",
+			),
+			// Up.
+			(Command::Up(up::UpArgs { command: None, ..Default::default() }), "up"),
+			(
+				Command::Up(up::UpArgs {
+					command: Some(up::Command::Network(Default::default())),
+					..Default::default()
+				}),
+				"up network",
+			),
+			(
+				Command::Up(up::UpArgs {
+					command: Some(up::Command::Parachain(Default::default())),
+					..Default::default()
+				}),
+				"up chain",
+			),
+			(
+				Command::Up(up::UpArgs {
+					command: Some(up::Command::Contract(Default::default())),
+					..Default::default()
+				}),
+				"up contract",
+			),
+			// Call.
+			(
+				Command::Call(call::CallArgs { command: call::Command::Chain(Default::default()) }),
+				"call chain",
+			),
+			(
+				Command::Call(call::CallArgs {
+					command: call::Command::Contract(Default::default()),
+				}),
+				"call contract",
+			),
+			// New.
+			(
+				Command::New(new::NewArgs { command: new::Command::Parachain(Default::default()) }),
+				"new chain",
+			),
+			(
+				Command::New(new::NewArgs { command: new::Command::Pallet(Default::default()) }),
+				"new pallet",
+			),
+			(
+				Command::New(new::NewArgs { command: new::Command::Contract(Default::default()) }),
+				"new contract",
+			),
+			// Bench.
+			(
+				Command::Bench(bench::BenchmarkArgs {
+					command: bench::Command::Pallet(Default::default()),
+				}),
+				"bench pallet",
+			),
+		];
+
+		for (command, expected) in test_cases {
+			assert_eq!(command.to_string(), expected);
 		}
 	}
 }

--- a/crates/pop-cli/src/commands/new/contract.rs
+++ b/crates/pop-cli/src/commands/new/contract.rs
@@ -26,6 +26,7 @@ use std::{
 use strum::VariantArray;
 
 #[derive(Args, Clone)]
+#[cfg_attr(test, derive(Default))]
 pub struct NewContractCommand {
 	/// The name of the contract.
 	pub(crate) name: Option<String>,
@@ -44,7 +45,7 @@ pub struct NewContractCommand {
 
 impl NewContractCommand {
 	/// Executes the command.
-	pub(crate) async fn execute(self) -> Result<()> {
+	pub(crate) async fn execute(self) -> Result<Contract> {
 		// If the user doesn't provide a name, guide them in generating a contract.
 		let contract_config = if self.name.is_none() {
 			guide_user_to_generate_contract().await?
@@ -62,7 +63,7 @@ impl NewContractCommand {
 		// Validate contract name.
 		if let Err(e) = is_valid_contract_name(name) {
 			Cli.outro_cancel(e)?;
-			return Ok(());
+			return Ok(Contract::Standard);
 		}
 
 		let contract_type = &contract_config.contract_type.clone().unwrap_or_default();
@@ -79,7 +80,7 @@ impl NewContractCommand {
 			add_crate_to_workspace(&workspace_toml, path)?;
 		}
 
-		Ok(())
+		Ok(template)
 	}
 }
 

--- a/crates/pop-cli/src/commands/new/mod.rs
+++ b/crates/pop-cli/src/commands/new/mod.rs
@@ -74,4 +74,3 @@ mod tests {
 		assert_eq!(Command::Contract(Default::default()).to_string(), "contract");
 	}
 }
-

--- a/crates/pop-cli/src/commands/new/mod.rs
+++ b/crates/pop-cli/src/commands/new/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use clap::{Args, Subcommand};
-
+use std::fmt::{Display, Formatter, Result};
 #[cfg(feature = "contract")]
 pub mod contract;
 #[cfg(feature = "parachain")]
@@ -46,3 +46,32 @@ pub enum Command {
 	#[clap(alias = "c")]
 	Contract(contract::NewContractCommand),
 }
+
+impl Display for Command {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		match self {
+			#[cfg(feature = "parachain")]
+			Command::Parachain(_) => write!(f, "chain"),
+			#[cfg(feature = "parachain")]
+			Command::Pallet(_) => write!(f, "pallet"),
+			#[cfg(feature = "contract")]
+			Command::Contract(_) => write!(f, "contract"),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn command_display_works() {
+		#[cfg(feature = "parachain")]
+		assert_eq!(Command::Parachain(Default::default()).to_string(), "chain");
+		#[cfg(feature = "parachain")]
+		assert_eq!(Command::Pallet(Default::default()).to_string(), "pallet");
+		#[cfg(feature = "contract")]
+		assert_eq!(Command::Contract(Default::default()).to_string(), "contract");
+	}
+}
+

--- a/crates/pop-cli/src/commands/new/pallet.rs
+++ b/crates/pop-cli/src/commands/new/pallet.rs
@@ -39,6 +39,7 @@ fn after_help_advanced() -> &'static str {
 }
 
 #[derive(Args)]
+#[cfg_attr(test, derive(Default))]
 #[command(after_help= after_help_simple())]
 pub struct NewPalletCommand {
 	#[arg(help = "Name of the pallet")]

--- a/crates/pop-cli/src/commands/new/parachain.rs
+++ b/crates/pop-cli/src/commands/new/parachain.rs
@@ -28,6 +28,7 @@ use strum::VariantArray;
 const DEFAULT_INITIAL_ENDOWMENT: &str = "1u64 << 60";
 
 #[derive(Args, Clone)]
+#[cfg_attr(test, derive(Default))]
 pub struct NewParachainCommand {
 	#[arg(help = "Name of the project. If empty assistance in the process will be provided.")]
 	pub(crate) name: Option<String>,

--- a/crates/pop-cli/src/commands/test/contract.rs
+++ b/crates/pop-cli/src/commands/test/contract.rs
@@ -4,7 +4,7 @@ use crate::{
 	cli,
 	common::{
 		contracts::check_contracts_node_and_prompt,
-		Feature::{self, *},
+		TestFeature::{self, *},
 	},
 };
 use clap::Args;
@@ -21,12 +21,12 @@ pub(crate) struct TestContractCommand {
 	pub(crate) path: Option<PathBuf>,
 	/// Run end-to-end tests
 	#[arg(short, long)]
-	pub(crate) e2e: bool,
+	e2e: bool,
 	#[arg(short, long, help = "Path to the contracts node to run e2e tests [default: none]")]
-	pub(crate) node: Option<PathBuf>,
+	node: Option<PathBuf>,
 	/// Automatically source the needed binary required without prompting for confirmation.
 	#[clap(short = 'y', long)]
-	pub(crate) skip_confirm: bool,
+	skip_confirm: bool,
 }
 
 impl TestContractCommand {
@@ -34,7 +34,7 @@ impl TestContractCommand {
 	pub(crate) async fn execute(
 		mut self,
 		cli: &mut impl cli::traits::Cli,
-	) -> anyhow::Result<Feature> {
+	) -> anyhow::Result<TestFeature> {
 		if self.e2e {
 			cli.intro("Starting end-to-end tests")?;
 

--- a/crates/pop-cli/src/commands/test/contract.rs
+++ b/crates/pop-cli/src/commands/test/contract.rs
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::{cli, common::contracts::check_contracts_node_and_prompt};
+use crate::{
+	cli,
+	common::{
+		contracts::check_contracts_node_and_prompt,
+		Feature::{self, *},
+	},
+};
 use clap::Args;
 use pop_common::test_project;
 use pop_contracts::test_e2e_smart_contract;
@@ -15,12 +21,12 @@ pub(crate) struct TestContractCommand {
 	pub(crate) path: Option<PathBuf>,
 	/// Run end-to-end tests
 	#[arg(short, long)]
-	e2e: bool,
+	pub(crate) e2e: bool,
 	#[arg(short, long, help = "Path to the contracts node to run e2e tests [default: none]")]
-	node: Option<PathBuf>,
+	pub(crate) node: Option<PathBuf>,
 	/// Automatically source the needed binary required without prompting for confirmation.
 	#[clap(short = 'y', long)]
-	skip_confirm: bool,
+	pub(crate) skip_confirm: bool,
 }
 
 impl TestContractCommand {
@@ -28,7 +34,7 @@ impl TestContractCommand {
 	pub(crate) async fn execute(
 		mut self,
 		cli: &mut impl cli::traits::Cli,
-	) -> anyhow::Result<&'static str> {
+	) -> anyhow::Result<Feature> {
 		if self.e2e {
 			cli.intro("Starting end-to-end tests")?;
 
@@ -48,12 +54,12 @@ impl TestContractCommand {
 
 			test_e2e_smart_contract(self.path.as_deref(), self.node.as_deref())?;
 			cli.outro("End-to-end testing complete")?;
-			Ok("e2e")
+			Ok(E2e)
 		} else {
 			cli.intro("Starting unit tests")?;
 			test_project(self.path.as_deref())?;
 			cli.outro("Unit testing complete")?;
-			Ok("unit")
+			Ok(Unit)
 		}
 	}
 }

--- a/crates/pop-cli/src/commands/test/mod.rs
+++ b/crates/pop-cli/src/commands/test/mod.rs
@@ -10,7 +10,10 @@ use crate::{
 };
 use clap::{Args, Subcommand};
 use pop_common::test_project;
-use std::{fmt::{Display, Formatter, Result}, path::PathBuf};
+use std::{
+	fmt::{Display, Formatter, Result},
+	path::PathBuf,
+};
 
 #[cfg(feature = "contract")]
 pub mod contract;

--- a/crates/pop-cli/src/commands/test/mod.rs
+++ b/crates/pop-cli/src/commands/test/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use clap::{Args, Subcommand};
 use pop_common::test_project;
-use std::path::PathBuf;
+use std::{fmt::{Display, Formatter, Result}, path::PathBuf};
 
 #[cfg(feature = "contract")]
 pub mod contract;
@@ -91,6 +91,23 @@ impl Command {
 	}
 }
 
+impl Display for Command {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		match self {
+			#[cfg(feature = "parachain")]
+			Command::OnRuntimeUpgrade(_) => write!(f, "on runtime upgrade"),
+			#[cfg(feature = "parachain")]
+			Command::ExecuteBlock(_) => write!(f, "execute block"),
+			#[cfg(feature = "parachain")]
+			Command::FastForward(_) => write!(f, "fast forward"),
+			#[cfg(feature = "parachain")]
+			Command::CreateSnapshot(_) => write!(f, "create snapshot"),
+			#[cfg(feature = "contract")]
+			Command::Contract(_) => write!(f, "contract"),
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -133,5 +150,19 @@ mod tests {
 		let mut cli = MockCli::new();
 		assert_eq!(Command::test(args, &mut cli).await?, (Unknown, Unit));
 		cli.verify()
+	}
+
+	#[test]
+	fn command_display_works() {
+		#[cfg(feature = "parachain")]
+		assert_eq!(Command::OnRuntimeUpgrade(Default::default()).to_string(), "on runtime upgrade");
+		#[cfg(feature = "parachain")]
+		assert_eq!(Command::ExecuteBlock(Default::default()).to_string(), "execute block");
+		#[cfg(feature = "parachain")]
+		assert_eq!(Command::FastForward(Default::default()).to_string(), "fast forward");
+		#[cfg(feature = "parachain")]
+		assert_eq!(Command::CreateSnapshot(Default::default()).to_string(), "create snapshot");
+		#[cfg(feature = "contract")]
+		assert_eq!(Command::Contract(Default::default()).to_string(), "contract");
 	}
 }

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -426,6 +426,27 @@ fn display_contract_info(spinner: &ProgressBar, address: String, code_hash: Opti
 	));
 }
 
+impl Default for UpContractCommand {
+	fn default() -> Self {
+		Self {
+			path: None,
+			constructor: "new".to_string(),
+			args: vec![],
+			value: "0".to_string(),
+			gas_limit: None,
+			proof_size: None,
+			salt: None,
+			url: Url::parse("ws://localhost:9944").expect("default url is valid"),
+			suri: "//Alice".to_string(),
+			use_wallet: false,
+			dry_run: false,
+			upload_only: false,
+			skip_confirm: false,
+			valid: true,
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -440,25 +461,6 @@ mod tests {
 	use tempfile::TempDir;
 	use tokio::time::sleep;
 	use url::Url;
-
-	fn default_up_contract_command() -> UpContractCommand {
-		UpContractCommand {
-			path: None,
-			constructor: "new".to_string(),
-			args: vec![],
-			value: "0".to_string(),
-			gas_limit: None,
-			proof_size: None,
-			salt: None,
-			url: Url::parse("ws://localhost:9944").expect("default url is valid"),
-			suri: "//Alice".to_string(),
-			dry_run: false,
-			upload_only: false,
-			skip_confirm: false,
-			use_wallet: false,
-			valid: true,
-		}
-	}
 
 	async fn start_test_environment() -> anyhow::Result<(Child, u16, TempDir)> {
 		let random_port = find_free_port(None);
@@ -484,7 +486,7 @@ mod tests {
 
 	#[test]
 	fn conversion_up_contract_command_to_up_opts_works() -> anyhow::Result<()> {
-		let command = default_up_contract_command();
+		let command = UpContractCommand::default();
 		let opts: UpOpts = command.into();
 		assert_eq!(
 			opts,

--- a/crates/pop-cli/src/commands/up/mod.rs
+++ b/crates/pop-cli/src/commands/up/mod.rs
@@ -183,7 +183,7 @@ mod tests {
 			DeploymentProvider::VARIANTS.len(), // Register
 			None,
 		);
-		assert_eq!(Command::execute_project_deployment(args, &mut cli).await?, Project::Chain);
+		assert_eq!(Command::execute_project_deployment(args, &mut cli).await?, Chain);
 		cli.verify()
 	}
 
@@ -199,7 +199,7 @@ mod tests {
 		let mut cli = MockCli::new().expect_warning(
 			"No contract or rollup detected. Ensure you are in a valid project directory.",
 		);
-		assert_eq!(Command::execute_project_deployment(args, &mut cli).await?, Project::Unknown);
+		assert_eq!(Command::execute_project_deployment(args, &mut cli).await?, Unknown);
 		cli.verify()
 	}
 }

--- a/crates/pop-cli/src/commands/up/mod.rs
+++ b/crates/pop-cli/src/commands/up/mod.rs
@@ -8,7 +8,10 @@ use crate::{
 	},
 };
 use clap::{Args, Subcommand};
-use std::{fmt::{Display, Formatter, Result}, path::PathBuf};
+use std::{
+	fmt::{Display, Formatter, Result},
+	path::PathBuf,
+};
 
 #[cfg(feature = "contract")]
 mod contract;

--- a/crates/pop-cli/src/commands/up/mod.rs
+++ b/crates/pop-cli/src/commands/up/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 	},
 };
 use clap::{Args, Subcommand};
-use std::path::PathBuf;
+use std::{fmt::{Display, Formatter, Result}, path::PathBuf};
 
 #[cfg(feature = "contract")]
 mod contract;
@@ -92,6 +92,19 @@ impl Command {
 			"No contract or rollup detected. Ensure you are in a valid project directory.",
 		)?;
 		Ok(Unknown)
+	}
+}
+
+impl Display for Command {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		match self {
+			#[cfg(feature = "parachain")]
+			Command::Network(_) => write!(f, "network"),
+			#[cfg(feature = "parachain")]
+			Command::Parachain(_) => write!(f, "chain"),
+			#[cfg(feature = "contract")]
+			Command::Contract(_) => write!(f, "contract"),
+		}
 	}
 }
 
@@ -201,5 +214,12 @@ mod tests {
 		);
 		assert_eq!(Command::execute_project_deployment(args, &mut cli).await?, Unknown);
 		cli.verify()
+	}
+
+	#[test]
+	fn command_display_works() {
+		assert_eq!(Command::Network(Default::default()).to_string(), "network");
+		assert_eq!(Command::Parachain(Default::default()).to_string(), "chain");
+		assert_eq!(Command::Contract(Default::default()).to_string(), "contract");
 	}
 }

--- a/crates/pop-cli/src/commands/up/mod.rs
+++ b/crates/pop-cli/src/commands/up/mod.rs
@@ -2,7 +2,10 @@
 
 use crate::{
 	cli::{self, Cli},
-	common::builds::get_project_path,
+	common::{
+		builds::get_project_path,
+		Project::{self, *},
+	},
 };
 use clap::{Args, Subcommand};
 use std::path::PathBuf;
@@ -16,6 +19,7 @@ mod rollup;
 
 /// Arguments for launching or deploying a project.
 #[derive(Args, Clone)]
+#[cfg_attr(test, derive(Default))]
 #[command(args_conflicts_with_subcommands = true)]
 pub(crate) struct UpArgs {
 	/// Path to the project directory.
@@ -58,7 +62,7 @@ pub(crate) enum Command {
 
 impl Command {
 	/// Executes the command.
-	pub(crate) async fn execute(args: UpArgs) -> anyhow::Result<&'static str> {
+	pub(crate) async fn execute(args: UpArgs) -> anyhow::Result<Project> {
 		Self::execute_project_deployment(args, &mut Cli).await
 	}
 
@@ -66,7 +70,7 @@ impl Command {
 	async fn execute_project_deployment(
 		args: UpArgs,
 		cli: &mut impl cli::traits::Cli,
-	) -> anyhow::Result<&'static str> {
+	) -> anyhow::Result<Project> {
 		let project_path = get_project_path(args.path.clone(), args.path_pos.clone());
 		// If only contract feature enabled, deploy a contract
 		#[cfg(feature = "contract")]
@@ -75,19 +79,19 @@ impl Command {
 			cmd.path = project_path;
 			cmd.valid = true; // To handle deprecated command, remove in v0.8.0.
 			cmd.execute().await?;
-			return Ok("contract");
+			return Ok(Contract);
 		}
 		#[cfg(feature = "parachain")]
 		if pop_parachains::is_supported(project_path.as_deref())? {
 			let mut cmd = args.rollup;
 			cmd.path = project_path;
 			cmd.execute(cli).await?;
-			return Ok("parachain");
+			return Ok(Chain);
 		}
 		cli.warning(
 			"No contract or rollup detected. Ensure you are in a valid project directory.",
 		)?;
-		Ok("")
+		Ok(Unknown)
 	}
 }
 
@@ -140,7 +144,7 @@ mod tests {
 		)?;
 		let args = create_up_args(temp_dir.path().join("testing"))?;
 		let mut cli = MockCli::new();
-		assert_eq!(Command::execute_project_deployment(args, &mut cli).await?, "contract");
+		assert_eq!(Command::execute_project_deployment(args, &mut cli).await?, Project::Contract);
 		cli.verify()
 	}
 
@@ -179,7 +183,7 @@ mod tests {
 			DeploymentProvider::VARIANTS.len(), // Register
 			None,
 		);
-		assert_eq!(Command::execute_project_deployment(args, &mut cli).await?, "parachain");
+		assert_eq!(Command::execute_project_deployment(args, &mut cli).await?, Project::Chain);
 		cli.verify()
 	}
 
@@ -195,7 +199,7 @@ mod tests {
 		let mut cli = MockCli::new().expect_warning(
 			"No contract or rollup detected. Ensure you are in a valid project directory.",
 		);
-		assert_eq!(Command::execute_project_deployment(args, &mut cli).await?, "");
+		assert_eq!(Command::execute_project_deployment(args, &mut cli).await?, Project::Unknown);
 		cli.verify()
 	}
 }

--- a/crates/pop-cli/src/commands/up/network.rs
+++ b/crates/pop-cli/src/commands/up/network.rs
@@ -14,6 +14,7 @@ use std::{path::Path, time::Duration};
 use tokio::time::sleep;
 
 #[derive(Args, Clone)]
+#[cfg_attr(test, derive(Default))]
 pub(crate) struct ZombienetCommand {
 	/// The Zombienet network configuration file to be used.
 	#[arg(short, long)]

--- a/crates/pop-cli/src/common/mod.rs
+++ b/crates/pop-cli/src/common/mod.rs
@@ -23,7 +23,7 @@ pub mod wallet;
 use std::fmt::{Display, Formatter, Result};
 use strum::VariantArray;
 
-/// Data after command execution.
+/// Data returned after command execution.
 #[derive(Debug, PartialEq)]
 pub enum Data {
 	/// Project that was built.
@@ -41,7 +41,7 @@ pub enum Data {
 	Install(Os),
 	/// Template that was created.
 	New(Template),
-	/// No additional telemetry data.
+	/// No additional data.
 	Null,
 }
 

--- a/crates/pop-cli/src/common/mod.rs
+++ b/crates/pop-cli/src/common/mod.rs
@@ -19,3 +19,219 @@ pub mod runtime;
 #[cfg(feature = "parachain")]
 pub mod try_runtime;
 pub mod wallet;
+
+use std::fmt::{Display, Formatter, Result};
+use strum::VariantArray;
+
+#[derive(Debug, PartialEq)]
+pub enum Telemetry {
+	Null,
+	Build(Project),
+	Test { project: Project, feature: Feature },
+	Install(Os),
+	Up(Project),
+	New(Template),
+}
+
+/// Represents the type of project being operated on.
+#[derive(Debug, PartialEq, Clone, VariantArray)]
+pub enum Project {
+	Network,
+	/// A blockchain project (parachain, etc.).
+	Chain,
+	/// A smart contract project.
+	Contract,
+	/// Unknown project type.
+	Unknown,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Template {
+	Chain(pop_parachains::Parachain),
+	Contract(pop_contracts::Contract),
+	Pallet,
+}
+
+#[derive(Debug, PartialEq, Clone, VariantArray)]
+pub enum Feature {
+	Unit,
+	E2e,
+}
+
+#[derive(Debug, PartialEq, Clone, VariantArray)]
+pub enum Os {
+	Mac,
+	Linux,
+	Unsupported,
+}
+
+// Display the telemetry in a human-readable format while excluding the command name to prevent
+// double display.
+impl Display for Telemetry {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		use strum::EnumMessage;
+		use Telemetry::*;
+		use Template::*;
+
+		match self {
+			Null => write!(f, "null"),
+			Build(project) => write!(f, "{}", project),
+			Test { project, feature } => write!(f, "{} {}", project, feature),
+			Install(os) => write!(f, "{}", os),
+			Up(project) => write!(f, "{}", project),
+			New(template) => {
+				match template {
+					// Chain(chain) => write!(f, "{}", chain.get_str("Message").unwrap_or("")),
+					Chain(chain) => write!(f, "{}", chain.get_message().unwrap_or("")),
+					Contract(contract) => write!(f, "{}", contract.get_message().unwrap_or("")),
+					Pallet => write!(f, "pallet"),
+				}
+			},
+		}
+	}
+}
+
+impl Display for Project {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		use Project::*;
+		match self {
+			Network => write!(f, "network"),
+			Chain => write!(f, "chain"),
+			Contract => write!(f, "contract"),
+			Unknown => write!(f, "unknown"),
+		}
+	}
+}
+
+impl Display for Template {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		use Template::*;
+		match self {
+			Chain(chain) => write!(f, "{}", chain),
+			Contract(contract) => write!(f, "{}", contract),
+			Pallet => write!(f, "pallet"),
+		}
+	}
+}
+impl Display for Os {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		use Os::*;
+		match self {
+			Mac => write!(f, "mac"),
+			Linux => write!(f, "linux"),
+			Unsupported => write!(f, "unsupported"),
+		}
+	}
+}
+
+impl Display for Feature {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		use Feature::*;
+		match self {
+			Unit => write!(f, "unit"),
+			E2e => write!(f, "e2e"),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use strum::VariantArray;
+
+	#[test]
+	fn telemetry_display_works() {
+		// Null.
+		assert_eq!(Telemetry::Null.to_string(), "null");
+
+		// Build.
+		for project in Project::VARIANTS {
+			let telemetry = Telemetry::Build(project.clone());
+			assert_eq!(telemetry.to_string(), project.to_string());
+		}
+
+		// Test.
+		for project in Project::VARIANTS {
+			for feature in Feature::VARIANTS {
+				let telemetry =
+					Telemetry::Test { project: project.clone(), feature: feature.clone() };
+				assert_eq!(telemetry.to_string(), format!("{} {}", project, feature));
+			}
+		}
+
+		// Install.
+		for os in Os::VARIANTS {
+			let telemetry = Telemetry::Install(os.clone());
+			assert_eq!(telemetry.to_string(), os.to_string());
+		}
+
+		// Up.
+		for project in Project::VARIANTS {
+			let telemetry = Telemetry::Up(project.clone());
+			assert_eq!(telemetry.to_string(), project.to_string());
+		}
+
+		// New.
+		assert_eq!(Telemetry::New(Template::Pallet).to_string(), "pallet");
+
+		assert_eq!(
+			Telemetry::New(Template::Chain(pop_parachains::Parachain::Contracts)).to_string(),
+			"Contracts"
+		);
+		assert_eq!(
+			Telemetry::New(Template::Contract(pop_contracts::Contract::ERC20)).to_string(),
+			"Erc20"
+		);
+	}
+
+	#[test]
+	fn project_display_works() {
+		for project in Project::VARIANTS {
+			let expected = match project {
+				Project::Network => "network",
+				Project::Chain => "chain",
+				Project::Contract => "contract",
+				Project::Unknown => "unknown",
+			};
+			assert_eq!(project.to_string(), expected);
+		}
+	}
+
+	#[test]
+	fn feature_display_works() {
+		for feature in Feature::VARIANTS {
+			let expected = match feature {
+				Feature::Unit => "unit",
+				Feature::E2e => "e2e",
+			};
+			assert_eq!(feature.to_string(), expected);
+		}
+	}
+
+	#[test]
+	fn os_display_works() {
+		for os in Os::VARIANTS {
+			let expected = match os {
+				Os::Mac => "mac",
+				Os::Linux => "linux",
+				Os::Unsupported => "unsupported",
+			};
+			assert_eq!(os.to_string(), expected);
+		}
+	}
+
+	#[test]
+	fn template_display_works() {
+		assert_eq!(Template::Pallet.to_string(), "pallet");
+		// Test Chain variant with all Parachain types.
+		for parachain in pop_parachains::Parachain::VARIANTS {
+			let template = Template::Chain(parachain.clone());
+			assert_eq!(template.to_string(), parachain.to_string());
+		}
+		// Test Contract variant with all Contract types.
+		for contract in pop_contracts::Contract::VARIANTS {
+			let template = Template::Contract(contract.clone());
+			assert_eq!(template.to_string(), contract.to_string());
+		}
+	}
+}

--- a/crates/pop-cli/src/main.rs
+++ b/crates/pop-cli/src/main.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
 	if let Some(tel) = maybe_tel {
 		let data = result.as_ref().map_or_else(|e| e.to_string(), |t| t.to_string());
 		// Best effort to send on first try, no action if failure.
-		let _ = record_cli_command(tel.clone(), &event, &data).await;
+		let _ = record_cli_command(tel, &event, &data).await;
 	}
 	result.map(|_| ())
 }

--- a/crates/pop-telemetry/src/lib.rs
+++ b/crates/pop-telemetry/src/lib.rs
@@ -117,7 +117,7 @@ impl Telemetry {
 /// There is explicitly no reqwest retries on failure to ensure overhead
 /// stays to a minimum.
 pub async fn record_cli_used(tel: Telemetry) -> Result<()> {
-	let payload = generate_payload("", json!({}));
+	let payload = generate_payload("", "");
 
 	let res = tel.send_json(payload).await;
 	log::debug!("send_cli_used result: {:?}", res);
@@ -131,7 +131,7 @@ pub async fn record_cli_used(tel: Telemetry) -> Result<()> {
 /// `command_name`: the name of the command entered (new, up, build, etc)
 /// `data`: the JSON representation of subcommands. This should never include any user inputted
 /// data like a file name.
-pub async fn record_cli_command(tel: Telemetry, command_name: &str, data: Value) -> Result<()> {
+pub async fn record_cli_command(tel: Telemetry, command_name: &str, data: &str) -> Result<()> {
 	let payload = generate_payload(command_name, data);
 
 	let res = tel.send_json(payload).await;
@@ -193,7 +193,7 @@ where
 	Ok(deserialized)
 }
 
-fn generate_payload(event_name: &str, data: Value) -> Value {
+fn generate_payload(event_name: &str, data: &str) -> Value {
 	json!({
 		"payload": {
 			"hostname": "cli",


### PR DESCRIPTION
Refactors the implementations for collecting events and data from executing commands.

Essentially we convert the command before it is executed in the primary event. After execution the cli returns additional data. When an error occurs the error is added as data.