### PR TITLE
fix: wrap github rest api access in an apiclient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,9 +1258,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bzip2-sys"
@@ -8081,6 +8081,7 @@ name = "pop-common"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "cargo_toml",
  "contract-build",
  "contract-extrinsics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ toml = { version = "0.5.0", default-features = false }
 tracing-subscriber = { version = "0.3.19", default-features = false }
 
 # networking
-reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["default-tls", "json", "multipart", "stream"] }
 tokio = { version = "1.0", default-features = false, features = ["macros", "process", "rt-multi-thread"] }
 url = "2.5.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ version = "0.7.0"
 [workspace.dependencies]
 anyhow = { version = "1.0", default-features = false }
 assert_cmd = { version = "2.0.14", default-features = false }
+bytes = { version = "1.10.1", default-features = false }
 cargo_toml = { version = "0.20.3", default-features = false }
 dirs = { version = "5.0", default-features = false }
 duct = { version = "0.13", default-features = false }

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Run all tests (unit + integration):
 cargo test
 ```
 
+> Running tests may result in rate limits being exhausted due to the reliance on the GitHub REST API for determining
+> releases. As
+> per <https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#getting-a-higher-rate-limit>, a
+> personal access token can be used via the `GITHUB_TOKEN` environment variable.
+
 ## Acknowledgements
 
 Pop CLI would not be possible without these awesome crates!

--- a/crates/pop-common/Cargo.toml
+++ b/crates/pop-common/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+bytes.workspace = true
 cargo_toml.workspace = true
 contract-build.workspace = true
 contract-extrinsics.workspace = true

--- a/crates/pop-common/src/api.rs
+++ b/crates/pop-common/src/api.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-3.0
+
+use crate::APP_USER_AGENT;
+use reqwest::{IntoUrl, Response};
+use std::{
+	error::Error as _,
+	ops::Deref,
+	sync::{Arc, Mutex},
+	time::{SystemTime, SystemTimeError},
+};
+use thiserror::Error;
+use tokio::{
+	sync::{AcquireError, Semaphore},
+	time::{Duration, Instant},
+};
+
+pub(crate) struct ApiClient {
+	permits: Arc<Semaphore>,
+	token: Option<String>,
+	rate_limits: Arc<Mutex<RateLimits>>,
+}
+impl ApiClient {
+	pub(crate) fn new(max_concurrent: usize, token: Option<String>) -> Self {
+		Self {
+			permits: Arc::new(Semaphore::new(max_concurrent)),
+			token,
+			rate_limits: Arc::new(Mutex::new(RateLimits::default())),
+		}
+	}
+
+	pub(crate) async fn get<U: IntoUrl>(&self, url: U) -> Result<Response, Error> {
+		let _permit = self.permits.acquire().await?;
+		let mut rate_limits = self.rate_limits.lock().map_err(|_| Error::LockAcquisitionError)?;
+
+		// Check if prior evidence of being rate limited
+		// Note: only applies if multiple attempts within the same process (e.g., tests)
+		if let Some(0) = rate_limits.remaining {
+			if let Some(reset) = rate_limits.reset {
+				let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
+				if now < reset {
+					return Err(rate_limits.deref().into());
+				}
+			}
+		}
+
+		// Build request
+		let client = reqwest::Client::builder().user_agent(APP_USER_AGENT).build()?;
+		let mut request = client.get(url);
+		if let Some(token) = &self.token {
+			request = request.header("Authorization", format!("token {}", token));
+		}
+
+		// Send request
+		let response = request.send().await?;
+
+		// Update rate limits from response headers
+		let headers = response.headers();
+		rate_limits.limit = headers
+			.get("x-ratelimit-limit")
+			.and_then(|v| v.to_str().ok())
+			.and_then(|v| v.parse::<u64>().ok());
+		rate_limits.remaining = headers
+			.get("x-ratelimit-remaining")
+			.and_then(|v| v.to_str().ok())
+			.and_then(|v| v.parse::<u64>().ok());
+		rate_limits.reset = headers
+			.get("x-ratelimit-reset")
+			.and_then(|v| v.to_str().ok())
+			.and_then(|v| v.parse::<u64>().ok());
+		rate_limits.retry_after = headers
+			.get("retry-after")
+			.and_then(|v| v.to_str().ok())
+			.and_then(|v| v.parse::<u64>().ok())
+			.map(|v| Instant::now() + Duration::from_secs(v));
+
+		// Check if the response indicates rate limiting
+		match rate_limits.remaining {
+			Some(0) => Err(rate_limits.deref().into()),
+			_ => response.error_for_status().map_err(Error::HttpError),
+		}
+	}
+}
+
+#[derive(Debug, Default)]
+struct RateLimits {
+	limit: Option<u64>,
+	remaining: Option<u64>,
+	reset: Option<u64>,
+	retry_after: Option<Instant>,
+}
+
+impl From<&RateLimits> for Error {
+	fn from(v: &RateLimits) -> Self {
+		Error::RateLimited {
+			limit: v.limit,
+			remaining: v.remaining,
+			reset: v.reset,
+			retry_after: v.retry_after,
+		}
+	}
+}
+
+#[derive(Error, Debug)]
+pub enum Error {
+	/// A HTTP error occurred.
+	#[error("HTTP error: {0} caused by {:?}", reqwest::Error::source(.0))]
+	HttpError(#[from] reqwest::Error),
+	/// An error occurred acquiring a lock.
+	#[error("Lock acquisition error")]
+	LockAcquisitionError,
+	/// An API call failed due to rate limiting.
+	#[error("Rate limited: limit {limit:?}, remaining {remaining:?}, reset {reset:?}, retry after {retry_after:?}")]
+	RateLimited {
+		limit: Option<u64>,
+		remaining: Option<u64>,
+		reset: Option<u64>,
+		retry_after: Option<Instant>,
+	},
+	#[error("Time error: {0}")]
+	TimeError(#[from] SystemTimeError),
+	#[error("Synchronization error: {0}")]
+	SynchronizationError(#[from] AcquireError),
+}

--- a/crates/pop-common/src/lib.rs
+++ b/crates/pop-common/src/lib.rs
@@ -23,6 +23,8 @@ pub use test::test_project;
 
 /// Module for parsing and handling account IDs.
 pub mod account_id;
+/// Provides functionality for accessing rate-limited APIs.
+pub(crate) mod api;
 /// Provides build profiles for usage when building Rust projects.
 pub mod build;
 /// Represents the various errors that can occur in the crate.

--- a/crates/pop-common/src/sourcing/mod.rs
+++ b/crates/pop-common/src/sourcing/mod.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0
 
-mod binary;
+use crate::{api, git::GITHUB_API_CLIENT, Git, Status};
 pub use binary::*;
-
-use crate::{Git, Status, APP_USER_AGENT};
 use duct::cmd;
 use flate2::read::GzDecoder;
 use reqwest::StatusCode;
 use std::{
+	error::Error as _,
 	fs::{copy, metadata, read_dir, rename, File},
 	io::{BufRead, Seek, SeekFrom, Write},
 	os::unix::fs::PermissionsExt,
@@ -19,17 +18,22 @@ use tempfile::{tempdir, tempfile};
 use thiserror::Error;
 use url::Url;
 
+mod binary;
+
 /// An error relating to the sourcing of binaries.
 #[derive(Error, Debug)]
 pub enum Error {
 	/// An error occurred.
 	#[error("Anyhow error: {0}")]
 	AnyhowError(#[from] anyhow::Error),
+	/// An API error occurred.
+	#[error("API error: {0}")]
+	ApiError(#[from] api::Error),
 	/// An error occurred sourcing a binary from an archive.
 	#[error("Archive error: {0}")]
 	ArchiveError(String),
 	/// A HTTP error occurred.
-	#[error("HTTP error: {0}")]
+	#[error("HTTP error: {0} caused by {:?}", reqwest::Error::source(.0))]
 	HttpError(#[from] reqwest::Error),
 	/// An IO error occurred.
 	#[error("IO error: {0}")]
@@ -325,7 +329,7 @@ async fn from_git(
 /// * `owner` - The owner of the repository.
 /// * `repository` - The name of the repository.
 /// * `reference` - If applicable, the branch, tag or commit.
-/// * `manifest` -If applicable, a specification of the path to the manifest.
+/// * `manifest` - If applicable, a specification of the path to the manifest.
 /// * `package` - The name of the package to be built.
 /// * `artifacts` - Any additional artifacts which are required.
 /// * `release` - Whether to build optimized artifacts using the release profile.
@@ -344,7 +348,6 @@ async fn from_github_archive(
 	verbose: bool,
 ) -> Result<(), Error> {
 	// User agent required when using GitHub API
-	let client = reqwest::ClientBuilder::new().user_agent(APP_USER_AGENT).build()?;
 	let response =
 		match reference {
 			Some(reference) => {
@@ -357,8 +360,8 @@ async fn from_github_archive(
 				let mut response = None;
 				for url in urls {
 					status.update(&format!("Downloading from {url}..."));
-					response = Some(client.get(url).send().await?.error_for_status());
-					if let Some(Err(e)) = &response {
+					response = Some(GITHUB_API_CLIENT.get(url).await);
+					if let Some(Err(api::Error::HttpError(e))) = &response {
 						if e.status() == Some(StatusCode::NOT_FOUND) {
 							tokio::time::sleep(Duration::from_secs(1)).await;
 							continue;
@@ -371,7 +374,7 @@ async fn from_github_archive(
 			None => {
 				let url = format!("https://api.github.com/repos/{owner}/{repository}/tarball");
 				status.update(&format!("Downloading from {url}..."));
-				client.get(url).send().await?.error_for_status()?
+				GITHUB_API_CLIENT.get(url).await?
 			},
 		};
 	let mut file = tempfile()?;

--- a/crates/pop-common/src/sourcing/mod.rs
+++ b/crates/pop-common/src/sourcing/mod.rs
@@ -272,7 +272,7 @@ async fn from_archive(
 		if src.exists() {
 			if let Err(_e) = rename(&src, dest) {
 				// If rename fails (e.g., due to cross-device linking), fallback to copy and remove
-				std::fs::copy(&src, dest)?;
+				copy(&src, dest)?;
 				std::fs::remove_file(&src)?;
 			}
 		} else {
@@ -378,7 +378,7 @@ async fn from_github_archive(
 			},
 		};
 	let mut file = tempfile()?;
-	file.write_all(&response.bytes().await?)?;
+	file.write_all(&response)?;
 	file.seek(SeekFrom::Start(0))?;
 	// Extract contents
 	status.update("Extracting from archive...");


### PR DESCRIPTION
Applies some of the best practices from https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api in an attempt to minimize errors caused by rate limiting of the Github API. When rate limiting occurs, errors will be returned with more detail information.

One can also now create a personal token on GitHub and specify locally via `GITHUB_TOKEN` if rate limiting occurs. The default limit is 60 per hour, so probably fine for most standard CLI usage.

todos:
- [x] response caching within the context of tests only
- [x] doc comments
- [x] tests

[sc-3686]