### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.0] - 2025-05-07
+
+### 🚀 Features
+
+- `pop build runtime` and `pop build --deterministic` (#510)
+- Hashing (#517)
+- Revive compatibility with feature flag (#500)
+
+### 🐛 Fixes
+
+- Benchmarking logger (#513)
+- Wrap github rest api access in an apiclient (#530)
+- Separate runtime binary path and runtime path (#531)
+
+### 📚 Documentation
+
+- Improve project documentation (#521)
+
+### 🧪 Testing
+
+- No default features (#522)
+
+### ⚙️ Miscellaneous Tasks
+
+- Source remote binary if version not matches (#516)
+- Update required version of the frame-omni-bencher binary (#527)
+- Update init to use latest rust-cache action (#533)
+- Enable concurrency controls (#532)
+- Bump versions
+
+### Build
+
+- *(deps)* Eliminate unnecessary dependencies (#520)
+
 ## [0.7.0] - 2025-04-02
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8845,7 +8845,7 @@ dependencies = [
 
 [[package]]
 name = "pop-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8884,7 +8884,7 @@ dependencies = [
 
 [[package]]
 name = "pop-common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8918,7 +8918,7 @@ dependencies = [
 
 [[package]]
 name = "pop-contracts"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "contract-build 5.0.3",
@@ -8950,7 +8950,7 @@ dependencies = [
 
 [[package]]
 name = "pop-parachains"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -8991,7 +8991,7 @@ dependencies = [
 
 [[package]]
 name = "pop-telemetry"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "dirs",
  "env_logger 0.11.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ documentation = "https://learn.onpop.io/"
 license = "GPL-3.0"
 repository = "https://github.com/r0gue-io/pop-cli"
 rust-version = "1.81.0"
-version = "0.7.0"
+version = "0.8.0"
 
 [workspace.dependencies]
 anyhow = { version = "1.0", default-features = false }

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -32,20 +32,20 @@ toml.workspace = true
 url.workspace = true
 
 # contracts
-pop-contracts = { path = "../pop-contracts", version = "0.7.0", default-features = false, optional = true }
+pop-contracts = { path = "../pop-contracts", version = "0.8.0", default-features = false, optional = true }
 sp-core = { workspace = true, optional = true }
 sp-weights = { workspace = true, optional = true }
 
 # parachains
-pop-parachains = { path = "../pop-parachains", version = "0.7.0", optional = true }
+pop-parachains = { path = "../pop-parachains", version = "0.8.0", optional = true }
 git2 = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 
 # telemetry
-pop-telemetry = { path = "../pop-telemetry", version = "0.7.0", optional = true }
+pop-telemetry = { path = "../pop-telemetry", version = "0.8.0", optional = true }
 
 # common
-pop-common = { path = "../pop-common", version = "0.7.0" }
+pop-common = { path = "../pop-common", version = "0.8.0" }
 
 # wallet-integration
 axum = { workspace = true, optional = true }

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -175,22 +175,7 @@ impl Command {
 					None => up::Command::execute(args).await.map(Up),
 					Some(cmd) => match cmd {
 						#[cfg(feature = "parachain")]
-						up::Command::Network(mut cmd) => {
-							cmd.valid = true;
-							cmd.execute().await.map(|_| Up(crate::common::Project::Network))
-						},
-						// TODO: Deprecated, will be removed in v0.8.0.
-						#[cfg(feature = "parachain")]
-						#[allow(deprecated)]
-						up::Command::Parachain(cmd) => cmd.execute().await.map(|_| Null),
-						// TODO: Deprecated, will be removed in v0.8.0.
-						#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts"))]
-						#[allow(deprecated)]
-						up::Command::Contract(mut cmd) => {
-							cmd.path =
-								crate::common::builds::get_project_path(args.path, args.path_pos);
-							cmd.execute().await.map(|_| Null)
-						},
+						up::Command::Network(cmd) => cmd.execute().await.map(|_| Up(crate::common::Project::Network)),
 					},
 				}
 			},
@@ -207,13 +192,6 @@ impl Command {
 						.await
 						.map(|(project, feature)| Test { project, feature }),
 					Some(cmd) => match cmd {
-						// TODO: Deprecated, will be removed in v0.8.0.
-						#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts"))]
-						#[allow(deprecated)]
-						test::Command::Contract(cmd) => cmd.execute(&mut Cli).await.map(|feature| Test {
-							project: crate::common::Project::Contract,
-							feature,
-						}),
 						#[cfg(feature = "parachain")]
 						test::Command::OnRuntimeUpgrade(cmd) => cmd.execute(&mut Cli).await.map(|_| Null),
 						#[cfg(feature = "parachain")]

--- a/crates/pop-cli/src/commands/test/mod.rs
+++ b/crates/pop-cli/src/commands/test/mod.rs
@@ -58,12 +58,6 @@ pub(crate) enum Command {
 	/// Create a chain state snapshot.
 	#[cfg(feature = "parachain")]
 	CreateSnapshot(create_snapshot::TestCreateSnapshotCommand),
-	/// [DEPRECATED] Test a smart contract (will be removed in v0.8.0).
-	#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts"))]
-	#[clap(alias = "c")]
-	#[deprecated(since = "0.7.0", note = "will be removed in v0.8.0")]
-	#[allow(rustdoc::broken_intra_doc_links)]
-	Contract(contract::TestContractCommand),
 }
 
 impl Command {
@@ -113,9 +107,6 @@ impl Display for Command {
 			Command::FastForward(_) => write!(f, "fast forward"),
 			#[cfg(feature = "parachain")]
 			Command::CreateSnapshot(_) => write!(f, "create snapshot"),
-			#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts"))]
-			#[allow(deprecated)]
-			Command::Contract(_) => write!(f, "contract"),
 		}
 	}
 }
@@ -188,7 +179,5 @@ mod tests {
 		assert_eq!(Command::FastForward(Default::default()).to_string(), "fast forward");
 		#[cfg(feature = "parachain")]
 		assert_eq!(Command::CreateSnapshot(Default::default()).to_string(), "create snapshot");
-		#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts"))]
-		assert_eq!(Command::Contract(Default::default()).to_string(), "contract");
 	}
 }

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -90,20 +90,12 @@ pub struct UpContractCommand {
 	/// confirmation.
 	#[clap(short = 'y', long)]
 	pub(crate) skip_confirm: bool,
-	// Deprecation flag, used to specify whether the deprecation warning is shown (will be removed
-	// in v0.8.0).
-	#[clap(skip)]
-	pub(crate) valid: bool,
 }
 
 impl UpContractCommand {
 	/// Executes the command.
 	pub(crate) async fn execute(mut self) -> anyhow::Result<()> {
 		Cli.intro("Deploy a smart contract")?;
-		// Show warning if specified as deprecated.
-		if !self.valid {
-			Cli.warning("DEPRECATION: Please use `pop up` (or simply `pop u`) in the future...")?;
-		}
 		// Check if build exists in the specified "Contract build directory"
 		if !has_contract_been_built(self.path.as_deref()) {
 			// Build the contract in release mode
@@ -493,7 +485,6 @@ impl Default for UpContractCommand {
 			dry_run: false,
 			upload_only: false,
 			skip_confirm: false,
-			valid: true,
 		}
 	}
 }
@@ -594,7 +585,6 @@ mod tests {
 			upload_only: true,
 			skip_confirm: true,
 			use_wallet: true,
-			valid: true,
 		};
 
 		let rpc_client = subxt::backend::rpc::RpcClient::from_url(&up_contract_opts.url).await?;
@@ -652,7 +642,6 @@ mod tests {
 			upload_only: false,
 			skip_confirm: true,
 			use_wallet: true,
-			valid: true,
 		};
 
 		// Retrieve call data based on the above command options.

--- a/crates/pop-cli/src/commands/up/mod.rs
+++ b/crates/pop-cli/src/commands/up/mod.rs
@@ -26,8 +26,7 @@ mod rollup;
 #[command(args_conflicts_with_subcommands = true)]
 pub(crate) struct UpArgs {
 	/// Path to the project directory.
-	// TODO: Introduce the short option in v0.8.0 once deprecated parachain command is removed.
-	#[arg(long, global = true)]
+	#[arg(short, long, global = true)]
 	pub path: Option<PathBuf>,
 
 	/// Directory path without flag for your project [default: current directory]
@@ -51,20 +50,8 @@ pub(crate) struct UpArgs {
 pub(crate) enum Command {
 	#[cfg(feature = "parachain")]
 	/// Launch a local network.
-	#[clap(alias = "n")]
+	#[clap(aliases = ["n", "parachain"])]
 	Network(network::ZombienetCommand),
-	#[cfg(feature = "parachain")]
-	/// [DEPRECATED] Launch a local network (will be removed in v0.8.0).
-	#[clap(alias = "p", hide = true)]
-	#[deprecated(since = "0.7.0", note = "will be removed in v0.8.0")]
-	#[allow(rustdoc::broken_intra_doc_links)]
-	Parachain(network::ZombienetCommand),
-	#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts"))]
-	/// [DEPRECATED] Deploy a smart contract (will be removed in v0.8.0).
-	#[clap(alias = "c", hide = true)]
-	#[deprecated(since = "0.7.0", note = "will be removed in v0.8.0")]
-	#[allow(rustdoc::broken_intra_doc_links)]
-	Contract(contract::UpContractCommand),
 }
 
 impl Command {
@@ -84,7 +71,6 @@ impl Command {
 		if pop_contracts::is_supported(project_path.as_deref())? {
 			let mut cmd = args.contract;
 			cmd.path = project_path;
-			cmd.valid = true; // To handle deprecated command, remove in v0.8.0.
 			cmd.execute().await?;
 			return Ok(Contract);
 		}
@@ -107,12 +93,6 @@ impl Display for Command {
 		match self {
 			#[cfg(feature = "parachain")]
 			Command::Network(_) => write!(f, "network"),
-			#[cfg(feature = "parachain")]
-			#[allow(deprecated)]
-			Command::Parachain(_) => write!(f, "chain"),
-			#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts"))]
-			#[allow(deprecated)]
-			Command::Contract(_) => write!(f, "contract"),
 		}
 	}
 }
@@ -155,7 +135,6 @@ mod tests {
 				dry_run: true,
 				upload_only: true,
 				skip_confirm: false,
-				valid: false,
 			},
 			#[cfg(feature = "parachain")]
 			rollup: rollup::UpCommand::default(),
@@ -241,9 +220,5 @@ mod tests {
 	fn command_display_works() {
 		#[cfg(feature = "parachain")]
 		assert_eq!(Command::Network(Default::default()).to_string(), "network");
-		#[cfg(feature = "parachain")]
-		assert_eq!(Command::Parachain(Default::default()).to_string(), "chain");
-		#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts"))]
-		assert_eq!(Command::Contract(Default::default()).to_string(), "contract");
 	}
 }

--- a/crates/pop-cli/src/commands/up/network.rs
+++ b/crates/pop-cli/src/commands/up/network.rs
@@ -49,10 +49,6 @@ pub(crate) struct ZombienetCommand {
 	/// Automatically source all needed binaries required without prompting for confirmation.
 	#[clap(short = 'y', long)]
 	skip_confirm: bool,
-	// Deprecation flag, used to specify whether the deprecation warning is shown (will be removed
-	// in v0.8.0).
-	#[clap(skip)]
-	pub(crate) valid: bool,
 }
 
 impl ZombienetCommand {
@@ -61,13 +57,6 @@ impl ZombienetCommand {
 		clear_screen()?;
 		intro(format!("{}: Launch a local network", style(" Pop CLI ").black().on_magenta()))?;
 		set_theme(Theme);
-
-		// Show warning if specified as deprecated.
-		if !self.valid {
-			log::warning(
-				"DEPRECATION: Please use `pop up network` (or simply `pop u n`) in the future...",
-			)?;
-		}
 
 		// Parse arguments
 		let cache = crate::cache()?;

--- a/crates/pop-contracts/Cargo.toml
+++ b/crates/pop-contracts/Cargo.toml
@@ -41,7 +41,7 @@ contract-transcode_inkv6 = { workspace = true, optional = true }
 scale-info = { workspace = true }
 
 # pop
-pop-common = { path = "../pop-common", version = "0.7.0" }
+pop-common = { path = "../pop-common", version = "0.8.0" }
 
 [dev-dependencies]
 # Used in doc tests.

--- a/crates/pop-parachains/Cargo.toml
+++ b/crates/pop-parachains/Cargo.toml
@@ -50,7 +50,7 @@ sc-cli.workspace = true
 sp-version.workspace = true
 
 # Pop
-pop-common = { path = "../pop-common", version = "0.7.0" }
+pop-common = { path = "../pop-common", version = "0.8.0" }
 
 [dev-dependencies]
 # Used in doc tests.


### PR DESCRIPTION
- [X]  Update crate versions to 0.8.0.
- [X]  Update Changelog file. Run `git cliff --bump`
- [X]  Remove Deprecated flags introduced 2 releases ago: 
          - Remove `pop test contract`, it works only with `pop test`.
          - Remove `pop up contract`, it works only with `pop up`.
          - Remove `pop test parachain`, it works only with `pop up`.