### PR TITLE
Add command to convert from/to Ethereum addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8900,6 +8900,7 @@ dependencies = [
  "duct",
  "env_logger 0.11.7",
  "git2",
+ "hex",
  "mockito",
  "open",
  "os_info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ env_logger = { version = "0.11.7", default-features = false }
 flate2 = "1.0.30"
 git2 = { version = "0.18", default-features = true, features = ["vendored-openssl"] }
 glob = { version = "0.3.1", default-features = false }
+hex = { version = "0.4.3", default-features = false }
 log = { version = "0.4.20", default-features = false }
 mockito = { version = "1.4.0", default-features = false }
 tar = { version = "0.4.40", default-features = false }

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -20,6 +20,7 @@ console.workspace = true
 dirs.workspace = true
 duct.workspace = true
 env_logger.workspace = true
+hex.workspace = true
 os_info.workspace = true
 reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/pop-cli/src/commands/convert.rs
+++ b/crates/pop-cli/src/commands/convert.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-3.0
+
+use self::Command::*;
+use super::*;
+use crate::cli::traits::Cli;
+use anyhow::Result;
+use clap::Args;
+use hex;
+use regex::Regex;
+use sp_core::crypto::{AccountId32, Ss58Codec};
+
+const ETHEREUM_ADDRESS_REGEX: &str = "^0x[0-9a-fA-F]{40}$";
+const EE_BYTE: u8 = 0xEE;
+const DEFAULT_POLKADOT_SS58_PREFIX: u16 = 0;
+
+fn convert_address(address: &str, ss58_prefix: Option<u16>) -> Result<String> {
+    let eth_regex = Regex::new(ETHEREUM_ADDRESS_REGEX)?;
+
+    if eth_regex.is_match(address) {
+        let mut raw_bytes = hex::decode(&address[2..])?;
+        raw_bytes.extend_from_slice(&[EE_BYTE; 12]);
+
+        // Convert H256 to AccountId32 first
+        let account_id = AccountId32::new(raw_bytes[..].try_into()?);
+        let version = ss58_prefix.unwrap_or(DEFAULT_POLKADOT_SS58_PREFIX);
+        let ss58_address = account_id.to_ss58check_with_version(version.into());
+        Ok(ss58_address)
+
+    } else {
+        // Try to decode SS58 address
+        let account_id = AccountId32::from_ss58check(address)?;
+        let bytes: [u8; 32] = account_id.into();
+
+        // Verify last 12 bytes are 0xEE
+        if !bytes[20..].iter().all(|&b| b == EE_BYTE) {
+            return Err(anyhow::anyhow!("Invalid address: last 12 bytes must be 0xEE"));
+        }
+
+        // Take first 20 bytes and format as hex
+        let eth_address = format!("0x{}", hex::encode(&bytes[..20]));
+        Ok(eth_address)
+    }
+}
+
+/// Arguments for utility commands.
+#[derive(Args)]
+#[command(args_conflicts_with_subcommands = true)]
+pub(crate) struct ConvertArgs {
+	/// Entry point subcommand for several utility functionalities.
+	#[command(subcommand)]
+	pub(crate) command: Command,
+}
+
+/// Entrypoint for several utility commands.
+#[derive(Subcommand)]
+pub(crate) enum Command {
+	/// Convert an Ethereum address to a Substrate address and vice versa.
+	#[clap(alias = "a")]
+	Address {
+		#[arg(help = "The Substrate or Ethereum address")]
+		address: String,
+        #[arg(help = "The Substrate prefix")]
+        prefix: Option<u16>,
+	},
+}
+
+impl Command {
+	/// Executes the command.
+	pub(crate) fn execute(&self, cli: &mut impl Cli) -> Result<()> {
+		let output = match self {
+            Command::Address { address, prefix } => convert_address(address.as_str(), *prefix)?
+        };
+        cli.success(&output)?;
+		Ok(())
+	}
+}
+
+impl Display for Command {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		match self {
+            Address { address, .. } => write!(f, "{address}"),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ethereum_address_validation() {
+        // Test valid Ethereum address conversion with different prefixes
+        assert_eq!(convert_address("0x742d35Cc6634C0532925a3b844Bc454e4438f44e", Some(0)).unwrap(), "13dKz82CEiU7fKfhfQ5aLpdbXHApLfJH5Z6y2RTZpRwKiNhX");
+        assert_eq!(convert_address("0x742d35Cc6634C0532925a3b844Bc454e4438f44e", None).unwrap(), "13dKz82CEiU7fKfhfQ5aLpdbXHApLfJH5Z6y2RTZpRwKiNhX");
+        assert_eq!(convert_address("0x742d35Cc6634C0532925a3b844Bc454e4438f44e", Some(42)).unwrap(), "5Eh2qnm8NwCeDnfBhm2aCfoSffBAeMk914NUs8UDGLuoY6qg");
+
+        // Test case sensitivity in Ethereum addresses
+        assert_eq!(convert_address("0x742D35CC6634C0532925A3B844BC454E4438F44E", None).unwrap(), "13dKz82CEiU7fKfhfQ5aLpdbXHApLfJH5Z6y2RTZpRwKiNhX");
+        assert_eq!(convert_address("0x742d35cc6634c0532925a3b844bc454e4438f44e", None).unwrap(), "13dKz82CEiU7fKfhfQ5aLpdbXHApLfJH5Z6y2RTZpRwKiNhX");
+
+        // Test invalid Ethereum addresses
+        assert!(convert_address("742d35Cc6634C0532925a3b844Bc454e4438f44e", None).is_err()); // Missing 0x prefix
+        assert!(convert_address("0xInvalidAddress", None).is_err()); // Invalid characters
+        assert!(convert_address("0x742d35Cc6634C0532925a3b844Bc454e4438f44", None).is_err()); // Too short
+        assert!(convert_address("0x742d35Cc6634C0532925a3b844Bc454e4438f44e1", None).is_err()); // Too long
+        assert!(convert_address("0x742d35Cc6634C0532925a3b844Bc454e4438f44g", None).is_err()); // Invalid hex
+
+        // Test SS58 to ETH conversion with different formats
+        let ss58_default = "13dKz82CEiU7fKfhfQ5aLpdbXHApLfJH5Z6y2RTZpRwKiNhX";
+        let ss58_kusama = "5Eh2qnm8NwCeDnfBhm2aCfoSffBAeMk914NUs8UDGLuoY6qg";
+        assert_eq!(convert_address(ss58_default, None).unwrap(), "0x742d35cc6634c0532925a3b844bc454e4438f44e");
+        assert_eq!(convert_address(ss58_kusama, None).unwrap(), "0x742d35cc6634c0532925a3b844bc454e4438f44e");
+
+        // Test invalid SS58 addresses
+        let invalid_ss58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"; // Not originally from ETH
+        assert!(convert_address(invalid_ss58, None).is_err());
+        assert!(convert_address("invalid_format", None).is_err()); // Completely invalid format
+        assert!(convert_address("5Eh2qnm8NwCeDnfBhm2aCfoSffBAeMk914NUs8UDGLuoY6q", None).is_err()); // Too short
+        assert!(convert_address("5Eh2qnm8NwCeDnfBhm2aCfoSffBAeMk914NUs8UDGLuoY6qgg", None).is_err()); // Too long
+    }
+}

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod build;
 #[cfg(any(feature = "chain", feature = "polkavm-contracts", feature = "wasm-contracts"))]
 pub(crate) mod call;
 pub(crate) mod clean;
+pub(crate) mod convert;
 #[cfg(feature = "hashing")]
 mod hash;
 #[cfg(any(feature = "chain", feature = "polkavm-contracts", feature = "wasm-contracts"))]
@@ -59,6 +60,9 @@ pub(crate) enum Command {
 	/// Remove generated/cached artifacts.
 	#[clap(alias = "C")]
 	Clean(clean::CleanArgs),
+    /// Convert between different formats.
+    #[clap(alias = "cv")]
+    Convert(convert::ConvertArgs),
 }
 
 /// Help message for the build command.
@@ -243,7 +247,11 @@ impl Command {
 					},
 				}
 			},
