### PR TITLE
feat: `pop build runtime` and `pop build --deterministic`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7274,9 +7274,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -7315,9 +7315,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4240,7 +4240,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5621,7 +5621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -13630,9 +13630,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -13658,9 +13658,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/pop-cli/src/commands/bench/overhead.rs
+++ b/crates/pop-cli/src/commands/bench/overhead.rs
@@ -72,8 +72,9 @@ impl BenchmarkOverhead {
 					cli,
 					&current_dir().unwrap_or(PathBuf::from("./")),
 					self.profile.as_ref().ok_or_else(|| anyhow::anyhow!("No profile provided"))?,
-					vec![Feature::Benchmark],
+					&[Feature::Benchmark],
 					!self.no_build,
+					false,
 				)?);
 			}
 

--- a/crates/pop-cli/src/commands/bench/pallet.rs
+++ b/crates/pop-cli/src/commands/bench/pallet.rs
@@ -670,8 +670,9 @@ impl BenchmarkPallet {
 			cli,
 			&get_current_directory(),
 			&profile,
-			vec![Feature::Benchmark],
+			&[Feature::Benchmark],
 			!self.no_build,
+			false,
 		)?);
 		Ok(())
 	}

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -13,6 +13,7 @@ use clap::{Args, Subcommand};
 use contract::BuildContract;
 use duct::cmd;
 use pop_common::Profile;
