### PR TITLE
Skip redundant question when calling a contract

### DIFF
--- a/crates/pop-cli/src/cli.rs
+++ b/crates/pop-cli/src/cli.rs
@@ -733,7 +733,13 @@ pub(crate) mod tests {
 		}
 
 		fn interact(&mut self) -> Result<T> {
-			Ok(self.items[self.item].clone())
+			let item = self.items.get(self.item).ok_or_else(|| {
+				std::io::Error::new(
+					std::io::ErrorKind::NotFound,
+					format!("Missing item at position {}", self.item),
+				)
+			})?;
+			Ok(item.clone())
 		}
 
 		fn item(mut self, value: T, label: impl Display, hint: impl Display) -> Self {

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -226,6 +226,7 @@ impl CallContractCommand {
 				.default_input("./")
 				.interact()?;
 			project_path = Some(PathBuf::from(input_path));
+			self.path = project_path.clone();
 		}
 		let contract_path = project_path
 			.as_ref()


### PR DESCRIPTION
Closes #561

This PR enhances the contract call command by storing the contract path in subsequent calls to the same contract. 

Since I was on it, I slightly improved the error message in the mocked cli in case a given message, identified by its index, is not found.