### PR TITLE
chore: source remote binary if version not matches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7274,9 +7274,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -7315,9 +7315,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",

--- a/crates/pop-cli/src/common/binary.rs
+++ b/crates/pop-cli/src/common/binary.rs
@@ -174,56 +174,6 @@ mod tests {
 	use super::*;
 	use crate::{cli::MockCli, common::contracts::ContractsNodeGenerator};
 
-	#[test]
-	fn semantic_version_invalid_works() {
-		assert!(SemanticVersion::try_from("bash".to_string()).is_ok());
-		assert!(SemanticVersion::try_from("which".to_string()).is_ok());
-	}
-
-	#[test]
-	fn which_version_works() {
-		assert_eq!(
-			which_version(
-				"bash",
-				&SemanticVersion::try_from("bash".to_string()).unwrap(),
-				&Ordering::Equal,
-			)
-			.unwrap()
-			.to_str()
-			.unwrap()
-			.to_string(),
-			cmd("which", &["bash"]).read().unwrap(),
-		);
-		assert_eq!(
-			which_version("bash", &SemanticVersion(0, 0, 0), &Ordering::Greater)
-				.unwrap()
-				.to_str()
-				.unwrap()
-				.to_string(),
-			cmd("which", &["bash"]).read().unwrap(),
-		);
-		assert_eq!(
-			which_version("bash", &SemanticVersion(0, 0, 0), &Ordering::Less)
-				.unwrap_err()
-				.to_string(),
-			"Binary version does not match target version".to_string()
-		);
-		assert_eq!(
-			which_version("no-binary-found", &SemanticVersion(0, 0, 0), &Ordering::Less)
-				.unwrap_err()
-				.to_string(),
-			"Failed to find binary".to_string()
-		);
-	}
-
-	#[test]
-	fn semantic_version_invalid_binary() {
-		assert_eq!(
-			SemanticVersion::try_from("./dummy-binary".to_string()).unwrap_err().to_string(),
-			"Failed to get version: No such file or directory (os error 2)".to_string()
-		);
-	}
-
 	#[tokio::test]
 	async fn check_binary_and_prompt_works() -> anyhow::Result<()> {
 		let binary_name = "substrate-contracts-node";
@@ -269,5 +219,54 @@ mod tests {
 			.unwrap()
 			.starts_with(&cache_path.path().join(binary_name).to_str().unwrap()));
 		cli.verify()
+	}
+
+	#[test]
+	fn semantic_version_works() {
+		assert!(SemanticVersion::try_from("bash".to_string()).is_ok());
+	}
+
+	#[test]
+	fn semantic_version_invalid_binary() {
+		assert_eq!(
+			SemanticVersion::try_from("./dummy-binary".to_string()).unwrap_err().to_string(),
+			"Failed to get version: No such file or directory (os error 2)".to_string()
+		);
+	}
+
+	#[test]
+	fn which_version_works() {
+		assert_eq!(
+			which_version(
+				"bash",
+				&SemanticVersion::try_from("bash".to_string()).unwrap(),
+				&Ordering::Equal,
+			)
+			.unwrap()
+			.to_str()
+			.unwrap()
+			.to_string(),
+			cmd("which", &["bash"]).read().unwrap(),
+		);
+		assert_eq!(
+			which_version("bash", &SemanticVersion(0, 0, 0), &Ordering::Greater)
+				.unwrap()
+				.to_str()
+				.unwrap()
+				.to_string(),
+			cmd("which", &["bash"]).read().unwrap(),
+		);
+		assert_eq!(
+			which_version("bash", &SemanticVersion(0, 0, 0), &Ordering::Less)
+				.unwrap_err()
+				.to_string(),
+			"Binary version does not match target version".to_string()
+		);
+		assert_eq!(
+			which_version("no-binary-found", &SemanticVersion(0, 0, 0), &Ordering::Less)
+				.unwrap_err()
+				.to_string(),
+			"Failed to find binary".to_string()
+		);
 	}
 }

