### PR TITLE
build(deps): consolidate sp-weights dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ ink_env_v6 = { version = "6.0.0-alpha", package = "ink_env", default-features = 
 sp-core = { version = "32.0.0", default-features = false }
 sp-core_inkv6 = { version = "36.1.0", package = "sp-core", default-features = false }
 sp-weights = { version = "31.0.0", default-features = false }
-sp-weights_inkv6 = { version = "31.1.0", package = "sp-weights", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 scale-info = { version = "2.11.4", default-features = false, features = ["derive"] }
 scale-value = { version = "0.17.0", default-features = false, features = ["from-string", "parser-ss58"] }

--- a/crates/pop-contracts/Cargo.toml
+++ b/crates/pop-contracts/Cargo.toml
@@ -24,8 +24,7 @@ ink_env = { workspace = true, optional = true }
 ink_env_v6 = { workspace = true, optional = true }
 sp-core = { workspace = true, optional = true }
 sp-core_inkv6 = { workspace = true, optional = true }
-sp-weights = { workspace = true, optional = true }
-sp-weights_inkv6 = { workspace = true, optional = true }
+sp-weights.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 subxt-signer.workspace = true
@@ -49,5 +48,5 @@ tokio-test.workspace = true
 
 [features]
 default = ["v5"]
-v5 = ["dep:contract-build", "dep:contract-extrinsics", "dep:contract-transcode", "dep:ink_env", "dep:sp-core", "dep:sp-weights"]
-v6 = ["dep:contract-build_inkv6", "dep:contract-extrinsics_inkv6", "dep:contract-transcode_inkv6", "dep:ink_env_v6", "dep:sp-core_inkv6", "dep:sp-weights_inkv6"]
+v5 = ["dep:contract-build", "dep:contract-extrinsics", "dep:contract-transcode", "dep:ink_env", "dep:sp-core"]
+v6 = ["dep:contract-build_inkv6", "dep:contract-extrinsics_inkv6", "dep:contract-transcode_inkv6", "dep:ink_env_v6", "dep:sp-core_inkv6"]


### PR DESCRIPTION
Received an error when using `cargo metadata` due to two instances of the `sp-weights` dependency with the exact same version.