### PR TITLE
chore: include map account as one of the quick actions in pop call

### DIFF
--- a/crates/pop-parachains/src/call/metadata/action.rs
+++ b/crates/pop-parachains/src/call/metadata/action.rs
@@ -99,6 +99,14 @@ pub enum Action {
 		props(Pallet = "System")
 	)]
 	Remark,
+	/// Register the callers account id so that it can be used in contract interactions.
+	#[strum(
+		serialize = "map_account",
+		message = "map_account",
+		detailed_message = "Map account",
+		props(Pallet = "Revive")
+	)]
+	MapAccount,
 }
 
 impl Action {
@@ -155,6 +163,7 @@ mod tests {
 			(Register, "Register a parachain ID with genesis state and code"),
 			(Reserve, "Reserve a parachain ID"),
 			(Remark, "Make a remark"),
+			(MapAccount, "Map account"),
 		]);
 
 		for action in Action::VARIANTS.iter() {
@@ -175,6 +184,7 @@ mod tests {
 			(Register, "Registrar"),
 			(Reserve, "Registrar"),
 			(Remark, "System"),
+			(MapAccount, "Revive"),
 		]);
 
 		for action in Action::VARIANTS.iter() {
@@ -195,6 +205,7 @@ mod tests {
 			(Register, "register"),
 			(Reserve, "reserve"),
 			(Remark, "remark_with_event"),
+			(MapAccount, "map_account"),
 		]);
 
 		for action in Action::VARIANTS.iter() {
@@ -210,7 +221,16 @@ mod tests {
 		let actions = supported_actions(&parse_chain_metadata(&client)?);
 		assert_eq!(
 			actions,
-			vec![Transfer, CreateAsset, MintAsset, CreateCollection, MintNFT, PureProxy, Remark]
+			vec![
+				Transfer,
+				CreateAsset,
+				MintAsset,
+				CreateCollection,
+				MintNFT,
+				PureProxy,
+				Remark,
+				MapAccount
+			]
 		);
 
 		// Test Polkadot Relay Chain.


### PR DESCRIPTION
Small improvement: to make account mapping easier with `pop`, I’ve added it as one of the predefined actions.
Just run `pop call` and follow the interactive UI.

<img width="483" height="186" alt="Captura de pantalla 2025-07-10 a las 15 25 56" src="https://github.com/user-attachments/assets/2594a7a8-6036-4e04-ad91-311a6b2d7d17" />
