### PR TITLE
build(deps): eliminate unnecessary dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -30,6 +30,8 @@ jobs:
   build:
     needs: lint
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-Dwarnings"
     steps:
       - uses: actions/checkout@v4
 
@@ -37,10 +39,13 @@ jobs:
         with:
           git-user: ${{ env.GITHUB_ACTOR }}
 
-      - name: Check Feature Contracts Excl.
+      - name: Check no default features
+        run: cargo check --no-default-features
+
+      - name: Check contracts feature
         run: cargo check --no-default-features --features contract
 
-      - name: Check Features Parachain Excl.
+      - name: Check parachain feature
         run: cargo check --no-default-features --features parachain
 
       - name: Build default features
@@ -132,7 +137,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: [ "ubuntu-latest", "macos-latest" ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -167,7 +172,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: [ "ubuntu-latest", "macos-latest" ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3779,6 +3779,7 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe",
  "openssl-sys",
  "url",
 ]
@@ -5564,6 +5565,7 @@ checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -6187,6 +6189,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
 dependencies = [
  "libsecp256k1-core",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,9 +382,6 @@ checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
 dependencies = [
  "askama_derive",
  "askama_escape",
- "humansize",
- "num-traits",
- "percent-encoding",
 ]
 
 [[package]]
@@ -753,13 +750,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -780,7 +775,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -853,9 +847,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "basic-toml"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
 dependencies = [
  "serde",
 ]
@@ -2913,7 +2907,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
  "log",
- "regex",
 ]
 
 [[package]]
@@ -2935,10 +2928,7 @@ version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
 dependencies = [
- "anstream",
- "anstyle",
  "env_filter",
- "jiff",
  "log",
 ]
 
@@ -3789,7 +3779,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
  "openssl-sys",
  "url",
 ]
