### PR TITLE
test(parachains/bench): fix expected error in load_pallet_extrinsics test

### DIFF
--- a/crates/pop-parachains/src/bench/mod.rs
+++ b/crates/pop-parachains/src/bench/mod.rs
@@ -344,10 +344,9 @@ mod tests {
 
 		assert_eq!(
 		    load_pallet_extrinsics(&runtime_path, &binary.path()).await.err().unwrap().to_string(),
-				"Failed to run benchmarking: Error: Input(\"Could not call runtime API to Did not find the benchmarking metadata. \
+				"Failed to run benchmarking: Error: Input(\"Did not find the benchmarking runtime api. \
 				This could mean that you either did not build the node correctly with the `--features runtime-benchmarks` flag, \
-				or the chain spec that you are using was not created by a node that was compiled with the flag: Other: \
-				Exported method Benchmark_benchmark_metadata is not found\")"
+				or the chain spec that you are using was not created by a node that was compiled with the flag\")"
 		);
 		Ok(())
 	}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,13 +1,13 @@
 [toolchain]
-channel = "stable"
+channel = "1.86"
 components = [
-	"cargo",
-	"clippy",
-	"rust-analyzer",
-	"rust-src",
-	"rust-std",
-	"rustc",
-	"rustfmt",
+    "cargo",
+    "clippy",
+    "rust-analyzer",
+    "rust-src",
+    "rust-std",
+    "rustc",
+    "rustfmt",
 ]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
Fixes the current failing test by updating the expected value.