### PR TITLE
chore: update required version of the frame-omni-bencher binary

### DIFF
--- a/crates/pop-cli/src/common/bench.rs
+++ b/crates/pop-cli/src/common/bench.rs
@@ -17,7 +17,7 @@ use std::{
 use super::binary::{which_version, SemanticVersion};
 
 pub(crate) const EXECUTED_COMMAND_COMMENT: &str = "// Executed Command:";
-const TARGET_BINARY_VERSION: SemanticVersion = SemanticVersion(0, 1, 0);
+const TARGET_BINARY_VERSION: SemanticVersion = SemanticVersion(0, 10, 0);
 const BINARY_NAME: &str = "frame-omni-bencher";
 
 impl_binary_generator!(OmniBencherGenerator, omni_bencher_generator);

--- a/crates/pop-cli/src/common/bench.rs
+++ b/crates/pop-cli/src/common/bench.rs
@@ -17,7 +17,7 @@ use std::{
 use super::binary::{which_version, SemanticVersion};
 
 pub(crate) const EXECUTED_COMMAND_COMMENT: &str = "// Executed Command:";
-const TARGET_BINARY_VERSION: SemanticVersion = SemanticVersion(0, 10, 0);
+const TARGET_BINARY_VERSION: SemanticVersion = SemanticVersion(0, 1, 0);
 const BINARY_NAME: &str = "frame-omni-bencher";
 
 impl_binary_generator!(OmniBencherGenerator, omni_bencher_generator);
@@ -240,9 +240,8 @@ mod tests {
 	async fn omni_bencher_version_works() -> anyhow::Result<()> {
 		let cache_path = tempdir().expect("Could create temp dir");
 		let path = source_omni_bencher_binary(&mut MockCli::new(), cache_path.path(), true).await?;
-		assert_eq!(
-			SemanticVersion::try_from(path.to_str().unwrap().to_string())?,
-			SemanticVersion(0, 1, 0)
+		assert!(
+			SemanticVersion::try_from(path.to_str().unwrap().to_string())? >= TARGET_BINARY_VERSION
 		);
 		Ok(())
 	}

--- a/crates/pop-cli/src/common/try_runtime.rs
+++ b/crates/pop-cli/src/common/try_runtime.rs
@@ -1181,9 +1181,8 @@ mod tests {
 	async fn try_runtime_version_works() -> anyhow::Result<()> {
 		let cache_path = tempdir().expect("Could create temp dir");
 		let path = source_try_runtime_binary(&mut MockCli::new(), cache_path.path(), true).await?;
-		assert_eq!(
-			SemanticVersion::try_from(path.to_str().unwrap().to_string())?,
-			SemanticVersion(0, 8, 0)
+		assert!(
+			SemanticVersion::try_from(path.to_str().unwrap().to_string())? >= TARGET_BINARY_VERSION
 		);
 		Ok(())
 	}

--- a/crates/pop-parachains/src/bench/binary.rs
+++ b/crates/pop-parachains/src/bench/binary.rs
@@ -83,8 +83,8 @@ mod tests {
 	async fn omni_bencher_generator_works() -> Result<(), Error> {
 		let temp_dir = tempdir()?;
 		let temp_dir_path = temp_dir.into_path();
-		let version = "polkadot-stable2412-4";
-		let binary = omni_bencher_generator(temp_dir_path.clone(), None).await?;
+		let version = "polkadot-stable2412";
+		let binary = omni_bencher_generator(temp_dir_path.clone(), Some(version)).await?;
 		assert!(matches!(binary, Binary::Source { name: _, source, cache }
 				if source == Source::GitHub(ReleaseArchive {
 					owner: "r0gue-io".to_string(),

--- a/crates/pop-parachains/src/bench/binary.rs
+++ b/crates/pop-parachains/src/bench/binary.rs
@@ -83,7 +83,7 @@ mod tests {
 	async fn omni_bencher_generator_works() -> Result<(), Error> {
 		let temp_dir = tempdir()?;
 		let temp_dir_path = temp_dir.into_path();
-		let version = "polkadot-stable2412";
+		let version = "polkadot-stable2412-4";
 		let binary = omni_bencher_generator(temp_dir_path.clone(), None).await?;
 		assert!(matches!(binary, Binary::Source { name: _, source, cache }
 				if source == Source::GitHub(ReleaseArchive {


### PR DESCRIPTION
Update the version tests of the binaries `frame-omni-bencher` and `try-runtime`. The idea is, whatever versions above the threshold one are accepted and source binaries if the deprecated version of the binaries used.

If there is a break in the future version of the binary, we update the threshold version and change the code to support newer versions. 