### PR TITLE
fix(dockerfile): could not launch local network

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,13 @@ RUN cargo build --release
 
 # Build image, preinstalling all dependencies for general Polkadot development
 FROM ubuntu:24.04
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    libssl-dev \
+    libgcc-s1 \
+    libstdc++6 \
+    && apt-get clean
+
 COPY --from=builder /pop/target/release/pop /usr/bin/pop
-RUN apt-get update && apt-get install -y ca-certificates && pop install -y && apt-get clean
+RUN /usr/bin/pop install -y
 CMD ["/usr/bin/pop"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN rustup show active-toolchain || rustup toolchain install
 RUN cargo build --release
 
 # Build image, preinstalling all dependencies for general Polkadot development
-FROM rust:slim
+FROM ubuntu:24.04
 COPY --from=builder /pop/target/release/pop /usr/bin/pop
-RUN apt-get update && pop install -y && apt-get clean
+RUN apt-get update && apt-get install -y ca-certificates && pop install -y && apt-get clean
 CMD ["/usr/bin/pop"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,6 @@ RUN cargo build --release
 FROM ubuntu:24.04
 RUN apt-get update && apt-get install -y \
     ca-certificates \
-    libssl-dev \
-    libgcc-s1 \
-    libstdc++6 \
     && apt-get clean
  
 COPY --from=builder /pop/target/release/pop /usr/bin/pop

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
     libgcc-s1 \
     libstdc++6 \
     && apt-get clean
-
+ 
 COPY --from=builder /pop/target/release/pop /usr/bin/pop
-RUN /usr/bin/pop install -y
-CMD ["/usr/bin/pop"]
+ENTRYPOINT ["/usr/bin/pop"]
+CMD ["install", "-y"]


### PR DESCRIPTION
This PR updates the Dockerfile to replace the runtime base image `rust:slim` with `ubuntu:24.04`. This resolves runtime errors caused by incompatible `glibc` versions when running the pop up network https://github.com/r0gue-io/pop-cli/issues/401

[sc-3871]