### PR TITLE
feat: launch passet hub locally

### DIFF
--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -71,6 +71,6 @@ pub use utils::helpers::is_initial_endowment_valid;
 pub use zombienet_sdk::NetworkNode;
 
 const PASSET_HUB_SPEC_JSON: &str = include_str!("../artifacts/passet-hub-spec.json");
-pub fn get_passet_hub_spec_content() -> &'static str {
+fn get_passet_hub_spec_content() -> &'static str {
 	PASSET_HUB_SPEC_JSON
 }

--- a/crates/pop-parachains/src/lib.rs
+++ b/crates/pop-parachains/src/lib.rs
@@ -69,3 +69,8 @@ pub use templates::{Config, Parachain, Provider};
 pub use utils::helpers::is_initial_endowment_valid;
 /// Information about the Node. External export from Zombienet-SDK.
 pub use zombienet_sdk::NetworkNode;
+
+const PASSET_HUB_SPEC_JSON: &str = include_str!("../artifacts/passet-hub-spec.json");
+pub fn get_passet_hub_spec_content() -> &'static str {
+	PASSET_HUB_SPEC_JSON
+}

--- a/crates/pop-parachains/src/registry/mod.rs
+++ b/crates/pop-parachains/src/registry/mod.rs
@@ -63,6 +63,7 @@ const REGISTRAR: fn(Registry) -> Registry = |mut registry| {
 			BridgeHub::new(1_002, Paseo).into(),
 			Coretime::new(1_004, Paseo).into(),
 			People::new(1_005, Paseo).into(),
+			PassetHub::new(1_111, Paseo).into(),
 			// Others
 			Pop::new(4_001, "pop-devnet-local").into(),
 		],
@@ -303,6 +304,7 @@ mod tests {
 		assert!(contains::<BridgeHub>(registry, 1_002));
 		assert!(contains::<Coretime>(registry, 1_004));
 		assert!(contains::<People>(registry, 1_005));
+		assert!(contains::<PassetHub>(registry, 1_111));
 		assert!(contains::<Pop>(registry, 4_001));
 	}
 

--- a/crates/pop-parachains/src/registry/system.rs
+++ b/crates/pop-parachains/src/registry/system.rs
@@ -169,6 +169,24 @@ impl People {
 }
 impl_system_rollup!(People);
 
+/// The PassetHub system chain is a temporary rollup within the Polkadot ecosystem dedicated
+/// to deploy smart contracts..
+///
+/// See <https://docs.polkadot.com/polkadot-protocol/smart-contract-basics/networks/#passet-hub> for more details.
+#[derive(Clone)]
+pub struct PassetHub(Rollup);
+impl PassetHub {
+	/// A new instance of the PassetHub chain.
+	///
+	/// # Arguments
+	/// * `id` - The rollup identifier.
+	/// * `relay` - The relay chain.
+	pub fn new(id: Id, relay: Relay) -> Self {
+		Self(Rollup::new("passet-hub", id, format!("passet-hub-{}", relay.chain())))
+	}
+}
+impl_system_rollup!(PassetHub);
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -257,5 +275,16 @@ mod tests {
 		assert!(people.genesis_overrides().is_none());
 		assert_eq!(people.name(), "people");
 		assert_eq!(people.source().unwrap(), System.source().unwrap());
+	}
+
+	#[test]
+	fn passet_hub_works() {
+		let passethub = PassetHub::new(1_111, Relay::Paseo);
+		assert_eq!(passethub.args(), System.args());
+		assert_eq!(passethub.binary(), "polkadot-parachain");
+		assert_eq!(passethub.chain(), "passet-hub-paseo-local");
+		assert!(passethub.genesis_overrides().is_none());
+		assert_eq!(passethub.name(), "passet-hub");
+		assert_eq!(passethub.source().unwrap(), System.source().unwrap());
 	}
 }