--- a/crates/pop-cli/src/common/try_runtime.rs
+++ b/crates/pop-cli/src/common/try_runtime.rs
@@ -1,14 +1,19 @@
 // SPDX-License-Identifier: GPL-3.0
 
+use super::{
+	binary::which_version,
+	builds::guide_user_to_select_profile,
+	chain::get_pallets,
+	runtime::{ensure_runtime_binary_exists, Feature},
+};
 use crate::{
 	cli::traits::*,
-	common::binary::{check_and_prompt, BinaryGenerator},
+	common::binary::{check_and_prompt, BinaryGenerator, SemanticVersion},
 	impl_binary_generator,
 };
 use clap::Args;
 use cliclack::spinner;
 use console::style;
-use duct::cmd;
 use frame_try_runtime::TryStateSelect;
 use pop_common::{sourcing::Binary, Profile};
 use pop_parachains::{
@@ -17,6 +22,7 @@ use pop_parachains::{
 	try_runtime_generator, try_state_details, try_state_label, Runtime, SharedParams,
 };
 use std::{
+	cmp::Ordering,
 	collections::HashSet,
 	env::current_dir,
 	fmt::Display,
@@ -24,17 +30,12 @@ use std::{
 };
 use strum::{EnumMessage, VariantArray};
 
-use super::{
-	builds::guide_user_to_select_profile,
-	chain::get_pallets,
-	runtime::{ensure_runtime_binary_exists, Feature},
-};
-
 const BINARY_NAME: &str = "try-runtime";
 pub(crate) const DEFAULT_BLOCK_HASH: &str = "0x0000000000";
 pub(crate) const DEFAULT_BLOCK_TIME: u64 = 6000;
 pub(crate) const DEFAULT_LIVE_NODE_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
 pub(crate) const DEFAULT_SNAPSHOT_PATH: &str = "your-parachain.snap";
+const TARGET_BINARY_VERSION: SemanticVersion = SemanticVersion(0, 8, 0);
 
 impl_binary_generator!(TryRuntimeGenerator, try_runtime_generator);
 
@@ -74,12 +75,10 @@ pub async fn check_try_runtime_and_prompt(
 	cli: &mut impl Cli,
 	skip_confirm: bool,
 ) -> anyhow::Result<PathBuf> {
-	Ok(match cmd("which", &[BINARY_NAME]).stdout_capture().run() {
-		Ok(output) => {
-			let path = String::from_utf8(output.stdout)?;
-			PathBuf::from(path.trim())
-		},
-		Err(_) => source_try_runtime_binary(cli, &crate::cache()?, skip_confirm).await?,
+	Ok(if let Ok(path) = which_version(BINARY_NAME, &TARGET_BINARY_VERSION, &Ordering::Greater) {
+		path
+	} else {
+		source_try_runtime_binary(cli, &crate::cache()?, skip_confirm).await?
 	})
 }
 
@@ -555,8 +554,12 @@ pub(crate) fn get_try_state_items() -> Vec<(String, String)> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{cli::MockCli, common::runtime::get_mock_runtime};
+	use crate::{
+		cli::MockCli,
+		common::{binary::SemanticVersion, runtime::get_mock_runtime},
+	};
 	use clap::Parser;
+	use tempfile::tempdir;
 
 	#[derive(Default)]
 	struct MockCommand {
@@ -1171,5 +1174,16 @@ mod tests {
 			),
 			vec!["--debug".to_string(), "-v".to_string(), "--output=result.txt".to_string()],
 		);
+	}
+
+	#[tokio::test]
+	async fn try_runtime_version_works() -> anyhow::Result<()> {
+		let cache_path = tempdir().expect("Could create temp dir");
+		let path = source_try_runtime_binary(&mut MockCli::new(), cache_path.path(), true).await?;
+		assert_eq!(
+			SemanticVersion::try_from(path.to_str().unwrap().to_string())?,
+			SemanticVersion(0, 8, 0)
+		);
+		Ok(())
 	}
 }


### PR DESCRIPTION
- Add a new type `SemanticVersion` to represent to the semantic version `(minor, major, patch)`
- Add a new method `which_version` that returns the path to the binary if the version matches the targeted one. 