### PR TITLE
fix: update branch used to fetch ink! v5 templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.1] - 2025-05-13
+
+### 🐛 Fixes
+- Fixed template fetching for ink! v5 contracts by pointing to the correct branch.
+
 ## [0.8.0] - 2025-05-07
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8845,7 +8845,7 @@ dependencies = [
 
 [[package]]
 name = "pop-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8884,7 +8884,7 @@ dependencies = [
 
 [[package]]
 name = "pop-common"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8918,7 +8918,7 @@ dependencies = [
 
 [[package]]
 name = "pop-contracts"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "contract-build 5.0.3",
@@ -8950,7 +8950,7 @@ dependencies = [
 
 [[package]]
 name = "pop-parachains"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "askama",
@@ -8991,7 +8991,7 @@ dependencies = [
 
 [[package]]
 name = "pop-telemetry"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "dirs",
  "env_logger 0.11.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ documentation = "https://learn.onpop.io/"
 license = "GPL-3.0"
 repository = "https://github.com/r0gue-io/pop-cli"
 rust-version = "1.81.0"
-version = "0.8.0"
+version = "0.8.1"
 
 [workspace.dependencies]
 anyhow = { version = "1.0", default-features = false }

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -32,20 +32,20 @@ toml.workspace = true
 url.workspace = true
 
 # contracts
-pop-contracts = { path = "../pop-contracts", version = "0.8.0", default-features = false, optional = true }
+pop-contracts = { path = "../pop-contracts", version = "0.8.1", default-features = false, optional = true }
 sp-core = { workspace = true, optional = true }
 sp-weights = { workspace = true, optional = true }
 
 # parachains
-pop-parachains = { path = "../pop-parachains", version = "0.8.0", optional = true }
+pop-parachains = { path = "../pop-parachains", version = "0.8.1", optional = true }
 git2 = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 
 # telemetry
-pop-telemetry = { path = "../pop-telemetry", version = "0.8.0", optional = true }
+pop-telemetry = { path = "../pop-telemetry", version = "0.8.1", optional = true }
 
 # common
-pop-common = { path = "../pop-common", version = "0.8.0" }
+pop-common = { path = "../pop-common", version = "0.8.1" }
 
 # wallet-integration
 axum = { workspace = true, optional = true }

--- a/crates/pop-contracts/Cargo.toml
+++ b/crates/pop-contracts/Cargo.toml
@@ -41,7 +41,7 @@ contract-transcode_inkv6 = { workspace = true, optional = true }
 scale-info = { workspace = true }
 
 # pop
-pop-common = { path = "../pop-common", version = "0.8.0" }
+pop-common = { path = "../pop-common", version = "0.8.1" }
 
 [dev-dependencies]
 # Used in doc tests.

--- a/crates/pop-contracts/src/templates.rs
+++ b/crates/pop-contracts/src/templates.rs
@@ -4,6 +4,7 @@
 pub use pop_common::templates::{Template, Type};
 use strum_macros::{AsRefStr, Display, EnumMessage, EnumProperty, EnumString, VariantArray};
 
+#[cfg(feature = "v6")]
 // Temporary branch name for v6 contract templates.
 pub(crate) const V6_CONTRACTS_BRANCH: &str = "v6.x";
 

--- a/crates/pop-parachains/Cargo.toml
+++ b/crates/pop-parachains/Cargo.toml
@@ -50,7 +50,7 @@ sc-cli.workspace = true
 sp-version.workspace = true
 
 # Pop
-pop-common = { path = "../pop-common", version = "0.8.0" }
+pop-common = { path = "../pop-common", version = "0.8.1" }
 
 [dev-dependencies]
 # Used in doc tests.


### PR DESCRIPTION
This PR fixes a bug reported in the ink! Telegram group, where ink! v5 templates were not loading correctly due to the code fetching from the wrong branch. It was basically generating the template from ink! v6 branch instead of the ink! v5.
The fix updates the logic to fetch templates from the correct branch for ink! v5.

Additionally, a test has been added to ensure this issue doesn’t happen again by validating the correct version after creating a contract.

This PR also bumps the version to `0.8.1` to publish the release with the fix.