### PR TITLE
feat: hashing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ sc-cli = { version = "0.50.1", default-features = false }
 sp-version = { version = "38.0.0", default-features = false }
 
 # pop-cli
-clap = { version = "4.5", default-features = false, features = ["derive"] }
+clap = { version = "4.5", default-features = false, features = ["derive", "string"] }
 cliclack = { version = "0.3.1", default-features = false }
 console = { version = "0.15", default-features = false }
 os_info = { version = "3", default-features = false }

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -63,6 +63,8 @@ sp-weights.workspace = true
 [features]
 default = ["contract", "parachain", "telemetry"]
 contract = ["dep:pop-contracts", "dep:sp-core", "dep:sp-weights", "wallet-integration"]
+experimental = ["hashing"]
+hashing = ["dep:sp-core"]
 parachain = ["dep:pop-parachains", "dep:git2", "dep:tracing-subscriber", "wallet-integration"]
 telemetry = ["dep:pop-telemetry"]
 wallet-integration = ["dep:axum", "dep:open", "dep:tower-http"]

--- a/crates/pop-cli/src/commands/hash.rs
+++ b/crates/pop-cli/src/commands/hash.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
+use self::Command::*;
 use super::*;
 use anyhow::{anyhow, Result};
 use clap::{
@@ -82,16 +83,14 @@ impl Command {
 
 	fn data(&self) -> &Data {
 		match self {
-			Command::Blake2 { data, .. } => data,
-			Command::Keccak { data, .. } => data,
-			Command::Sha2 { data, .. } => data,
-			Command::TwoX { data, .. } => data,
+			Blake2 { data, .. } | Keccak { data, .. } | Sha2 { data, .. } | TwoX { data, .. } =>
+				data,
 		}
 	}
 
 	fn hash(&self) -> Result<Vec<u8>> {
 		match self {
-			Command::Blake2 { length, data, concat } => {
+			Blake2 { length, data, concat } => {
 				let mut hash = match length {
 					64 => blake2_64(data).to_vec(),
 					128 => blake2_128(data).to_vec(),
@@ -104,7 +103,7 @@ impl Command {
 				}
 				Ok(hash)
 			},
-			Command::Keccak { length, data } => {
+			Keccak { length, data } => {
 				let hash = match length {
 					256 => keccak_256(data).to_vec(),
 					512 => keccak_512(data).to_vec(),
@@ -112,14 +111,14 @@ impl Command {
 				};
 				Ok(hash)
 			},
-			Command::Sha2 { length, data } => {
+			Sha2 { length, data } => {
 				let hash = match length {
 					256 => sha2_256(data).to_vec(),
 					_ => return Err(anyhow!("unsupported length: {}", length)),
 				};
 				Ok(hash)
 			},
-			Command::TwoX { length, data, concat } => {
+			TwoX { length, data, concat } => {
 				let mut hash = match length {
 					64 => twox_64(data).to_vec(),
 					128 => twox_128(data).to_vec(),
@@ -138,10 +137,10 @@ impl Command {
 impl Display for Command {
 	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
 		match self {
-			Command::Blake2 { length, .. } => write!(f, "blake2 {length}"),
-			Command::Keccak { length, .. } => write!(f, "keccak {length}"),
-			Command::Sha2 { length, .. } => write!(f, "sha2 {length}"),
-			Command::TwoX { length, .. } => write!(f, "twox {length}"),
+			Blake2 { length, .. } => write!(f, "blake2 {length}"),
+			Keccak { length, .. } => write!(f, "keccak {length}"),
+			Sha2 { length, .. } => write!(f, "sha2 {length}"),
+			TwoX { length, .. } => write!(f, "twox {length}"),
 		}
 	}
 }

--- a/crates/pop-cli/src/commands/hash.rs
+++ b/crates/pop-cli/src/commands/hash.rs
@@ -216,6 +216,10 @@ impl TypedValueParser for SupportedLengths {
 			.parse_ref(cmd, arg, value)
 			.map(|v| v.parse::<u16>().expect("only u16 values supported"))
 	}
+
+	fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
+		self.0.possible_values()
+	}
 }
 
 #[cfg(test)]
@@ -419,5 +423,23 @@ mod tests {
 	fn data_from_string_works() {
 		let value = "test";
 		assert!(matches!(Data::from_str(value), Ok(String(bytes)) if bytes == value.as_bytes()));
+	}
+
+	#[test]
+	fn supported_lengths_works() {
+		let values = [8, 16, 32, 64];
+		let supported_lengths = SupportedLengths::new(values);
+		for value in values {
+			assert_eq!(
+				supported_lengths
+					.parse_ref(&Default::default(), Option::None, &OsStr::new(&value.to_string()))
+					.unwrap(),
+				value
+			);
+		}
+		assert!(supported_lengths
+			.possible_values()
+			.unwrap()
+			.eq(values.map(|v| PossibleValue::new(v.to_string())),))
 	}
 }

--- a/crates/pop-cli/src/commands/hash.rs
+++ b/crates/pop-cli/src/commands/hash.rs
@@ -2,6 +2,7 @@
 
 use self::Command::*;
 use super::*;
+use crate::cli::traits::Cli;
 use anyhow::{anyhow, Result};
 use clap::{
 	builder::{PossibleValue, PossibleValuesParser, TypedValueParser},
@@ -72,12 +73,13 @@ pub(crate) enum Command {
 
 impl Command {
 	/// Executes the command.
-	pub(crate) fn execute(&self) -> Result<()> {
+	pub(crate) fn execute(&self, cli: &mut impl Cli) -> Result<()> {
 		let hash = self.hash()?;
 		let additional_info = format!("(Source: {}, Output: {} bytes)", self.data(), hash.len());
 		let output =
 			format!("{} {}", to_hex(&self.hash()?, false), console::style(additional_info).dim());
-		println!("{output}");
+		cli.success(&output)?;
+		console::Term::stderr().clear_last_lines(1)?;
 		Ok(())
 	}
 

--- a/crates/pop-cli/src/commands/hash.rs
+++ b/crates/pop-cli/src/commands/hash.rs
@@ -16,13 +16,16 @@ const DATA: &'static str =
 const LENGTH: &'static str = "The length of the resulting hash, in bits.";
 const MAX_CODE_SIZE: u64 = 3 * 1024 * 1024;
 
+/// Arguments for hashing.
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
 pub(crate) struct HashArgs {
+	/// Hash data using a supported hash algorithm.
 	#[command(subcommand)]
 	pub(crate) command: Command,
 }
 
+/// Hash data using a supported hash algorithm.
 #[derive(Subcommand)]
 pub(crate) enum Command {
 	/// Hashes data using the BLAKE2b cryptographic hash algorithm.
@@ -64,6 +67,7 @@ pub(crate) enum Command {
 }
 
 impl Command {
+	/// Executes the command.
 	pub(crate) fn execute(&self) -> Result<()> {
 		let (hash, data) = match self {
 			Command::Blake2 { length, data, concat } => {

--- a/crates/pop-cli/src/commands/hash.rs
+++ b/crates/pop-cli/src/commands/hash.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-3.0
+
+use super::*;
+use anyhow::Result;
+use clap::builder::PossibleValuesParser;
+use sp_core::{
+	bytes::{from_hex, to_hex},
+	hashing::*,
+};
+use std::ops::Deref;
+use strum_macros::Display;
+
+const CONCAT: &'static str = "Whether to append the source data to the hash.";
+const DATA: &'static str =
+	"The data to be hashed: input directly or specified as a path to a file.";
+const LENGTH: &'static str = "The length of the resulting hash, in bits.";
+const MAX_CODE_SIZE: u64 = 3 * 1024 * 1024;
+
+#[derive(Args)]
+#[command(args_conflicts_with_subcommands = true)]
+pub(crate) struct HashArgs {
+	#[command(subcommand)]
+	pub(crate) command: Command,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum Command {
+	/// Hashes data using the BLAKE2b cryptographic hash algorithm.
+	#[clap(alias = "b2")]
+	Blake2 {
+		#[arg(help = LENGTH, value_parser = PossibleValuesParser::new(["64", "128", "256", "512"]))]
+		length: String,
+		#[arg(help = DATA)]
+		data: Data,
+		#[arg(short, help = CONCAT, long)]
+		concat: bool,
+	},
+	/// Hashes data using the Keccak cryptographic hash algorithm.
+	#[clap(alias = "kk")]
+	Keccak {
+		#[arg(help = LENGTH, value_parser = PossibleValuesParser::new(["256", "512"]))]
+		length: String,
+		#[arg(help = DATA)]
+		data: Data,
+	},
+	/// Hashes data using the SHA-2 cryptographic hash algorithm.
+	#[clap(alias = "s2")]
+	Sha2 {
+		#[arg(help = LENGTH, value_parser = PossibleValuesParser::new(["256"]))]
+		length: String,
+		#[arg(help = DATA)]
+		data: Data,
+	},
+	/// Hashes data using the non-cryptographic xxHash hash algorithm.
+	#[clap(alias = "xx", name = "twox")]
+	TwoX {
+		#[arg(help = LENGTH, value_parser = PossibleValuesParser::new(["64", "128"]))]
+		length: String,
+		#[arg(help = DATA)]
+		data: Data,
+		#[arg(short, help = CONCAT, long)]
+		concat: bool,
+	},
+}
+
+impl Command {
+	pub(crate) fn execute(&self) -> Result<()> {
+		let (hash, data) = match self {
+			Command::Blake2 { length, data, concat } => {
+				let mut hash = match length.parse::<u16>()? {
+					64 => blake2_64(data).to_vec(),
+					128 => blake2_128(data).to_vec(),
+					256 => blake2_256(data).to_vec(),
+					512 => blake2_512(data).to_vec(),
+					_ => unreachable!("args validated by clap"),
+				};
+				if *concat {
+					hash.extend_from_slice(data)
+				}
+				(hash, data)
+			},
+			Command::Keccak { length, data } => {
+				let hash = match length.parse::<u16>()? {
+					256 => keccak_256(data).to_vec(),
+					512 => keccak_512(data).to_vec(),
+					_ => unreachable!("args validated by clap"),
+				};
+				(hash, data)
+			},
+			Command::Sha2 { length, data } => {
+				let hash = match length.parse::<u16>()? {
+					256 => sha2_256(data).to_vec(),
+					_ => unreachable!("args validated by clap"),
+				};
+				(hash, data)
+			},
+			Command::TwoX { length, data, concat } => {
+				let mut hash = match length.parse::<u16>()? {
+					64 => twox_64(data).to_vec(),
+					128 => twox_128(data).to_vec(),
+					256 => twox_256(data).to_vec(),
+					_ => unreachable!("args validated by clap"),
+				};
+				if *concat {
+					hash.extend_from_slice(data)
+				}
+				(hash, data)
+			},
+		};
+
+		println!("{} {}", to_hex(&hash, false), console::style(format!("(Source: {data})")).dim());
+		Ok(())
+	}
+}
+
+#[derive(Clone, Debug, Display)]
+pub(crate) enum Data {
+	File(Vec<u8>),
+	Hex(Vec<u8>),
+	String(Vec<u8>),
+}
+
+impl From<&str> for Data {
+	fn from(value: &str) -> Self {
+		// Check if value is specifying a file
+		if let Ok(metadata) = std::fs::metadata(value) {
+			if metadata.is_file() {
+				// Limit the size to that of the max code size for a runtime
+				if metadata.len() > MAX_CODE_SIZE {
+					panic!("file size exceeds maximum code size");
+				}
+
+				if let Ok(data) = std::fs::read(value) {
+					return Self::File(data)
+				}
+			}
+		}
+		// Otherwise check if hex via prefix or just hash as string
+		if value.starts_with("0x") {
+			Self::Hex(from_hex(value).unwrap())
+		} else {
+			Self::String(value.as_bytes().into())
+		}
+	}
+}
+
+impl Deref for Data {
+	type Target = [u8];
+
+	fn deref(&self) -> &Self::Target {
+		match self {
+			Data::File(data) => data,
+			Data::Hex(data) => data,
+			Data::String(data) => data,
+		}
+	}
+}

--- a/crates/pop-cli/src/commands/hash.rs
+++ b/crates/pop-cli/src/commands/hash.rs
@@ -108,7 +108,11 @@ impl Command {
 			},
 		};
 
-		println!("{} {}", to_hex(&hash, false), console::style(format!("(Source: {data})")).dim());
+		println!(
+			"{} {}",
+			to_hex(&hash, false),
+			console::style(format!("(Source: {data}, Output: {} bytes)", hash.len())).dim()
+		);
 		Ok(())
 	}
 }

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -191,7 +191,7 @@ impl Command {
 			#[cfg(feature = "hashing")]
 			Self::Hash(args) => {
 				env_logger::init();
-				args.command.execute().map(|_| Null)
+				args.command.execute(&mut Cli).map(|_| Null)
 			},
 			Self::Clean(args) => {
 				env_logger::init();

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 	cli::Cli,
 	common::Data::{self, *},
 };
-use clap::{Args, Subcommand};
+use clap::Subcommand;
 use std::fmt::{Display, Formatter, Result};
 
 #[cfg(feature = "parachain")]
@@ -252,7 +252,7 @@ impl Display for Command {
 			#[cfg(feature = "parachain")]
 			Self::Bench(args) => write!(f, "bench {}", args.command),
 			#[cfg(feature = "hashing")]
-			Command::Hash(_) => write!(f, "hash"),
+			Command::Hash(args) => write!(f, "hash {}", args.command),
 		}
 	}
 }
@@ -374,5 +374,13 @@ mod tests {
 		for (command, expected) in test_cases {
 			assert_eq!(command.to_string(), expected);
 		}
+	}
+
+	#[cfg(feature = "hashing")]
+	#[test]
+	fn hash_command_display_works() {
+		use hash::{Command::*, Data, HashArgs};
+		let command = Blake2 { length: "256".to_string(), data: Data::default(), concat: false };
+		assert_eq!(format!("hash {command}"), Command::Hash(HashArgs { command }).to_string());
 	}
 }

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -380,7 +380,7 @@ mod tests {
 	#[test]
 	fn hash_command_display_works() {
 		use hash::{Command::*, Data, HashArgs};
-		let command = Blake2 { length: "256".to_string(), data: Data::default(), concat: false };
+		let command = Blake2 { length: 256, data: Data::default(), concat: false };
 		assert_eq!(format!("hash {command}"), Command::Hash(HashArgs { command }).to_string());
 	}
 }

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 	cli::Cli,
 	common::Data::{self, *},
 };
-use clap::Subcommand;
+use clap::{Args, Subcommand};
 use std::fmt::{Display, Formatter, Result};
 
 #[cfg(feature = "parachain")]
@@ -14,6 +14,8 @@ pub(crate) mod build;
 #[cfg(any(feature = "parachain", feature = "contract"))]
 pub(crate) mod call;
 pub(crate) mod clean;
+#[cfg(feature = "hashing")]
+mod hash;
 #[cfg(any(feature = "parachain", feature = "contract"))]
 pub(crate) mod install;
 #[cfg(any(feature = "parachain", feature = "contract"))]
@@ -48,6 +50,10 @@ pub(crate) enum Command {
 	/// Test a Rust project.
 	#[clap(alias = "t")]
 	Test(test::TestArgs),
+	/// Hash data using a supported hash algorithm.
+	#[clap(alias = "h")]
+	#[cfg(feature = "hashing")]
+	Hash(hash::HashArgs),
 	/// Remove generated/cached artifacts.
 	#[clap(alias = "C")]
 	Clean(clean::CleanArgs),
@@ -182,6 +188,11 @@ impl Command {
 					.await
 					.map(|(project, feature)| Test { project, feature })
 			},
+			#[cfg(feature = "hashing")]
+			Self::Hash(args) => {
+				env_logger::init();
+				args.command.execute().map(|_| Null)
+			},
 			Self::Clean(args) => {
 				env_logger::init();
 				match args.command {
@@ -240,6 +251,8 @@ impl Display for Command {
 			Self::Clean(_) => write!(f, "clean"),
 			#[cfg(feature = "parachain")]
 			Self::Bench(args) => write!(f, "bench {}", args.command),
+			#[cfg(feature = "hashing")]
+			Command::Hash(_) => write!(f, "hash"),
 		}
 	}
 }


### PR DESCRIPTION
Based on https://www.shawntabrizi.com/substrate-js-utilities/ and https://github.com/hack-ink/subalfred, adds a simple `hash` command as an additional utility to the CLI. It is feature gated behind `experimental` for now. It supports all the hashers typically used by the SDK (blake2, keccack, sha2, twox), without taking on any new dependencies.

### Installation
```shell
cargo install --path ./crates/pop-cli --locked --features experimental
```

### Usage 
There is a subcommand for each supported hasher, which expects the required length of the output along with input data in the form of a string, hex or path to a file to be hashed. The command structure is intended to be as simple as possible, whilst also allowing easier future extensibility. Whilst the commands could be combined with the output length (e.g. keccak-256), its the same amount of characters to type and providing the length separately makes it more natural in terms of how a hasher works imo. Possible values for length are included in `--help`.

Some of the commands also support an additional `--concat` option which can be used for storage key hashing.

```shell
pop hash blake2 256 ./runtime.wasm
pop hash twox 128 some_text
pop hash keccak 256 0x68656c6c6f
```

TODOs:
- [x] potentially include the length, in bytes, with the output 
- [ ] docs - a separate pr to add to pop-docs once approved
- [x] tests

[sc-3512]