-		}
+            Command::Convert(args) => {
+                env_logger::init();
+                args.command.execute(&mut Cli).map(|_| Null)
+            },
+        }
 	}
 }
 
@@ -314,7 +322,8 @@ impl Display for Command {
 			Self::Bench(args) => write!(f, "bench {}", args.command),
 			#[cfg(feature = "hashing")]
 			Command::Hash(args) => write!(f, "hash {}", args.command),
-		}
+            Command::Convert(args) => write!(f, "convert {}", args.command)
+        }
 	}
 }
 


### PR DESCRIPTION
Closes #566

This PR address the `convert` command to initially convert fromEthereum address format to Substrate format and viceversa.

However, and merely as a proposal, I think this command should be a gateway to the same (or more!) functionality as the one we can find in the [Substrate js-utilities](https://www.shawntabrizi.com/substrate-js-utilities/).

Also, this `convert` command could be perfectly isolated as a separate feature. Would be fine for me to address that, but firstly it'd be good go have some feedback.

## Usage

```sh
# Convert from Substrate address to Ethereum address:
pop convert address 13dKz82CEiU7fKfhfQ5aLpdbXHApLfJH5Z6y2RTZpRwKiNhX
0x742d35cc6634c0532925a3b844bc454e4438f44e
```

```sh
# Convert from Ethereum address to Substrate address with prefix 0 (Polkadot).
pop convert address 0x742d35Cc6634C0532925a3b844Bc454e4438f44e          
13dKz82CEiU7fKfhfQ5aLpdbXHApLfJH5Z6y2RTZpRwKiNhX
```

```sh
# Convert from Ethereum address to Substrate address with prefix 42 (Generic).
pop convert address 0x742d35Cc6634C0532925a3b844Bc454e4438f44e 42   
5Eh2qnm8NwCeDnfBhm2aCfoSffBAeMk914NUs8UDGLuoY6qg
```