### PR TITLE
ci: update init to use latest rust-cache action

### DIFF
--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -12,15 +12,18 @@ runs:
   steps:
     - name: Setup Ubuntu dependencies
       shell: bash
-      run: sudo apt update && sudo apt install -y protobuf-compiler
+      run: |
+        sudo apt update
+        sudo apt install -y protobuf-compiler
 
     - name: Free up space on runner
       shell: bash
       run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /opt/ghc
-        sudo rm -rf "/usr/local/share/boost"
-        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY" /opt/ghc /usr/local/lib/android /usr/local/share/boost 
+        sudo rm -rf /usr/local/share/chromium /usr/share/dotnet /usr/share/swift
+        sudo docker image prune -af
+        sudo apt-get clean
+        sudo rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
     - name: Setup git config
       shell: bash
@@ -29,7 +32,7 @@ runs:
         git config --global user.email ${{ inputs.git-user }}@users.noreply.github.com
 
     - name: Rust Cache
-      uses: Swatinem/rust-cache@v2.7.3
+      uses: Swatinem/rust-cache@v2.7.8
       with:
         cache-on-failure: true
         cache-all-crates: true


### PR DESCRIPTION
Noticed some caching issues in the CI runs due to sunsetting of old GitHub cache actions (https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts), so updating to the latest version of the rust-cache action.

Also clears additional space.