### PR TITLE
feat: sdd metadata specification flag to pop build for polkavm contracts

### DIFF
--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -2,6 +2,8 @@
 
 use crate::cli;
 use pop_contracts::{build_smart_contract, Verbosity};
+#[cfg(feature = "polkavm-contracts")]
+use pop_contracts::MetadataSpec;
 use std::path::PathBuf;
 
 /// Configuration for building a smart contract.
@@ -10,6 +12,9 @@ pub struct BuildContract {
 	pub(crate) path: Option<PathBuf>,
 	/// Build profile: `true` for release mode, `false` for debug mode.
 	pub(crate) release: bool,
+	#[cfg(feature = "polkavm-contracts")]
+	/// Which specification specification to use for contract metadata.
+    pub(crate)metadata: Option<MetadataSpec>,
 }
 
 impl BuildContract {
@@ -26,7 +31,13 @@ impl BuildContract {
 		cli.intro("Building your contract")?;
 		// Build contract.
 		let build_result =
-			build_smart_contract(self.path.as_deref(), self.release, Verbosity::Default)?;
+			build_smart_contract(
+				self.path.as_deref(),
+				self.release,
+				Verbosity::Default,
+				#[cfg(feature = "polkavm-contracts")]
+				self.metadata,
+			)?;
 		cli.success(build_result.display())?;
 		cli.outro("Build completed successfully!")?;
 		Ok("contract")

--- a/crates/pop-cli/src/commands/build/contract.rs
+++ b/crates/pop-cli/src/commands/build/contract.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use crate::cli;
-use pop_contracts::{build_smart_contract, Verbosity};
 #[cfg(feature = "polkavm-contracts")]
 use pop_contracts::MetadataSpec;
+use pop_contracts::{build_smart_contract, Verbosity};
 use std::path::PathBuf;
 
 /// Configuration for building a smart contract.
@@ -14,7 +14,7 @@ pub struct BuildContract {
 	pub(crate) release: bool,
 	#[cfg(feature = "polkavm-contracts")]
 	/// Which specification specification to use for contract metadata.
-    pub(crate)metadata: Option<MetadataSpec>,
+	pub(crate) metadata: Option<MetadataSpec>,
 }
 
 impl BuildContract {
@@ -30,14 +30,13 @@ impl BuildContract {
 	fn build(self, cli: &mut impl cli::traits::Cli) -> anyhow::Result<&'static str> {
 		cli.intro("Building your contract")?;
 		// Build contract.
-		let build_result =
-			build_smart_contract(
-				self.path.as_deref(),
-				self.release,
-				Verbosity::Default,
-				#[cfg(feature = "polkavm-contracts")]
-				self.metadata,
-			)?;
+		let build_result = build_smart_contract(
+			self.path.as_deref(),
+			self.release,
+			Verbosity::Default,
+			#[cfg(feature = "polkavm-contracts")]
+			self.metadata,
+		)?;
 		cli.success(build_result.display())?;
 		cli.outro("Build completed successfully!")?;
 		Ok("contract")

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -84,8 +84,8 @@ pub(crate) struct BuildArgs {
 	pub(crate) only_runtime: bool,
 	#[cfg(feature = "polkavm-contracts")]
 	/// Which specification to use for contract metadata.
-    #[clap(long, help_heading = CONTRACT_HELP_HEADER)]
-    metadata: Option<MetadataSpec>,
+	#[clap(long, help_heading = CONTRACT_HELP_HEADER)]
+	metadata: Option<MetadataSpec>,
 }
 
 /// Subcommand for building chain artifacts.

--- a/crates/pop-cli/src/commands/build/mod.rs
+++ b/crates/pop-cli/src/commands/build/mod.rs
@@ -9,6 +9,8 @@ use clap::{Args, Subcommand};
 use contract::BuildContract;
 use duct::cmd;
 use pop_common::Profile;
+#[cfg(feature = "polkavm-contracts")]
+use pop_contracts::MetadataSpec;
 use std::path::PathBuf;
 #[cfg(feature = "parachain")]
 use {
@@ -31,6 +33,8 @@ pub(crate) mod spec;
 const CHAIN_HELP_HEADER: &str = "Chain options";
 #[cfg(feature = "parachain")]
 const RUNTIME_HELP_HEADER: &str = "Runtime options";
+#[cfg(feature = "polkavm-contracts")]
+const CONTRACT_HELP_HEADER: &str = "Contract options";
 const PACKAGE: &str = "package";
 #[cfg(feature = "parachain")]
 const PARACHAIN: &str = "parachain";
@@ -78,6 +82,10 @@ pub(crate) struct BuildArgs {
 	#[clap(long, help_heading = RUNTIME_HELP_HEADER)]
 	#[cfg(feature = "parachain")]
 	pub(crate) only_runtime: bool,
+	#[cfg(feature = "polkavm-contracts")]
+	/// Which specification to use for contract metadata.
+    #[clap(long, help_heading = CONTRACT_HELP_HEADER)]
+    metadata: Option<MetadataSpec>,
 }
 
 /// Subcommand for building chain artifacts.
@@ -120,6 +128,9 @@ impl Command {
 				Some(profile) => profile.into(),
 				None => args.release,
 			};
+			#[cfg(feature = "polkavm-contracts")]
+			BuildContract { path: project_path, release, metadata: args.metadata }.execute()?;
+			#[cfg(not(feature = "polkavm-contracts"))]
 			BuildContract { path: project_path, release }.execute()?;
 			return Ok(Contract);
 		}

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -166,7 +166,13 @@ impl CallContractCommand {
 		cli.warning("NOTE: contract has not yet been built.")?;
 		let spinner = spinner();
 		spinner.start("Building contract in RELEASE mode...");
-		let result = match build_smart_contract(project_path.as_deref(), true, Verbosity::Quiet, #[cfg(feature = "polkavm-contracts")] None) {
+		let result = match build_smart_contract(
+			project_path.as_deref(),
+			true,
+			Verbosity::Quiet,
+			#[cfg(feature = "polkavm-contracts")]
+			None,
+		) {
 			Ok(result) => result,
 			Err(e) => {
 				return Err(anyhow!(format!(

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -166,7 +166,7 @@ impl CallContractCommand {
 		cli.warning("NOTE: contract has not yet been built.")?;
 		let spinner = spinner();
 		spinner.start("Building contract in RELEASE mode...");
-		let result = match build_smart_contract(project_path.as_deref(), true, Verbosity::Quiet) {
+		let result = match build_smart_contract(project_path.as_deref(), true, Verbosity::Quiet, #[cfg(feature = "polkavm-contracts")] None) {
 			Ok(result) => result,
 			Err(e) => {
 				return Err(anyhow!(format!(

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -102,7 +102,13 @@ impl UpContractCommand {
 			Cli.warning("NOTE: contract has not yet been built.")?;
 			let spinner = spinner();
 			spinner.start("Building contract in RELEASE mode...");
-			let result = match build_smart_contract(self.path.as_deref(), true, Verbosity::Quiet, #[cfg(feature = "polkavm-contracts")] None) {
+			let result = match build_smart_contract(
+				self.path.as_deref(),
+				true,
+				Verbosity::Quiet,
+				#[cfg(feature = "polkavm-contracts")]
+				None,
+			) {
 				Ok(result) => result,
 				Err(e) => {
 					Cli.outro_cancel(format!("🚫 An error occurred building your contract: {e}\nUse `pop build` to retry with build output."))?;

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -102,7 +102,7 @@ impl UpContractCommand {
 			Cli.warning("NOTE: contract has not yet been built.")?;
 			let spinner = spinner();
 			spinner.start("Building contract in RELEASE mode...");
-			let result = match build_smart_contract(self.path.as_deref(), true, Verbosity::Quiet) {
+			let result = match build_smart_contract(self.path.as_deref(), true, Verbosity::Quiet, #[cfg(feature = "polkavm-contracts")] None) {
 				Ok(result) => result,
 				Err(e) => {
 					Cli.outro_cancel(format!("🚫 An error occurred building your contract: {e}\nUse `pop build` to retry with build output."))?;

--- a/crates/pop-contracts/src/build.rs
+++ b/crates/pop-contracts/src/build.rs
@@ -14,10 +14,13 @@ use std::path::Path;
 ///   if not specified.
 /// * `release` - Whether the smart contract should be built without any debugging functionality.
 /// * `verbosity` - The build output verbosity.
+/// * `metadata_spec` - *(v6 only)* Optionally specify the contract metadata format/version.
 pub fn build_smart_contract(
-	path: Option<&Path>,
-	release: bool,
-	verbosity: Verbosity,
+    path: Option<&Path>,
+    release: bool,
+    verbosity: Verbosity,
+    #[cfg(feature = "v6")]
+    metadata_spec: Option<crate::MetadataSpec>,
 ) -> anyhow::Result<BuildResult> {
 	let manifest_path = get_manifest_path(path)?;
 
@@ -26,11 +29,24 @@ pub fn build_smart_contract(
 		false => BuildMode::Debug,
 	};
 
-	// Default values
-	let args = ExecuteArgs { manifest_path, build_mode, verbosity, ..Default::default() };
+    #[cfg(feature = "v6")]
+    let args = ExecuteArgs {
+        manifest_path,
+        build_mode,
+        verbosity,
+        metadata_spec: metadata_spec.unwrap_or_default(),
+        ..Default::default()
+    };
+    #[cfg(not(feature = "v6"))]
+    let args = ExecuteArgs {
+        manifest_path,
+        build_mode,
+        verbosity,
+        ..Default::default()
+    };
 
-	// Execute the build and log the output of the build
-	execute(args)
+    // Execute the build and log the output of the build
+    execute(args)
 }
 
 /// Determines whether the manifest at the supplied path is a supported smart contract project.

--- a/crates/pop-contracts/src/build.rs
+++ b/crates/pop-contracts/src/build.rs
@@ -16,11 +16,10 @@ use std::path::Path;
 /// * `verbosity` - The build output verbosity.
 /// * `metadata_spec` - *(v6 only)* Optionally specify the contract metadata format/version.
 pub fn build_smart_contract(
-    path: Option<&Path>,
-    release: bool,
-    verbosity: Verbosity,
-    #[cfg(feature = "v6")]
-    metadata_spec: Option<crate::MetadataSpec>,
+	path: Option<&Path>,
+	release: bool,
+	verbosity: Verbosity,
+	#[cfg(feature = "v6")] metadata_spec: Option<crate::MetadataSpec>,
 ) -> anyhow::Result<BuildResult> {
 	let manifest_path = get_manifest_path(path)?;
 
@@ -29,24 +28,19 @@ pub fn build_smart_contract(
 		false => BuildMode::Debug,
 	};
 
-    #[cfg(feature = "v6")]
-    let args = ExecuteArgs {
-        manifest_path,
-        build_mode,
-        verbosity,
-        metadata_spec: metadata_spec.unwrap_or_default(),
-        ..Default::default()
-    };
-    #[cfg(not(feature = "v6"))]
-    let args = ExecuteArgs {
-        manifest_path,
-        build_mode,
-        verbosity,
-        ..Default::default()
-    };
+	#[cfg(feature = "v6")]
+	let args = ExecuteArgs {
+		manifest_path,
+		build_mode,
+		verbosity,
+		metadata_spec: metadata_spec.unwrap_or_default(),
+		..Default::default()
+	};
+	#[cfg(not(feature = "v6"))]
+	let args = ExecuteArgs { manifest_path, build_mode, verbosity, ..Default::default() };
 
-    // Execute the build and log the output of the build
-    execute(args)
+	// Execute the build and log the output of the build
+	execute(args)
 }
 
 /// Determines whether the manifest at the supplied path is a supported smart contract project.

--- a/crates/pop-contracts/src/lib.rs
+++ b/crates/pop-contracts/src/lib.rs
@@ -38,13 +38,6 @@ pub use utils::{
 };
 // External exports
 pub use sp_weights::Weight;
-#[cfg(feature = "v5")]
-pub use {
-	contract_extrinsics::{extrinsic_calls::UploadCode, CallExec},
-	ink_env::{DefaultEnvironment, Environment},
-	sp_core::Bytes,
-	up::{get_code_hash_from_event, get_instantiate_payload, get_upload_payload},
-};
 #[cfg(feature = "v6")]
 pub use {
 	contract_build_inkv6::MetadataSpec,
@@ -53,4 +46,11 @@ pub use {
 	sp_core_inkv6::Bytes,
 	up::{get_instantiate_payload, get_upload_payload},
 	utils::map_account::AccountMapper,
+};
+#[cfg(feature = "v5")]
+pub use {
+	contract_extrinsics::{extrinsic_calls::UploadCode, CallExec},
+	ink_env::{DefaultEnvironment, Environment},
+	sp_core::Bytes,
+	up::{get_code_hash_from_event, get_instantiate_payload, get_upload_payload},
 };

--- a/crates/pop-contracts/src/lib.rs
+++ b/crates/pop-contracts/src/lib.rs
@@ -47,6 +47,7 @@ pub use {
 };
 #[cfg(feature = "v6")]
 pub use {
+	contract_build_inkv6::MetadataSpec,
 	contract_extrinsics_inkv6::{CallExec, ExtrinsicOpts, UploadCode},
 	ink_env_v6::{DefaultEnvironment, Environment},
 	sp_core_inkv6::Bytes,


### PR DESCRIPTION
This PR introduces a new` --metadata` flag to the pop build command, allowing users to specify the contract metadata: ink! or solidity when building `polkavm` contracts. This flag is only available when the `polkavm-contracts` feature is enabled.

## Test it locally
```bash
cargo install --path ./crates/pop-cli --locked --no-default-features -F polkavm-contracts,parachain
```
In the Cargo.toml of your contract include:
```toml
[package.metadata.ink-lang]
abi="sol"
```
Then, build the contract with the desired metadata format:
```
pop build --release --metadata solidity
```

Closes https://github.com/r0gue-io/pop-cli/issues/549

## Known Limitations
- Integration testing is currently difficult, as the `[package.metadata.ink-lang] abi = "sol"` section must be manually added to `Cargo.toml` after generate the smart contract. Once the next `cargo-contract` release lands, new contracts will include this by default.
- When running `pop up`, the CLI currently cannot deploy ink! contracts built with Solidity metadata.The approach now is: `pop-cli `will automatically rebuild the contract using the default ink! metadata before deployment.