### PR TITLE
chore: release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.9.0] - 2025-07-16
+## [0.9.0] - 2025-08-01
 
 ### 🚀 Features
 
 - *(up)* Add support for launching networks without network config files (#523)
 - *(bench/pallet)* Support benchmarking multiple pallets (#547)
 - Launch passet hub locally (#570)
+- Add interactive mode to 'pop new' command (#578)
 
 ### 🐛 Fixes
 
 - *(ci)* Address failing unit tests and cargo-deny issues (#548)
 - *(dockerfile)* Could not launch local network (#546)
+- *(contracts)* Update branch for contract template retrieval (#577)
 
 ### 🚜 Refactor
 
 - *(common/api)* Use async-aware mutex (#541)
+- Change `parachain` to `chain` for consistency (#564)
 
 ### 🧪 Testing
 
@@ -28,6 +31,7 @@ All notable changes to this project will be documented in this file.
 
 - Optimize polkavm contract jobs (#540)
 - Bump version
+- Update CHANGELOG
 
 ### Build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.0] - 2025-07-16
+
+### 🚀 Features
+
+- *(up)* Add support for launching networks without network config files (#523)
+- *(bench/pallet)* Support benchmarking multiple pallets (#547)
+- Launch passet hub locally (#570)
+
+### 🐛 Fixes
+
+- *(ci)* Address failing unit tests and cargo-deny issues (#548)
+- *(dockerfile)* Could not launch local network (#546)
+
+### 🚜 Refactor
+
+- *(common/api)* Use async-aware mutex (#541)
+
+### 🧪 Testing
+
+- *(parachains/bench)* Fix expected error in load_pallet_extrinsics test (#539)
+- *(cli/try-runtime)* Update pallets in try-state test after runtime upgrade (#543)
+
+### ⚙️ Miscellaneous Tasks
+
+- Optimize polkavm contract jobs (#540)
+- Bump version
+
+### Build
+
+- *(deps)* Consolidate sp-weights dependency (#538)
+
 ## [0.8.1] - 2025-05-13
 
 ### 🐛 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8887,7 +8887,7 @@ dependencies = [
 
 [[package]]
 name = "pop-cli"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8927,7 +8927,7 @@ dependencies = [
 
 [[package]]
 name = "pop-common"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8961,7 +8961,7 @@ dependencies = [
 
 [[package]]
 name = "pop-contracts"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "contract-build 5.0.3",
@@ -8993,7 +8993,7 @@ dependencies = [
 
 [[package]]
 name = "pop-telemetry"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "dirs",
  "env_logger 0.11.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ documentation = "https://learn.onpop.io/"
 license = "GPL-3.0"
 repository = "https://github.com/r0gue-io/pop-cli"
 rust-version = "1.81.0"
-version = "0.8.1"
+version = "0.9.0"
 
 [workspace.dependencies]
 anyhow = { version = "1.0", default-features = false }

--- a/crates/pop-chains/Cargo.toml
+++ b/crates/pop-chains/Cargo.toml
@@ -51,7 +51,7 @@ sc-cli.workspace = true
 sp-version.workspace = true
 
 # Pop
-pop-common = { path = "../pop-common", version = "0.8.1" }
+pop-common = { path = "../pop-common", version = "0.9.0" }
 
 [dev-dependencies]
 # Used in doc tests.

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -32,7 +32,7 @@ toml.workspace = true
 url.workspace = true
 
 # contracts
-pop-contracts = { path = "../pop-contracts", version = "0.8.1", default-features = false, optional = true }
+pop-contracts = { path = "../pop-contracts", version = "0.9.0", default-features = false, optional = true }
 sp-core = { workspace = true, optional = true }
 sp-weights = { workspace = true, optional = true }
 
@@ -43,10 +43,10 @@ regex = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 
 # telemetry
-pop-telemetry = { path = "../pop-telemetry", version = "0.8.1", optional = true }
+pop-telemetry = { path = "../pop-telemetry", version = "0.9.0", optional = true }
 
 # common
-pop-common = { path = "../pop-common", version = "0.8.1" }
+pop-common = { path = "../pop-common", version = "0.9.0" }
 
 # wallet-integration
 axum = { workspace = true, optional = true }

--- a/crates/pop-contracts/Cargo.toml
+++ b/crates/pop-contracts/Cargo.toml
@@ -40,7 +40,7 @@ contract-transcode_inkv6 = { workspace = true, optional = true }
 scale-info = { workspace = true }
 
 # pop
-pop-common = { path = "../pop-common", version = "0.8.1" }
+pop-common = { path = "../pop-common", version = "0.9.0" }
 
 [dev-dependencies]
 # Used in doc tests.


### PR DESCRIPTION
- Bump all crate versions to `0.9.0`.
- Updated Changelog file with` git cliff --bump`.

After this PR is merge: Publish crates in crates.io
