### PR TITLE
fix(contracts): update branch for contract template retrieval

### DIFF
--- a/crates/pop-contracts/src/new.rs
+++ b/crates/pop-contracts/src/new.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::{errors::Error, templates::V5_CONTRACTS_BRANCH, utils::canonicalized_path, Contract};
+#[cfg(feature = "v5")]
+use crate::templates::V5_CONTRACTS_BRANCH;
+use crate::{errors::Error, utils::canonicalized_path, Contract};
 use anyhow::Result;
 #[cfg(feature = "v5")]
 use contract_build::new_contract_project;

--- a/crates/pop-contracts/src/templates.rs
+++ b/crates/pop-contracts/src/templates.rs
@@ -5,6 +5,7 @@ pub use pop_common::templates::{Template, Type};
 use strum_macros::{AsRefStr, Display, EnumMessage, EnumProperty, EnumString, VariantArray};
 
 // Branch name for v5 contract templates.
+#[cfg(feature = "v5")]
 pub(crate) const V5_CONTRACTS_BRANCH: &str = "v5.x.x";
 
 /// Supported contract template providers.


### PR DESCRIPTION
In the ink-examples repository, the decision was made to merge the v6 branch into main, making it the default branch https://github.com/use-ink/ink-examples/pull/81 
The v5 contracts have been moved to a dedicated branch.

This PR updates pop-cli accordingly to support that change.