+#[cfg(feature = "parachain")]
 use runtime::BuildRuntime;
 use std::{
 	fmt::{Display, Formatter, Result},

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -71,6 +71,7 @@ pub(crate) struct BuildArgs {
 	/// Whether to build a runtime deterministically.
 	#[clap(short, long, help_heading = RUNTIME_HELP_HEADER)]
 	pub(crate) deterministic: bool,
+	/// Whether to build only the runtime.
 	#[clap(long, help_heading = RUNTIME_HELP_HEADER)]
 	pub(crate) only_runtime: bool,
 }
@@ -134,7 +135,7 @@ impl Command {
 			return Ok(Chain);
 		}
 
-		// If only parachain feature enabled, build as parachain
+		// If project is a parachain runtime, build as parachain runtime
 		#[cfg(feature = "parachain")]
 		if pop_parachains::is_supported(project_path.as_deref())? {
 			let profile = match args.profile {

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -212,7 +212,6 @@ impl Display for Command {
 		match self {
 			#[cfg(feature = "parachain")]
 			Command::Spec(_) => write!(f, "spec"),
-			_ => Ok(()),
 		}
 	}
 }
@@ -320,5 +319,30 @@ mod tests {
 	#[test]
 	fn command_display_works() {
 		assert_eq!(Command::Spec(Default::default()).to_string(), "spec");
+	}
+
+	#[test]
+	fn collect_features_works() {
+		assert_eq!(
+			collect_features("runtime-benchmarks", false, false),
+			vec!["runtime-benchmarks"]
+		);
+		assert_eq!(collect_features("try-runtime", false, false), vec!["try-runtime"]);
+		assert_eq!(
+			collect_features("try-runtime", true, false),
+			vec!["try-runtime", "runtime-benchmarks"]
+		);
+		assert_eq!(
+			collect_features("runtime-benchmarks", false, true),
+			vec!["runtime-benchmarks", "try-runtime"]
+		);
+		assert_eq!(
+			collect_features("runtime-benchmarks,try-runtime", false, false),
+			vec!["runtime-benchmarks", "try-runtime"]
+		);
+		assert_eq!(
+			collect_features("runtime-benchmarks,try-runtime", true, true),
+			vec!["runtime-benchmarks", "try-runtime"]
+		);
 	}
 }

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -150,7 +150,7 @@ impl Command {
 				deterministic: args.deterministic,
 			}
 			.execute()?;
-			return Ok("runtime");
+			return Ok(Chain);
 		}
 
 		// Otherwise build as a normal Rust project
@@ -307,7 +307,7 @@ mod tests {
 				profile: Some(profile.clone()),
 				benchmark,
 				try_runtime,
-        deterministic,
+				deterministic,
 				features: Some(features.join(","))
 			},
 			&mut cli,

--- a/crates/pop-cli/src/commands/build/parachain.rs
+++ b/crates/pop-cli/src/commands/build/parachain.rs
@@ -161,7 +161,7 @@ mod tests {
 				package: package.clone(),
 				profile: profile.clone(),
 				benchmark: features.contains(&Benchmark.as_ref()),
-				try_runtime: features.contains(&TryRuntime.as_ref())
+				try_runtime: features.contains(&TryRuntime.as_ref()),
 			}
 			.build(&mut cli)?,
 			project

--- a/crates/pop-cli/src/commands/build/runtime.rs
+++ b/crates/pop-cli/src/commands/build/runtime.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0
+
 use crate::{
 	cli::{self},
 	common::{

--- a/crates/pop-cli/src/commands/build/runtime.rs
+++ b/crates/pop-cli/src/commands/build/runtime.rs
@@ -1,0 +1,182 @@
+use crate::{
+	cli,
+	common::runtime::{
+		build_deterministic_runtime, build_runtime,
+		Feature::{self, Benchmark, TryRuntime},
+	},
+	style::style,
+};
+use cliclack::spinner;
+use pop_common::{manifest::from_path, Profile};
+use std::{
+	env::current_dir,
+	path::{Path, PathBuf},
+};
+
+// Configuration for building a runtime.
+pub struct BuildRuntime {
+	/// Directory path for your runtime project.
+	pub(crate) path: PathBuf,
+	/// Build profile.
+	pub(crate) profile: Profile,
+	/// Whether to build the runtime with `runtime-benchmarks` feature.
+	pub(crate) benchmark: bool,
+	/// Whether to build the runtime with `try-runtime` feature.
+	pub(crate) try_runtime: bool,
+	/// Whether to build a runtime deterministically.
+	pub(crate) deterministic: bool,
+}
+
+impl BuildRuntime {
+	/// Executes the build process.
+	pub(crate) fn execute(self) -> anyhow::Result<()> {
+		let root = current_dir().unwrap_or(PathBuf::from("./"));
+		let target_path = self.profile.target_directory(root.as_path());
+		self.build(&mut cli::Cli, &target_path)
+	}
+
+	fn build(self, cli: &mut impl cli::traits::Cli, project_root: &Path) -> anyhow::Result<()> {
+		let spinner = spinner();
+		let manifest = from_path(Some(self.path.as_path()))?;
+		let package = manifest.package();
+		let name = package.clone().name;
+
+		// Enable the features based on the user's input.
+		let mut features = vec![];
+		if self.benchmark {
+			features.push(Benchmark);
+		}
+		if self.try_runtime {
+			features.push(TryRuntime);
+		}
+
+		cli.intro(if features.is_empty() {
+			format!("Building {:?} runtime", name)
+		} else {
+			let joined = features
+				.iter()
+				.map(|feat| feat.as_ref().to_string())
+				.collect::<Vec<String>>()
+				.join(",");
+			format!("Building {:?} runtime with features: {}", name, joined)
+		})?;
+		if self.deterministic {
+			spinner.start("Building runtime deterministically...");
+			build_deterministic_runtime(&mut cli::Cli, &spinner, name, self.profile, self.path)?;
+			spinner.stop("");
+		} else {
+			self.build_non_determinisic(&mut cli::Cli, project_root, features)?;
+		}
+		Ok(())
+	}
+
+	fn build_non_determinisic(
+		self,
+		cli: &mut impl cli::traits::Cli,
+		project_root: &Path,
+		features: Vec<Feature>,
+	) -> anyhow::Result<()> {
+		if self.profile == Profile::Debug {
+			cli.warning("NOTE: this command now defaults to DEBUG builds. Please use `--release` (or simply `-r`) for a release build...")?;
+		}
+		// Build runtime.
+		let target_path = self.profile.target_directory(project_root).join("wbuild");
+		let binary = build_runtime(cli, &self.path, &target_path, &self.profile, features)?;
+		let generated_files = [format!("Binary generated at: {}", binary.display())];
+		let generated_files: Vec<_> = generated_files
+			.iter()
+			.map(|s| style(format!("{} {s}", console::Emoji("●", ">"))).dim().to_string())
+			.collect();
+		cli.success(format!("Generated files:\n{}", generated_files.join("\n")))?;
+		cli.outro(format!(
+			"Need help? Learn more at {}\n",
+			style("https://learn.onpop.io").magenta().underlined()
+		))?;
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use cli::MockCli;
+	use duct::cmd;
+	use pop_common::manifest::{add_feature, add_production_profile};
+	use std::fs;
+	use strum::VariantArray;
+
+	#[test]
+	fn build_runtime_works() -> anyhow::Result<()> {
+		let temp_dir = tempfile::tempdir()?;
+		let path = temp_dir.path();
+		let runtime_name = "mock_runtime";
+		cmd("cargo", ["new", "--lib", runtime_name]).dir(&path).run()?;
+
+		// Create a runtime directory
+		let target_dir = path.join(runtime_name);
+		add_feature(target_dir.as_path(), ("try-runtime".to_string(), vec![]))?;
+		add_feature(target_dir.as_path(), ("runtime-benchmarks".to_string(), vec![]))?;
+
+		let project_path = path.join(runtime_name);
+		let features = &[Benchmark.as_ref(), TryRuntime.as_ref()];
+		add_production_profile(&project_path)?;
+		for feature in features {
+			add_feature(&project_path, (feature.to_string(), vec![]))?;
+		}
+
+		for profile in Profile::VARIANTS {
+			let target_path = profile
+				.target_directory(&target_dir)
+				.join(format!("./wbuild/{}/{}.wasm", runtime_name, runtime_name));
+			fs::create_dir_all(target_path)?;
+
+			// Build without features.
+			test_build(&project_path, profile, &[], false)?;
+
+			// Build with one feature.
+			test_build(&project_path, profile, &[Benchmark.as_ref()], false)?;
+
+			// Build with multiple features.
+			test_build(&project_path, profile, features, false)?;
+		}
+		Ok(())
+	}
+
+	fn test_build(
+		project_path: &PathBuf,
+		profile: &Profile,
+		features: &[&str],
+		deterministic: bool,
+	) -> anyhow::Result<()> {
+		let manifest = from_path(Some(project_path.as_path()))?;
+		let package = manifest.package();
+		let name = package.clone().name;
+
+		let mut cli = MockCli::new().expect_intro(if features.is_empty() {
+			format!("Building {:?} runtime", name)
+		} else {
+			format!("Building {:?} runtime with features: {}", name, features.join(","))
+		});
+
+		if deterministic {
+		} else {
+			if profile == &Profile::Debug {
+				cli = cli.expect_warning("NOTE: this command now defaults to DEBUG builds. Please use `--release` (or simply `-r`) for a release build...");
+			}
+			cli = cli
+				.expect_warning("NOTE: this may take some time...")
+				.expect_info(format!("The rutnime was built in {profile} mode."))
+				.expect_outro("\n✅ Runtime built successfully.\n");
+		}
+
+		BuildRuntime {
+			path: project_path.clone(),
+			profile: profile.clone(),
+			benchmark: features.contains(&Benchmark.as_ref()),
+			try_runtime: features.contains(&TryRuntime.as_ref()),
+			deterministic: false,
+		}
+		.build(&mut cli, project_path)?;
+		cli.verify()
+	}
+}

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -569,13 +569,13 @@ impl BuildSpec {
 			spinner.start("Generating chain specification...");
 			// Generate chain spec.
 			generate_plain_chain_spec(&binary_path, output_file, default_bootnode, chain)?;
+			spinner.stop("");
 			// Customize spec based on input.
 			self.customize()?;
 			// Deterministic build.
 			if self.deterministic {
 				let (runtime_path, code) = build_deterministic_runtime(
 					cli,
-					&spinner,
 					self.package.clone(),
 					self.profile.clone(),
 					self.runtime_dir.clone(),

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -569,14 +569,14 @@ impl BuildSpec {
 			spinner.start("Generating chain specification...");
 			// Generate chain spec.
 			generate_plain_chain_spec(&binary_path, output_file, default_bootnode, chain)?;
-			spinner.stop("");
 			// Customize spec based on input.
 			self.customize()?;
 			// Deterministic build.
 			if self.deterministic {
 				let (runtime_path, code) = build_deterministic_runtime(
 					cli,
-					self.package.clone(),
+					&spinner,
+					&self.package,
 					self.profile.clone(),
 					self.runtime_dir.clone(),
 				)

--- a/crates/pop-cli/src/common/runtime.rs
+++ b/crates/pop-cli/src/common/runtime.rs
@@ -5,9 +5,9 @@ use cliclack::{spinner, ProgressBar};
 use pop_common::{manifest::from_path, Profile};
 #[cfg(feature = "parachain")]
 use pop_parachains::{
-	build_project, get_preset_names, get_runtime_path, runtime_binary_path, GenesisBuilderPolicy,
+	build_project, get_preset_names, get_runtime_path, runtime_binary_path, ContainerEngine,
+	DeterministicBuilder, GenesisBuilderPolicy,
 };
-use pop_parachains::{ContainerEngine, DeterministicBuilder};
 use std::{
 	self,
 	ffi::OsStr,

--- a/crates/pop-cli/src/common/runtime.rs
+++ b/crates/pop-cli/src/common/runtime.rs
@@ -131,7 +131,7 @@ fn print_build_output(cli: &mut impl Cli, binary_path: &Path) -> anyhow::Result<
 pub(crate) fn build_deterministic_runtime(
 	cli: &mut impl Cli,
 	spinner: &ProgressBar,
-	package: &String,
+	package: &str,
 	profile: Profile,
 	runtime_dir: PathBuf,
 ) -> anyhow::Result<(PathBuf, Vec<u8>)> {

--- a/crates/pop-cli/src/common/try_runtime.rs
+++ b/crates/pop-cli/src/common/try_runtime.rs
@@ -218,8 +218,9 @@ pub(crate) fn update_runtime_source(
 			cli,
 			&current_dir().unwrap_or(PathBuf::from("./")),
 			profile.as_ref().ok_or_else(|| anyhow::anyhow!("No profile provided"))?,
-			vec![Feature::TryRuntime],
+			&[Feature::TryRuntime],
 			!no_build,
+			false,
 		)?);
 	}
 	Ok(())

--- a/crates/pop-common/src/manifest.rs
+++ b/crates/pop-common/src/manifest.rs
@@ -216,7 +216,7 @@ mod tests {
 	}
 
 	#[test]
-	fn from_path_works() -> anyhow::Result<(), anyhow::Error> {
+	fn from_path_works() -> anyhow::Result<()> {
 		// Workspace manifest from directory
 		from_path(Some(Path::new("../../")))?;
 		// Workspace manifest from path

--- a/crates/pop-parachains/src/build/runtime.rs
+++ b/crates/pop-parachains/src/build/runtime.rs
@@ -49,7 +49,7 @@ impl DeterministicBuilder {
 	pub fn new(
 		engine: ContainerEngine,
 		path: Option<PathBuf>,
-		package: &String,
+		package: &str,
 		profile: Profile,
 		runtime_dir: PathBuf,
 	) -> Result<Self, Error> {
@@ -69,7 +69,7 @@ impl DeterministicBuilder {
 			digest,
 			engine,
 			image: DEFAULT_IMAGE.to_string(),
-			package: package.clone(),
+			package: package.to_owned(),
 			path: dir,
 			profile,
 			runtime_dir,

--- a/crates/pop-parachains/src/build/runtime.rs
+++ b/crates/pop-parachains/src/build/runtime.rs
@@ -49,7 +49,7 @@ impl DeterministicBuilder {
 	pub fn new(
 		engine: ContainerEngine,
 		path: Option<PathBuf>,
-		package: String,
+		package: &String,
 		profile: Profile,
 		runtime_dir: PathBuf,
 	) -> Result<Self, Error> {
@@ -69,7 +69,7 @@ impl DeterministicBuilder {
 			digest,
 			engine,
 			image: DEFAULT_IMAGE.to_string(),
-			package,
+			package: package.clone(),
 			path: dir,
 			profile,
 			runtime_dir,
@@ -153,7 +153,7 @@ mod tests {
 		let srtool_builer = DeterministicBuilder::new(
 			ContainerEngine::Docker,
 			None,
-			"parachain-template-runtime".to_string(),
+			&"parachain-template-runtime".to_string(),
 			Profile::Release,
 			PathBuf::from("./runtime"),
 		)?;
@@ -188,7 +188,7 @@ mod tests {
 			DeterministicBuilder::new(
 				ContainerEngine::Podman,
 				Some(path.to_path_buf()),
-				"parachain-template-runtime".to_string(),
+				&"parachain-template-runtime".to_string(),
 				Profile::Production,
 				PathBuf::from("./runtime"),
 			)?
@@ -218,7 +218,7 @@ mod tests {
 		let srtool_builder = DeterministicBuilder::new(
 			ContainerEngine::Podman,
 			None,
-			"template-runtime".to_string(),
+			&"template-runtime".to_string(),
 			Profile::Debug,
 			PathBuf::from("./runtime-folder"),
 		)?;

--- a/crates/pop-parachains/src/build/runtime.rs
+++ b/crates/pop-parachains/src/build/runtime.rs
@@ -2,16 +2,19 @@
 
 use crate::Error;
 use duct::cmd;
-use pop_common::Profile;
+use pop_common::{manifest::from_path, Profile};
 pub use srtool_lib::{get_image_digest, get_image_tag, ContainerEngine};
-use std::{env, fs, path::PathBuf};
+use std::{
+	env, fs,
+	path::{Path, PathBuf},
+};
 
 const DEFAULT_IMAGE: &str = "docker.io/paritytech/srtool";
 const TIMEOUT: u64 = 60 * 60;
 
 /// Builds and executes the command for running a deterministic runtime build process using
 /// srtool.
-pub struct Builder {
+pub struct DeterministicBuilder {
 	/// Mount point for cargo cache.
 	cache_mount: String,
 	/// List of default features to enable during the build process.
@@ -34,7 +37,7 @@ pub struct Builder {
 	tag: String,
 }
 
-impl Builder {
+impl DeterministicBuilder {
 	/// Creates a new instance of `Builder`.
 	///
 	/// # Arguments
@@ -119,14 +122,35 @@ impl Builder {
 	}
 }
 
+/// Determines whether the manifest at the supplied path is a supported Substrate runtime project.
+///
+/// # Arguments
+/// * `path` - The optional path to the manifest, defaulting to the current directory if not
+///   specified.
+pub fn is_supported(path: Option<&Path>) -> Result<bool, Error> {
+	let manifest = from_path(path)?;
+	// Simply check for a parachain dependency
+	const DEPENDENCIES: [&str; 3] = ["frame-system", "frame-support", "substrate-wasm-builder"];
+	let has_dependencies = DEPENDENCIES.into_iter().any(|d| {
+		manifest.dependencies.contains_key(d) ||
+			manifest.workspace.as_ref().is_some_and(|w| w.dependencies.contains_key(d))
+	});
+	let has_features = manifest.features.contains_key("runtime-benchmarks") ||
+		manifest.features.contains_key("try-runtime");
+	Ok(has_dependencies && has_features)
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use anyhow::Result;
+	use fs::write;
+	use pop_common::manifest::Dependency;
+	use tempfile::tempdir;
 
 	#[test]
 	fn srtool_builder_new_works() -> Result<()> {
-		let srtool_builer = Builder::new(
+		let srtool_builer = DeterministicBuilder::new(
 			ContainerEngine::Docker,
 			None,
 			"parachain-template-runtime".to_string(),
@@ -161,7 +185,7 @@ mod tests {
 		let tag = get_image_tag(Some(TIMEOUT))?;
 		let digest = get_image_digest(DEFAULT_IMAGE, &tag).unwrap_or_default();
 		assert_eq!(
-			Builder::new(
+			DeterministicBuilder::new(
 				ContainerEngine::Podman,
 				Some(path.to_path_buf()),
 				"parachain-template-runtime".to_string(),
@@ -191,7 +215,7 @@ mod tests {
 
 	#[test]
 	fn get_output_path_works() -> Result<()> {
-		let srtool_builder = Builder::new(
+		let srtool_builder = DeterministicBuilder::new(
 			ContainerEngine::Podman,
 			None,
 			"template-runtime".to_string(),
@@ -199,6 +223,28 @@ mod tests {
 			PathBuf::from("./runtime-folder"),
 		)?;
 		assert_eq!(srtool_builder.get_output_path().display().to_string(), "./runtime-folder/target/srtool/debug/wbuild/template-runtime/template_runtime.compact.compressed.wasm");
+		Ok(())
+	}
+
+	#[test]
+	fn is_supported_works() -> Result<()> {
+		let temp_dir = tempdir()?;
+		let path = temp_dir.path();
+
+		// Standard rust project
+		let name = "hello_world";
+		cmd("cargo", ["new", name]).dir(&path).run()?;
+		assert!(!is_supported(Some(&path.join(name)))?);
+
+		// Parachain runtime with dependency
+		let mut manifest = from_path(Some(&path.join(name)))?;
+		manifest
+			.dependencies
+			.insert("substrate-wasm-builder".into(), Dependency::Simple("^0.14.0".into()));
+		manifest.features.insert("try-runtime".into(), vec![]);
+		let manifest = toml_edit::ser::to_string_pretty(&manifest)?;
+		write(path.join(name).join("Cargo.toml"), manifest)?;
+		assert!(is_supported(Some(&path.join(name)))?);
 		Ok(())
 	}
 }

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -25,8 +25,8 @@ pub use bench::{
 };
 pub use build::{
 	binary_path, build_parachain, build_project, export_wasm_file, generate_genesis_state_file,
-	generate_plain_chain_spec, generate_raw_chain_spec, is_supported,
-	runtime::{Builder, ContainerEngine},
+	generate_plain_chain_spec, generate_raw_chain_spec, is_supported, runtime,
+	runtime::{ContainerEngine, DeterministicBuilder},
 	runtime_binary_path, ChainSpec,
 };
 pub use call::{


### PR DESCRIPTION
- The PR implements a feature to build only the runtime when the user is in the `/runtime` folder of the parachain project. Tackling the issue #504. 
- Implements `pop build --deterministic` to build a runtime deterministically. #478 
- If `--only-runtime` is provided and the command is run at the parachain project root, it prompts user to select the runtime to build if there're multiple. If there is only one runtime, it builds the runtime instead of a parachain. 

```
pop build --only-runtime
```
Or
```
pop build --deterministic --only-runtime
```