### PR TITLE
test(cli/try-runtime): update pallets in try-state test after runtime upgrade

### DIFF
--- a/crates/pop-cli/src/common/try_runtime.rs
+++ b/crates/pop-cli/src/common/try_runtime.rs
@@ -793,6 +793,7 @@ mod tests {
 						"MessageQueue",
 						"Messaging",
 						"Motion",
+						"MultiBlockMigrations",
 						"Multisig",
 						"NftFractionalization",
 						"Nfts",
@@ -810,6 +811,7 @@ mod tests {
 						"TransactionPayment",
 						"Treasury",
 						"Utility",
+						"WeightReclaim",
 						"XcmpQueue",
 					]
 					.iter()


### PR DESCRIPTION
The list of pallets on the live network changed recently, causing a try-state test to fail. 

Ideally that test should be rewritten to run against a local node/mock, but that it beyond the current requirements to fix CI, which is preventing other PRs from being merged.

[sc-3794]