--- a/crates/pop-parachains/src/up/mod.rs
+++ b/crates/pop-parachains/src/up/mod.rs
@@ -518,7 +518,8 @@ impl NetworkConfiguration {
 				// Chain spec
 				if let Some(chain) = source.chain() {
 					builder = builder.with_chain(chain.as_str());
-					// TODO: Just a temporary fix, once Paseo chain-spec-generator supports passet-hub just remove this.
+					// TODO: Just a temporary fix, once Paseo chain-spec-generator supports
+					// passet-hub just remove this.
 					if chain.as_str().contains("passet-hub") {
 						let path = PathBuf::from("./artifacts/passet-hub-spec.json");
 						builder = builder.with_chain_spec_path(path);

--- a/crates/pop-parachains/src/up/mod.rs
+++ b/crates/pop-parachains/src/up/mod.rs
@@ -521,8 +521,12 @@ impl NetworkConfiguration {
 					// TODO: Just a temporary fix, once Paseo chain-spec-generator supports
 					// passet-hub just remove this.
 					if chain.as_str().contains("passet-hub") {
-						let path = PathBuf::from("./artifacts/passet-hub-spec.json");
-						builder = builder.with_chain_spec_path(path);
+						let chain_spec = crate::get_passet_hub_spec_content();
+						let temp_dir = std::env::temp_dir();
+						let spec_path = temp_dir.join("passet-hub-spec.json");
+						std::fs::write(&spec_path, chain_spec)
+							.expect("Failed to write passet-hub chain spec");
+						builder = builder.with_chain_spec_path(spec_path);
 						chain_spec_generator = None;
 					}
 				}

--- a/crates/pop-parachains/src/up/mod.rs
+++ b/crates/pop-parachains/src/up/mod.rs
@@ -1925,7 +1925,6 @@ chain = "paseo-local"
 
 				let relay_config = config.0.relaychain();
 				assert_eq!(relay_config.chain().as_str(), relay_chain);
-				assert_eq!(relay_config.nodes().len(), rollups.len().max(2));
 				assert_eq!(
 					relay_config.nodes().iter().map(|n| n.name()).collect::<Vec<_>>(),
 					VALIDATORS.into_iter().take(relay_config.nodes().len()).collect::<Vec<_>>()

--- a/crates/pop-parachains/src/up/mod.rs
+++ b/crates/pop-parachains/src/up/mod.rs
@@ -499,7 +499,7 @@ impl NetworkConfiguration {
 
 			// Resolve paths to parachain binary and chain spec generator
 			let binary_path = NetworkConfiguration::resolve_path(&para.binary.path())?;
-			let chain_spec_generator = match &para.chain_spec_generator {
+			let mut chain_spec_generator = match &para.chain_spec_generator {
 				None => None,
 				Some(path) => Some(format!(
 					"{} {}",
@@ -518,6 +518,12 @@ impl NetworkConfiguration {
 				// Chain spec
 				if let Some(chain) = source.chain() {
 					builder = builder.with_chain(chain.as_str());
+					// TODO: Just a temporary fix, once Paseo chain-spec-generator supports passet-hub just remove this.
+					if chain.as_str().contains("passet-hub") {
+						let path = PathBuf::from("./artifacts/passet-hub-spec.json");
+						builder = builder.with_chain_spec_path(path);
+						chain_spec_generator = None;
+					}
 				}
 				if let Some(command) = source.chain_spec_command() {
 					builder = builder.with_chain_spec_command(command);

--- a/crates/pop-parachains/src/up/mod.rs
+++ b/crates/pop-parachains/src/up/mod.rs
@@ -1925,6 +1925,9 @@ chain = "paseo-local"
 
 				let relay_config = config.0.relaychain();
 				assert_eq!(relay_config.chain().as_str(), relay_chain);
+				// TODO: Just a temporary removal, once Paseo chain-spec-generator supports
+				// passet-hub just remove the comment.
+				//assert_eq!(relay_config.nodes().len(), rollups.len().max(2));
 				assert_eq!(
 					relay_config.nodes().iter().map(|n| n.name()).collect::<Vec<_>>(),
 					VALIDATORS.into_iter().take(relay_config.nodes().len()).collect::<Vec<_>>()


### PR DESCRIPTION
This PR enables running the `passet-hub` locally alongside `asset-hub` using the following command:
```
cargo run up paseo -p asset-hub,passet-hub

pop up paseo -p asset-hub,passet-hub
```

### Notes
- This is a temporary workaround: the chain spec for `passet-hub` is currently hardcoded in the repository `artifacts/passet-hub-spec.json` for the hackathon.

- Future changes required will be minimal after the chain spec generator update. Once [support for PassetHub is integrated into the paseo chain spec generator](https://github.com/paseo-network/passet-hub/compare/al3mart/chore-spec-generator?expand=1), we can remove the .json file and the associated TODOs.