### PR TITLE
ci: optimize polkavm contract jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,9 @@ jobs:
 
       - name: Check contracts feature
         run: cargo check --no-default-features --features contract
-      
+
       - name: Check polkavm-contracts feature
-        run: cargo check --no-default-features --features "polkavm-contracts, v6"
+        run: cargo check --no-default-features --features "polkavm-contracts, v6" -p pop-cli -p pop-contracts
 
       - name: Check parachain feature
         run: cargo check --no-default-features --features parachain
@@ -151,7 +151,7 @@ jobs:
       - name: Run unit tests for polkavm-contracts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run:  cargo test --lib --bins --no-default-features --features "polkavm-contracts, v6"
+        run: cargo test --lib --bins --no-default-features --features "polkavm-contracts, v6" -p pop-cli -p pop-contracts
 
   coverage:
     needs: lint


### PR DESCRIPTION
The polkavm contract jobs are currently running all tests in the project rather than only those which actually have the specified features. That is, parachain jobs are being run in parallel unnecessarily.

This PR simply constrains these jobs to only run over the `pop-cli` and `pop-contracts` crates where these features exist.