### PR TITLE
fix: test create_snapshot with relaychain URL

### DIFF
--- a/crates/pop-cli/src/commands/test/create_snapshot.rs
+++ b/crates/pop-cli/src/commands/test/create_snapshot.rs
@@ -163,7 +163,7 @@ mod tests {
 			)
 			.expect_input(
 				"Enter the URI of the remote node:",
-				DEFAULT_REMOTE_NODE_URL.to_string()
+				"wss://paseo-rpc.dwellir.com".to_string()
 			).expect_input(
 			    format!(
          			"Enter the path to write the snapshot to (optional):\n{}",


### PR DESCRIPTION
Fetching states from Pop Network on PASEO does not work as expected. Updating the URL to test with Paseo Relaychain. This is a temporary fix to unblock the CI. 