### PR TITLE
fix(ci): address failing unit tests and cargo-deny issues

### DIFF
--- a/crates/pop-cli/src/commands/call/chain.rs
+++ b/crates/pop-cli/src/commands/call/chain.rs
@@ -617,7 +617,7 @@ mod tests {
 	use url::Url;
 
 	const BOB_SURI: &str = "//Bob";
-	const POP_NETWORK_TESTNET_URL: &str = "wss://rpc2.paseo.popnetwork.xyz";
+	const POP_NETWORK_TESTNET_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
 	const POLKADOT_NETWORK_URL: &str = "wss://polkadot-rpc.publicnode.com";
 
 	#[tokio::test]

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -597,7 +597,7 @@ mod tests {
 	#[cfg(feature = "polkavm-contracts")]
 	const CONTRACT_ADDRESS: &str = "0x4f04054746fb19d3b027f5fe1ca5e87a68b49bac";
 	#[cfg(feature = "wasm-contracts")]
-	const CONTRACTS_NETWORK_URL: &str = "wss://rpc2.paseo.popnetwork.xyz/";
+	const CONTRACTS_NETWORK_URL: &str = "wss://rpc1.paseo.popnetwork.xyz/";
 	#[cfg(feature = "polkavm-contracts")]
 	const CONTRACTS_NETWORK_URL: &str = "wss://westend-asset-hub-rpc.polkadot.io/";
 

--- a/crates/pop-cli/src/commands/test/create_snapshot.rs
+++ b/crates/pop-cli/src/commands/test/create_snapshot.rs
@@ -14,7 +14,7 @@ use pop_parachains::{parse::url, run_try_runtime, state::LiveState, TryRuntimeCl
 
 // Custom arguments which are not in `try-runtime create-snapshot`.
 const CUSTOM_ARGS: [&str; 2] = ["--skip-confirm", "-y"];
-const DEFAULT_REMOTE_NODE_URL: &str = "wss://rpc2.paseo.popnetwork.xyz";
+const DEFAULT_REMOTE_NODE_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
 const DEFAULT_SNAPSHOT_PATH: &str = "example.snap";
 
 #[derive(Args, Default)]

--- a/crates/pop-cli/src/commands/up/mod.rs
+++ b/crates/pop-cli/src/commands/up/mod.rs
@@ -160,7 +160,7 @@ mod tests {
 				gas_limit: None,
 				proof_size: None,
 				salt: None,
-				url: Url::parse("wss://rpc2.paseo.popnetwork.xyz")?,
+				url: Url::parse("wss://rpc1.paseo.popnetwork.xyz")?,
 				suri: "//Alice".to_string(),
 				use_wallet: false,
 				dry_run: true,

--- a/crates/pop-cli/src/commands/up/rollup.rs
+++ b/crates/pop-cli/src/commands/up/rollup.rs
@@ -551,7 +551,7 @@ mod tests {
 	const MOCK_PROXIED_ADDRESS: &str = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 	const MOCK_PROXY_ADDRESS_ID: &str = "Id(13czcAAt6xgLwZ8k6ZpkrRL5V2pjKEui3v9gHAN9PoxYZDbf)";
 	const POLKADOT_NETWORK_URL: &str = "wss://polkadot-rpc.publicnode.com";
-	const POP_NETWORK_TESTNET_URL: &str = "wss://rpc2.paseo.popnetwork.xyz";
+	const POP_NETWORK_TESTNET_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
 
 	#[tokio::test]
 	async fn prepare_for_deployment_works() -> Result<()> {

--- a/crates/pop-cli/src/common/chain.rs
+++ b/crates/pop-cli/src/common/chain.rs
@@ -52,7 +52,7 @@ mod tests {
 	use super::*;
 	use crate::cli::MockCli;
 
-	const POP_NETWORK_TESTNET_URL: &str = "wss://rpc2.paseo.popnetwork.xyz";
+	const POP_NETWORK_TESTNET_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
 
 	#[tokio::test]
 	async fn configure_works() -> Result<()> {

--- a/crates/pop-cli/src/common/try_runtime.rs
+++ b/crates/pop-cli/src/common/try_runtime.rs
@@ -33,7 +33,7 @@ use strum::{EnumMessage, VariantArray};
 const BINARY_NAME: &str = "try-runtime";
 pub(crate) const DEFAULT_BLOCK_HASH: &str = "0x0000000000";
 pub(crate) const DEFAULT_BLOCK_TIME: u64 = 6000;
-pub(crate) const DEFAULT_LIVE_NODE_URL: &str = "wss://rpc2.paseo.popnetwork.xyz";
+pub(crate) const DEFAULT_LIVE_NODE_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
 pub(crate) const DEFAULT_SNAPSHOT_PATH: &str = "your-parachain.snap";
 const TARGET_BINARY_VERSION: SemanticVersion = SemanticVersion(0, 8, 0);
 

--- a/crates/pop-common/src/metadata.rs
+++ b/crates/pop-common/src/metadata.rs
@@ -162,7 +162,7 @@ mod tests {
 	use anyhow::Result;
 	use subxt::{OnlineClient, SubstrateConfig};
 
-	const POP_NETWORK_TESTNET_URL: &str = "wss://rpc2.paseo.popnetwork.xyz";
+	const POP_NETWORK_TESTNET_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
 
 	#[tokio::test]
 	async fn format_type_works() -> Result<()> {

--- a/crates/pop-contracts/src/call.rs
+++ b/crates/pop-contracts/src/call.rs
@@ -284,7 +284,7 @@ mod tests {
 	#[cfg(feature = "v5")]
 	const CONTRACT_ADDRESS: &str = "5CLPm1CeUvJhZ8GCDZCR7nWZ2m3XXe4X5MtAQK69zEjut36A";
 	#[cfg(feature = "v5")]
-	const CONTRACTS_NETWORK_URL: &str = "wss://rpc2.paseo.popnetwork.xyz";
+	const CONTRACTS_NETWORK_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
 	#[cfg(feature = "v6")]
 	const CONTRACT_ADDRESS: &str = "0x4f04054746fb19d3b027f5fe1ca5e87a68b49bac";
 	#[cfg(feature = "v6")]

--- a/crates/pop-contracts/src/up.rs
+++ b/crates/pop-contracts/src/up.rs
@@ -587,7 +587,7 @@ mod tests {
 	#[cfg(feature = "v6")]
 	const CONTRACT_FILE: &str = "./tests/files/testing.contract";
 	#[cfg(feature = "v5")]
-	const CONTRACTS_NETWORK_URL: &str = "wss://rpc2.paseo.popnetwork.xyz";
+	const CONTRACTS_NETWORK_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
 	#[cfg(feature = "v6")]
 	const CONTRACTS_NETWORK_URL: &str = "wss://westend-asset-hub-rpc.polkadot.io";
 

--- a/crates/pop-parachains/src/call/mod.rs
+++ b/crates/pop-parachains/src/call/mod.rs
@@ -199,7 +199,7 @@ mod tests {
 	use url::Url;
 
 	const ALICE_SURI: &str = "//Alice";
-	pub(crate) const POP_NETWORK_TESTNET_URL: &str = "wss://rpc2.paseo.popnetwork.xyz";
+	pub(crate) const POP_NETWORK_TESTNET_URL: &str = "wss://rpc1.paseo.popnetwork.xyz";
 
 	#[tokio::test]
 	async fn set_up_client_works() -> Result<()> {

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,7 @@ ignore = [
     { id = "RUSTSEC-2020-0168", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
     { id = "RUSTSEC-2024-0438", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
     { id = "RUSTSEC-2023-0091", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
+    { id = "RUSTSEC-2024-0442", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
 ]
 
 [licenses]


### PR DESCRIPTION
This PR fixes CI job failures affecting some open PRs. Specifically:
- Unit tests are failing due to outdated network URLs. Temporary fix until this is solved https://github.com/r0gue-io/pop-cli/issues/535 updating the Pop network URL
- Fix `cargo deny` error