@@ -4209,15 +4198,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4240,7 +4220,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -4994,30 +4974,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
-name = "jiff"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "jni"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5608,7 +5564,6 @@ checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -5621,7 +5576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6235,20 +6190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libssh2-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6742,7 +6683,6 @@ checksum = "652cd6d169a36eaf9d1e6bce1a221130439a966d7f27858af66a33a66e9c4ee2"
 dependencies = [
  "assert-json-diff",
  "bytes",
- "colored",
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
@@ -8095,8 +8035,6 @@ dependencies = [
  "dirs",
  "duct",
  "env_logger 0.11.7",
- "frame-benchmarking-cli",
- "frame-try-runtime",
  "git2",
  "mockito",
  "open",
@@ -8118,7 +8056,6 @@ dependencies = [
  "tokio",
  "toml 0.5.11",
  "tower-http 0.6.2",
- "tracing",
  "tracing-subscriber",
  "url",
 ]
@@ -8245,15 +8182,6 @@ name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "powerfmt"
@@ -10958,9 +10886,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
@@ -13850,7 +13778,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ dirs = { version = "5.0", default-features = false }
 duct = { version = "0.13", default-features = false }
 env_logger = { version = "0.11.7", default-features = false }
 flate2 = "1.0.30"
-git2 = { version = "0.18", default-features = false, features = ["vendored-openssl"] }
+git2 = { version = "0.18", default-features = true, features = ["vendored-openssl"] }
 glob = { version = "0.3.1", default-features = false }
 log = { version = "0.4.20", default-features = false }
 mockito = { version = "1.4.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,78 +21,77 @@ rust-version = "1.81.0"
 version = "0.7.0"
 
 [workspace.dependencies]
-anyhow = "1.0"
-assert_cmd = "2.0.14"
-cargo_toml = "0.20.3"
-dirs = "5.0"
-duct = "0.13"
-env_logger = "0.11.7"
+anyhow = { version = "1.0", default-features = false }
+assert_cmd = { version = "2.0.14", default-features = false }
+cargo_toml = { version = "0.20.3", default-features = false }
+dirs = { version = "5.0", default-features = false }
+duct = { version = "0.13", default-features = false }
+env_logger = { version = "0.11.7", default-features = false }
 flate2 = "1.0.30"
-git2 = { version = "0.18", features = ["vendored-openssl"] }
-glob = "0.3.1"
-log = "0.4.20"
-mockito = "1.4.0"
-tar = "0.4.40"
-tempfile = "3.10"
-thiserror = "1.0.58"
-tokio-test = "0.4.4"
-toml = "0.5.0"
-tracing = "0.1.41"
-tracing-subscriber = "0.3.19"
+git2 = { version = "0.18", default-features = false, features = ["vendored-openssl"] }
+glob = { version = "0.3.1", default-features = false }
+log = { version = "0.4.20", default-features = false }
+mockito = { version = "1.4.0", default-features = false }
+tar = { version = "0.4.40", default-features = false }
+tempfile = { version = "3.10", default-features = false }
+thiserror = { version = "1.0.58", default-features = false }
+tokio-test = { version = "0.4.4", default-features = false }
+toml = { version = "0.5.0", default-features = false }
+tracing-subscriber = { version = "0.3.19", default-features = false }
 
 # networking
-reqwest = { version = "0.12", features = ["json", "multipart", "stream"] }
-tokio = { version = "1.0", features = ["macros", "process", "rt-multi-thread"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "stream"] }
+tokio = { version = "1.0", default-features = false, features = ["macros", "process", "rt-multi-thread"] }
 url = "2.5.4"
 
 # contracts
-subxt-signer = { version = "0.38.0", features = ["subxt", "sr25519"] }
-subxt = "0.38.0"
-ink_env = "5.0.0"
-sp-core = "32.0.0"
-sp-weights = "31.0.0"
+subxt-signer = { version = "0.38.0", default-features = false, features = ["subxt", "sr25519"] }
+subxt = { version = "0.38.0", default-features = false }
+ink_env = { version = "5.0.0", default-features = false }
+sp-core = { version = "32.0.0", default-features = false }
+sp-weights = { version = "31.0.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 scale-info = { version = "2.11.4", default-features = false, features = ["derive"] }
 scale-value = { version = "0.17.0", default-features = false, features = ["from-string", "parser-ss58"] }
-contract-build = "5.0.2"
-contract-extrinsics = "5.0.2"
-contract-transcode = "5.0.2"
-heck = "0.5.0"
+contract-build = { version = "5.0.2", default-features = false }
+contract-extrinsics = { version = "5.0.2", default-features = false }
+contract-transcode = { version = "5.0.2", default-features = false }
+heck = { version = "0.5.0", default-features = false }
 
 # parachains
-askama = "0.12"
-regex = "1.10"
-walkdir = "2.5"
-indexmap = "2.2"
+askama = { version = "0.12", default-features = false, features = ["config"] }
+regex = { version = "1.10", default-features = false }
+walkdir = { version = "2.5", default-features = false }
+indexmap = { version = "2.2", default-features = false }
 toml_edit = { version = "0.22", features = ["serde"] }
-symlink = "0.1"
-serde_json = { version = "1.0", features = ["preserve_order"] }
-serde = { version = "1.0", features = ["derive"] }
-srtool-lib = "0.13.2"
-zombienet-sdk = "0.2.26"
+symlink = { version = "0.1", default-features = false }
+serde_json = { version = "1.0", default-features = false, features = ["preserve_order"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+srtool-lib = { version = "0.13.2", default-features = false }
+zombienet-sdk = { version = "0.2.26", default-features = false }
 git2_credentials = "0.13.0"
 
 # benchmarking
 cumulus-primitives-proof-size-hostfunction = "0.10.0"
-frame-benchmarking-cli = "46.0.0"
-sc-chain-spec = "41.0.0"
-sp-runtime = "40.0.1"
+frame-benchmarking-cli = { version = "46.0.0", default-features = false }
+sc-chain-spec = { version = "41.0.0", default-features = false }
+sp-runtime = { version = "40.0.1", default-features = false }
 sp-statement-store = "15.0.0"
 
 # try-runtime
 frame-try-runtime = "0.45.0"
-sc-cli = "0.50.1"
-sp-version = "38.0.0"
+sc-cli = { version = "0.50.1", default-features = false }
+sp-version = { version = "38.0.0", default-features = false }
 
 # pop-cli
-clap = { version = "4.5", features = ["derive"] }
-cliclack = "0.3.1"
-console = "0.15"
+clap = { version = "4.5", default-features = false, features = ["derive"] }
+cliclack = { version = "0.3.1", default-features = false }
+console = { version = "0.15", default-features = false }
 os_info = { version = "3", default-features = false }
-strum = "0.26"
-strum_macros = "0.26"
+strum = { version = "0.26", default-features = false }
+strum_macros = { version = "0.26", default-features = false }
 
 # wallet-integration
-axum = "0.7.9"
-open = "5.3.1"
-tower-http = "0.6.2"
+axum = { version = "0.7.9", default-features = false, features = ["http1", "json", "tokio"] }
+open = { version = "5.3.1", default-features = false }
+tower-http = { version = "0.6.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ tracing-subscriber = "0.3.19"
 
 # networking
 reqwest = { version = "0.12", features = ["json", "multipart", "stream"] }
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["macros", "process", "rt-multi-thread"] }
 url = "2.5.4"
 
 # contracts

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -39,6 +39,8 @@ sp-weights = { workspace = true, optional = true }
 
 # parachains
 pop-parachains = { path = "../pop-parachains", version = "0.7.0", optional = true }
+tracing-subscriber = { workspace = true, optional = true }
+
 dirs = { workspace = true, optional = true }
 git2.workspace = true
 
@@ -53,10 +55,6 @@ axum.workspace = true
 open.workspace = true
 tower-http = { workspace = true, features = ["fs", "cors"] }
 
-
-tracing.workspace = true
-tracing-subscriber.workspace = true
-
 [dev-dependencies]
 assert_cmd.workspace = true
 contract-extrinsics.workspace = true
@@ -68,5 +66,5 @@ sp-weights.workspace = true
 [features]
 default = ["contract", "parachain", "telemetry"]
 contract = ["dep:pop-contracts", "dep:sp-weights", "dep:dirs"]
-parachain = ["dep:pop-parachains", "dep:dirs"]
+parachain = ["dep:pop-parachains", "dep:dirs", "dep:tracing-subscriber"]
 telemetry = ["dep:pop-telemetry"]

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -58,9 +58,6 @@ frame-benchmarking-cli.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
-# try-runtime
-frame-try-runtime = { workspace = true, features = ["try-runtime"] }
-
 [dev-dependencies]
 assert_cmd.workspace = true
 contract-extrinsics.workspace = true

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -17,6 +17,7 @@ anyhow.workspace = true
 clap.workspace = true
 cliclack.workspace = true
 console.workspace = true
+dirs.workspace = true
 duct.workspace = true
 env_logger.workspace = true
 os_info.workspace = true
@@ -37,7 +38,6 @@ sp-weights = { workspace = true, optional = true }
 
 # parachains
 pop-parachains = { path = "../pop-parachains", version = "0.7.0", optional = true }
-dirs = { workspace = true, optional = true }
 git2 = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 
@@ -62,7 +62,7 @@ sp-weights.workspace = true
 
 [features]
 default = ["contract", "parachain", "telemetry"]
-contract = ["dep:pop-contracts", "dep:dirs", "dep:sp-core", "dep:sp-weights", "wallet-integration"]
-parachain = ["dep:pop-parachains", "dep:dirs", "dep:git2", "dep:tracing-subscriber", "wallet-integration"]
+contract = ["dep:pop-contracts", "dep:sp-core", "dep:sp-weights", "wallet-integration"]
+parachain = ["dep:pop-parachains", "dep:git2", "dep:tracing-subscriber", "wallet-integration"]
 telemetry = ["dep:pop-telemetry"]
 wallet-integration = ["dep:axum", "dep:open", "dep:tower-http"]

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -53,8 +53,7 @@ axum.workspace = true
 open.workspace = true
 tower-http = { workspace = true, features = ["fs", "cors"] }
 
-# benchmarking
-frame-benchmarking-cli.workspace = true
+
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -29,12 +29,12 @@ url.workspace = true
 clap.workspace = true
 cliclack.workspace = true
 console.workspace = true
-sp-core.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 
 # contracts
 pop-contracts = { path = "../pop-contracts", version = "0.7.0", optional = true }
+sp-core = { workspace = true, optional = true }
 sp-weights = { workspace = true, optional = true }
 
 # parachains
@@ -64,6 +64,6 @@ sp-weights.workspace = true
 
 [features]
 default = ["contract", "parachain", "telemetry"]
-contract = ["dep:pop-contracts", "dep:sp-weights", "dep:dirs"]
+contract = ["dep:pop-contracts", "dep:dirs", "dep:sp-core", "dep:sp-weights", ]
 parachain = ["dep:pop-parachains", "dep:dirs", "dep:git2", "dep:tracing-subscriber"]
 telemetry = ["dep:pop-telemetry"]

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -14,23 +14,21 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
+clap.workspace = true
+cliclack.workspace = true
+console.workspace = true
 duct.workspace = true
 env_logger.workspace = true
 os_info.workspace = true
 reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 toml.workspace = true
 url.workspace = true
-
-# pop-cli
-clap.workspace = true
-cliclack.workspace = true
-console.workspace = true
-strum.workspace = true
-strum_macros.workspace = true
 
 # contracts
 pop-contracts = { path = "../pop-contracts", version = "0.7.0", optional = true }

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -39,10 +39,9 @@ sp-weights = { workspace = true, optional = true }
 
 # parachains
 pop-parachains = { path = "../pop-parachains", version = "0.7.0", optional = true }
-tracing-subscriber = { workspace = true, optional = true }
-
 dirs = { workspace = true, optional = true }
-git2.workspace = true
+git2 = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
 
 # telemetry
 pop-telemetry = { path = "../pop-telemetry", version = "0.7.0", optional = true }
@@ -66,5 +65,5 @@ sp-weights.workspace = true
 [features]
 default = ["contract", "parachain", "telemetry"]
 contract = ["dep:pop-contracts", "dep:sp-weights", "dep:dirs"]
-parachain = ["dep:pop-parachains", "dep:dirs", "dep:tracing-subscriber"]
+parachain = ["dep:pop-parachains", "dep:dirs", "dep:git2", "dep:tracing-subscriber"]
 telemetry = ["dep:pop-telemetry"]

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -48,9 +48,9 @@ pop-telemetry = { path = "../pop-telemetry", version = "0.7.0", optional = true 
 pop-common = { path = "../pop-common", version = "0.7.0" }
 
 # wallet-integration
-axum.workspace = true
-open.workspace = true
-tower-http = { workspace = true, features = ["fs", "cors"] }
+axum = { workspace = true, optional = true }
+open = { workspace = true, optional = true }
+tower-http = { workspace = true, features = ["fs", "cors"], optional = true }
 
 [dev-dependencies]
 assert_cmd.workspace = true
@@ -62,6 +62,7 @@ sp-weights.workspace = true
 
 [features]
 default = ["contract", "parachain", "telemetry"]
-contract = ["dep:pop-contracts", "dep:dirs", "dep:sp-core", "dep:sp-weights", ]
-parachain = ["dep:pop-parachains", "dep:dirs", "dep:git2", "dep:tracing-subscriber"]
+contract = ["dep:pop-contracts", "dep:dirs", "dep:sp-core", "dep:sp-weights", "wallet-integration"]
+parachain = ["dep:pop-parachains", "dep:dirs", "dep:git2", "dep:tracing-subscriber", "wallet-integration"]
 telemetry = ["dep:pop-telemetry"]
+wallet-integration = ["dep:axum", "dep:open", "dep:tower-http"]

--- a/crates/pop-cli/src/cli.rs
+++ b/crates/pop-cli/src/cli.rs
@@ -10,6 +10,7 @@ pub(crate) mod traits {
 	use std::{fmt::Display, io::Result};
 
 	/// A command line interface.
+	#[allow(dead_code)]
 	pub trait Cli {
 		/// Constructs a new [`Confirm`] prompt.
 		fn confirm(&mut self, prompt: impl Display) -> impl Confirm;
@@ -26,6 +27,7 @@ pub(crate) mod traits {
 		/// Prints a footer of the prompt sequence with a failure style.
 		fn outro_cancel(&mut self, message: impl Display) -> Result<()>;
 		/// Constructs a new [`Password`] prompt.
+		#[allow(dead_code)]
 		fn password(&mut self, prompt: impl Display) -> impl Password;
 		/// Constructs a new [`Select`] prompt.
 		fn select<T: Clone + Eq>(&mut self, prompt: impl Display) -> impl Select<T>;
@@ -36,6 +38,7 @@ pub(crate) mod traits {
 	}
 
 	/// A confirmation prompt.
+	#[allow(dead_code)]
 	pub trait Confirm {
 		/// Sets the initially selected value.
 		fn initial_value(self, initial_value: bool) -> Self;
@@ -44,6 +47,7 @@ pub(crate) mod traits {
 	}
 
 	/// A text input prompt.
+	#[allow(dead_code)]
 	pub trait Input {
 		/// Sets the default value for the input.
 		fn default_input(self, value: &str) -> Self;
@@ -61,6 +65,7 @@ pub(crate) mod traits {
 	}
 
 	/// A multi-select prompt.
+	#[allow(dead_code)]
 	pub trait MultiSelect<T> {
 		/// Starts the prompt interaction.
 		fn interact(&mut self) -> Result<Vec<T>>;
@@ -73,12 +78,14 @@ pub(crate) mod traits {
 	}
 
 	/// A prompt that masks the input.
+	#[allow(dead_code)]
 	pub trait Password {
 		/// Starts the prompt interaction.
 		fn interact(&mut self) -> Result<String>;
 	}
 
 	/// A select prompt.
+	#[allow(dead_code)]
 	pub trait Select<T> {
 		/// Sets the initially selected value.
 		fn initial_value(self, initial_value: T) -> Self;

--- a/crates/pop-cli/src/commands/bench/block.rs
+++ b/crates/pop-cli/src/commands/bench/block.rs
@@ -9,9 +9,8 @@ use crate::{
 	},
 };
 use clap::Args;
-use frame_benchmarking_cli::BlockCmd;
 use pop_common::Profile;
-use pop_parachains::{generate_binary_benchmarks, BenchmarkingCliCommand};
+use pop_parachains::{bench::BlockCmd, generate_binary_benchmarks, BenchmarkingCliCommand};
 use std::{
 	env::current_dir,
 	path::{Path, PathBuf},
@@ -92,12 +91,11 @@ mod tests {
 	use crate::cli::MockCli;
 	use clap::Parser;
 	use duct::cmd;
-	use frame_benchmarking_cli::BlockCmd;
 	use pop_common::Profile;
 	use std::fs::{self, File};
 	use tempfile::tempdir;
 
-	use super::BenchmarkBlock;
+	use super::*;
 
 	#[test]
 	fn benchmark_block_works() -> anyhow::Result<()> {

--- a/crates/pop-cli/src/commands/bench/machine.rs
+++ b/crates/pop-cli/src/commands/bench/machine.rs
@@ -9,9 +9,8 @@ use crate::{
 	},
 };
 use clap::Args;
-use frame_benchmarking_cli::MachineCmd;
 use pop_common::Profile;
-use pop_parachains::{generate_binary_benchmarks, BenchmarkingCliCommand};
+use pop_parachains::{bench::MachineCmd, generate_binary_benchmarks, BenchmarkingCliCommand};
 use std::{
 	env::current_dir,
 	path::{Path, PathBuf},
@@ -93,12 +92,11 @@ mod tests {
 	use crate::cli::MockCli;
 	use clap::Parser;
 	use duct::cmd;
-	use frame_benchmarking_cli::MachineCmd;
 	use pop_common::Profile;
 	use std::fs::{self, File};
 	use tempfile::tempdir;
 
-	use super::BenchmarkMachine;
+	use super::*;
 
 	#[test]
 	fn benchmark_machine_works() -> anyhow::Result<()> {

--- a/crates/pop-cli/src/commands/bench/overhead.rs
+++ b/crates/pop-cli/src/commands/bench/overhead.rs
@@ -11,9 +11,10 @@ use crate::{
 };
 use clap::{Args, Parser};
 use cliclack::spinner;
-use frame_benchmarking_cli::OverheadCmd;
 use pop_common::Profile;
-use pop_parachains::{generate_omni_bencher_benchmarks, BenchmarkingCliCommand};
+use pop_parachains::{
+	bench::OverheadCmd, generate_omni_bencher_benchmarks, BenchmarkingCliCommand,
+};
 use std::{env::current_dir, path::PathBuf};
 use tempfile::tempdir;
 

--- a/crates/pop-cli/src/commands/bench/storage.rs
+++ b/crates/pop-cli/src/commands/bench/storage.rs
@@ -10,9 +10,8 @@ use crate::{
 	},
 };
 use clap::Args;
-use frame_benchmarking_cli::StorageCmd;
 use pop_common::Profile;
-use pop_parachains::{generate_binary_benchmarks, BenchmarkingCliCommand};
+use pop_parachains::{bench::StorageCmd, generate_binary_benchmarks, BenchmarkingCliCommand};
 use std::{
 	env::current_dir,
 	path::{Path, PathBuf},
@@ -134,12 +133,11 @@ mod tests {
 	use crate::cli::MockCli;
 	use clap::Parser;
 	use duct::cmd;
-	use frame_benchmarking_cli::StorageCmd;
 	use pop_common::Profile;
 	use std::fs::{self, File};
 	use tempfile::tempdir;
 
-	use super::BenchmarkStorage;
+	use super::*;
 
 	#[test]
 	fn benchmark_storage_works() -> anyhow::Result<()> {

--- a/crates/pop-cli/src/commands/build/runtime.rs
+++ b/crates/pop-cli/src/commands/build/runtime.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0
 
+pub use crate::common::runtime::Feature::{self, *};
 use crate::{
 	cli::{self},
 	common::{
 		prompt::display_message,
-		runtime::{
-			build_runtime, ensure_runtime_binary_exists,
-			Feature::{Benchmark, TryRuntime},
-		},
+		runtime::{build_runtime, ensure_runtime_binary_exists},
 	},
 };
 use pop_common::{find_workspace_toml, Profile};

--- a/crates/pop-cli/src/commands/test/execute_block.rs
+++ b/crates/pop-cli/src/commands/test/execute_block.rs
@@ -13,10 +13,10 @@ use crate::{
 };
 use clap::Args;
 use cliclack::spinner;
-use frame_try_runtime::TryStateSelect;
 use pop_parachains::{
 	parse_try_state_string, run_try_runtime,
 	state::{LiveState, State, StateCommand},
+	try_runtime::TryStateSelect,
 	SharedParams, TryRuntimeCliCommand,
 };
 

--- a/crates/pop-cli/src/commands/test/fast_forward.rs
+++ b/crates/pop-cli/src/commands/test/fast_forward.rs
@@ -18,10 +18,10 @@ use crate::{
 use clap::Args;
 use cliclack::spinner;
 use console::style;
-use frame_try_runtime::TryStateSelect;
 use pop_parachains::{
 	parse_try_state_string, run_try_runtime,
 	state::{LiveState, State, StateCommand},
+	try_runtime::TryStateSelect,
 	SharedParams, TryRuntimeCliCommand,
 };
 

--- a/crates/pop-cli/src/commands/test/mod.rs
+++ b/crates/pop-cli/src/commands/test/mod.rs
@@ -1,19 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::{
-	cli,
-	common::{
-		builds::get_project_path,
-		Project::{self, *},
-		TestFeature::{self, Unit},
-	},
+#[cfg(feature = "contract")]
+use crate::cli;
+use crate::common::{
+	builds::get_project_path,
+	Project::{self, *},
+	TestFeature::{self, Unit},
 };
 use clap::{Args, Subcommand};
 use pop_common::test_project;
-use std::{
-	fmt::{Display, Formatter, Result},
-	path::PathBuf,
-};
+#[cfg(any(feature = "parachain", feature = "contract"))]
+use std::fmt::{Display, Formatter, Result};
+use std::path::PathBuf;
 
 #[cfg(feature = "contract")]
 pub mod contract;
@@ -30,6 +28,7 @@ pub mod on_runtime_upgrade;
 #[derive(Args, Default)]
 #[command(args_conflicts_with_subcommands = true)]
 pub(crate) struct TestArgs {
+	#[cfg(any(feature = "contract", feature = "parachain"))]
 	#[command(subcommand)]
 	pub(crate) command: Option<Command>,
 	/// Directory path for your project [default: current directory]
@@ -67,12 +66,17 @@ pub(crate) enum Command {
 
 impl Command {
 	pub(crate) async fn execute(args: TestArgs) -> anyhow::Result<(Project, TestFeature)> {
-		Self::test(args, &mut cli::Cli).await
+		Self::test(
+			args,
+			#[cfg(feature = "contract")]
+			&mut cli::Cli,
+		)
+		.await
 	}
 
 	async fn test(
 		args: TestArgs,
-		cli: &mut impl cli::traits::Cli,
+		#[cfg(feature = "contract")] cli: &mut impl cli::traits::Cli,
 	) -> anyhow::Result<(Project, TestFeature)> {
 		let project_path = get_project_path(args.path.clone(), args.path_pos.clone());
 
@@ -94,6 +98,7 @@ impl Command {
 	}
 }
 
+#[cfg(any(feature = "parachain", feature = "contract"))]
 impl Display for Command {
 	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
 		match self {

--- a/crates/pop-cli/src/commands/test/on_runtime_upgrade.rs
+++ b/crates/pop-cli/src/commands/test/on_runtime_upgrade.rs
@@ -19,10 +19,10 @@ use clap::Args;
 use clap::Parser;
 use cliclack::spinner;
 use console::style;
-use frame_try_runtime::UpgradeCheckSelect;
 use pop_parachains::{
 	run_try_runtime,
 	state::{State, StateCommand},
+	try_runtime::UpgradeCheckSelect,
 	upgrade_checks_details, SharedParams, TryRuntimeCliCommand,
 };
 use std::{str::FromStr, thread::sleep, time::Duration};

--- a/crates/pop-cli/src/common/binary.rs
+++ b/crates/pop-cli/src/common/binary.rs
@@ -1,15 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::cli::traits::*;
-use cliclack::spinner;
 use duct::cmd;
-use pop_common::sourcing::{set_executable_permission, Binary};
-use std::{
-	cmp::Ordering,
-	path::{Path, PathBuf},
+#[cfg(feature = "parachain")]
+use std::cmp::Ordering;
+#[cfg(any(feature = "contract", feature = "parachain"))]
+use {
+	crate::cli::traits::*,
+	cliclack::spinner,
+	pop_common::sourcing::{set_executable_permission, Binary},
+	std::path::{Path, PathBuf},
 };
 
 /// A trait for binary generator.
+#[cfg(any(feature = "contract", feature = "parachain"))]
 pub(crate) trait BinaryGenerator {
 	/// Generates a binary.
 	///
@@ -31,6 +34,7 @@ pub(crate) trait BinaryGenerator {
 /// * `cache_path` - The cache directory path where the binary is stored.
 /// * `skip_confirm` - If `true`, skips confirmation prompts and automatically sources the binary if
 ///   needed.
+#[cfg(any(feature = "contract", feature = "parachain"))]
 pub async fn check_and_prompt<Generator: BinaryGenerator>(
 	cli: &mut impl Cli,
 	binary_name: &'static str,
@@ -150,6 +154,7 @@ impl TryFrom<String> for SemanticVersion {
 /// * `binary` - The name of the binary to find.
 /// * `target_version` - The version to match.
 /// * `order` - The ordering to use when matching versions.
+#[cfg(feature = "parachain")]
 pub(crate) fn which_version(
 	binary: &str,
 	target_version: &SemanticVersion,

--- a/crates/pop-cli/src/common/builds.rs
+++ b/crates/pop-cli/src/common/builds.rs
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::cli::traits::{Cli, Select};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[cfg(feature = "parachain")]
-use pop_common::Profile;
-#[cfg(feature = "parachain")]
-use pop_parachains::{binary_path, build_parachain};
-#[cfg(feature = "parachain")]
-use strum::{EnumMessage, VariantArray};
+use {
+	crate::cli::traits::{Cli, Select},
+	pop_common::Profile,
+	pop_parachains::{binary_path, build_parachain},
+	std::path::Path,
+	strum::{EnumMessage, VariantArray},
+};
 
 /// This method is used to get the proper project path format (with or without cli flag)
 pub fn get_project_path(path_flag: Option<PathBuf>, path_pos: Option<PathBuf>) -> Option<PathBuf> {

--- a/crates/pop-cli/src/common/mod.rs
+++ b/crates/pop-cli/src/common/mod.rs
@@ -14,6 +14,7 @@ pub mod helpers;
 /// Contains utilities for interacting with the CLI prompt.
 pub mod prompt;
 /// Contains runtime utilities.
+#[cfg(feature = "parachain")]
 pub mod runtime;
 /// Contains try-runtime utilities.
 #[cfg(feature = "parachain")]
@@ -37,10 +38,13 @@ pub enum Data {
 		feature: TestFeature,
 	},
 	/// Project that was started.
+	#[cfg(any(feature = "contract", feature = "parachain"))]
 	Up(Project),
 	/// OS where installation occurred.
+	#[cfg(any(feature = "contract", feature = "parachain"))]
 	Install(Os),
 	/// Template that was created.
+	#[cfg(any(feature = "contract", feature = "parachain"))]
 	New(Template),
 	/// No additional data.
 	Null,
@@ -70,6 +74,7 @@ pub enum TestFeature {
 
 /// Project templates.
 #[derive(Debug, PartialEq, Clone)]
+#[cfg(any(feature = "contract", feature = "parachain"))]
 pub enum Template {
 	/// Smart contract template.
 	#[cfg(feature = "contract")]
@@ -78,6 +83,7 @@ pub enum Template {
 	#[cfg(feature = "parachain")]
 	Chain(pop_parachains::Parachain),
 	/// Pallet template.
+	#[cfg(feature = "parachain")]
 	Pallet,
 }
 
@@ -96,21 +102,25 @@ pub enum Os {
 // double display.
 impl Display for Data {
 	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-		use strum::EnumMessage;
 		use Data::*;
-		use Template::*;
+		#[cfg(any(feature = "contract", feature = "parachain"))]
+		use {strum::EnumMessage, Template::*};
 
 		match self {
 			Null => write!(f, ""),
 			Build(project) => write!(f, "{}", project),
 			Test { project, feature } => write!(f, "{} {}", project, feature),
+			#[cfg(any(feature = "contract", feature = "parachain"))]
 			Install(os) => write!(f, "{}", os),
+			#[cfg(any(feature = "contract", feature = "parachain"))]
 			Up(project) => write!(f, "{}", project),
+			#[cfg(any(feature = "contract", feature = "parachain"))]
 			New(template) => match template {
 				#[cfg(feature = "parachain")]
 				Chain(chain) => write!(f, "{}", chain.get_message().unwrap_or("")),
 				#[cfg(feature = "contract")]
 				Contract(contract) => write!(f, "{}", contract.get_message().unwrap_or("")),
+				#[cfg(feature = "parachain")]
 				Pallet => write!(f, "pallet"),
 			},
 		}
@@ -129,6 +139,7 @@ impl Display for Project {
 	}
 }
 
+#[cfg(any(feature = "contract", feature = "parachain"))]
 impl Display for Template {
 	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
 		use Template::*;
@@ -137,6 +148,7 @@ impl Display for Template {
 			Chain(chain) => write!(f, "{}", chain),
 			#[cfg(feature = "contract")]
 			Contract(contract) => write!(f, "{}", contract),
+			#[cfg(feature = "parachain")]
 			Pallet => write!(f, "pallet"),
 		}
 	}

--- a/crates/pop-cli/src/common/mod.rs
+++ b/crates/pop-cli/src/common/mod.rs
@@ -18,6 +18,7 @@ pub mod runtime;
 /// Contains try-runtime utilities.
 #[cfg(feature = "parachain")]
 pub mod try_runtime;
+#[cfg(feature = "wallet-integration")]
 pub mod wallet;
 
 use std::fmt::{Display, Formatter, Result};

--- a/crates/pop-cli/src/common/prompt.rs
+++ b/crates/pop-cli/src/common/prompt.rs
@@ -4,6 +4,7 @@ use crate::cli::traits::Cli;
 use anyhow::Result;
 
 // Displays a message to the user, with formatting based on the success status.
+#[allow(dead_code)]
 pub(crate) fn display_message(message: &str, success: bool, cli: &mut impl Cli) -> Result<()> {
 	if success {
 		cli.outro(message)?;

--- a/crates/pop-cli/src/common/try_runtime.rs
+++ b/crates/pop-cli/src/common/try_runtime.rs
@@ -14,11 +14,11 @@ use crate::{
 use clap::Args;
 use cliclack::spinner;
 use console::style;
-use frame_try_runtime::TryStateSelect;
 use pop_common::{sourcing::Binary, Profile};
 use pop_parachains::{
 	parse, set_up_client,
 	state::{LiveState, State, StateCommand},
+	try_runtime::TryStateSelect,
 	try_runtime_generator, try_state_details, try_state_label, Runtime, SharedParams,
 };
 use std::{

--- a/crates/pop-cli/src/common/wallet.rs
+++ b/crates/pop-cli/src/common/wallet.rs
@@ -4,14 +4,16 @@ use crate::{
 	cli::traits::Cli,
 	wallet_integration::{FrontendFromString, TransactionData, WalletIntegrationManager},
 };
-use anyhow::{anyhow, Result};
 use cliclack::{log, spinner};
 #[cfg(feature = "parachain")]
-use pop_parachains::{
-	parse_and_format_events, submit_signed_extrinsic, ExtrinsicEvents, OnlineClient,
-	SubstrateConfig,
+use {
+	anyhow::{anyhow, Result},
+	pop_parachains::{
+		parse_and_format_events, submit_signed_extrinsic, ExtrinsicEvents, OnlineClient,
+		SubstrateConfig,
+	},
+	url::Url,
 };
-use url::Url;
 
 /// The prompt to ask the user if they want to use the wallet for signing.
 pub const USE_WALLET_PROMPT: &str = "Do you want to use your browser wallet to sign the extrinsic? (Selecting 'No' will prompt you to manually enter the secret key URI for signing, e.g., '//Alice')";

--- a/crates/pop-cli/src/main.rs
+++ b/crates/pop-cli/src/main.rs
@@ -21,6 +21,7 @@ mod common;
 #[cfg(feature = "parachain")]
 mod deployment_api;
 mod style;
+#[cfg(feature = "wallet-integration")]
 mod wallet_integration;
 
 #[tokio::main]

--- a/crates/pop-cli/src/main.rs
+++ b/crates/pop-cli/src/main.rs
@@ -1,8 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
 
-#[cfg(not(any(feature = "contract", feature = "parachain")))]
-compile_error!("feature \"contract\" or feature \"parachain\" must be enabled");
-
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use commands::*;
@@ -15,7 +12,6 @@ use std::{
 };
 
 mod cli;
-#[cfg(any(feature = "parachain", feature = "contract"))]
 mod commands;
 mod common;
 #[cfg(feature = "parachain")]

--- a/crates/pop-cli/src/style.rs
+++ b/crates/pop-cli/src/style.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use cliclack::ThemeState;
-#[cfg(any(feature = "parachain", feature = "contract"))]
 pub(crate) use console::style;
 use console::Style;
 
@@ -43,11 +42,13 @@ impl cliclack::Theme for Theme {
 }
 
 /// Formats a URL with bold and underlined style.
+#[cfg(feature = "parachain")]
 pub(crate) fn format_url(url: &str) -> String {
 	format!("{}", style(url).bold().underlined())
 }
 
 /// Formats the step label if steps should be shown.
+#[cfg(feature = "parachain")]
 pub(crate) fn format_step_prefix(current: usize, total: usize, show: bool) -> String {
 	show.then(|| format!("[{}/{}]: ", current, total)).unwrap_or_default()
 }

--- a/crates/pop-parachains/src/bench/mod.rs
+++ b/crates/pop-parachains/src/bench/mod.rs
@@ -4,6 +4,7 @@ use crate::Error;
 use clap::Parser;
 use duct::cmd;
 use frame_benchmarking_cli::PalletCmd;
+pub use frame_benchmarking_cli::{BlockCmd, MachineCmd, OverheadCmd, StorageCmd};
 use sc_chain_spec::GenesisConfigBuilderRuntimeCaller;
 use serde::{Deserialize, Serialize};
 use sp_runtime::traits::BlakeTwo256;

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -13,7 +13,7 @@ mod new_pallet;
 mod new_parachain;
 mod relay;
 mod templates;
-mod try_runtime;
+pub mod try_runtime;
 mod up;
 mod utils;
 

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 
 #![doc = include_str!("../README.md")]
-mod bench;
+
+pub mod bench;
 mod build;
 /// Provides functionality to construct, encode, sign, and submit chain extrinsics.
 mod call;

--- a/crates/pop-parachains/src/try_runtime/mod.rs
+++ b/crates/pop-parachains/src/try_runtime/mod.rs
@@ -1,6 +1,6 @@
 use crate::{errors::handle_command_error, Error};
 use duct::cmd;
-use frame_try_runtime::{TryStateSelect, UpgradeCheckSelect};
+pub use frame_try_runtime::{TryStateSelect, UpgradeCheckSelect};
 use std::{fmt::Display, path::PathBuf, str::from_utf8};
 
 /// Provides functionality for sourcing binaries of the `try-runtime-cli`.


### PR DESCRIPTION
Eliminates unnecessary dependencies when building without default features. The number of dependencies when building with the `contract` feature only has been halved from ~1k to 500k. A handful were removed more generally by using `default-features = false`.

Also updates CI to ensure that builds with -`-no-default-features` are successful and remain so. Whilst the tool is primarily aimed towards contract and parachain development, allowing successful builds with no default features allows the introduction and testing of additional experimental features which are not specific to these two developer journeys.

[sc-3569]