### PR TITLE
chore: Improve the hashing command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Generate code coverage
-        run: cargo llvm-cov --workspace --lib --bins --no-default-features --features "default experimental chain telemetry v5 wasm-contracts wallet-integration" --codecov --output-path codecov.json
+        run: cargo llvm-cov --workspace --lib --bins --no-default-features --features "default chain telemetry v5 wasm-contracts wallet-integration" --codecov --output-path codecov.json
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -33,7 +33,7 @@ url.workspace = true
 
 # contracts
 pop-contracts = { path = "../pop-contracts", version = "0.9.0", default-features = false, optional = true }
-sp-core = { workspace = true, optional = true }
+sp-core = { workspace = true }
 
 # parachains
 pop-chains = { path = "../pop-chains", version = "0.9.0", optional = true }
@@ -63,12 +63,10 @@ subxt-signer.workspace = true
 default = ["chain", "telemetry", "wasm-contracts"]
 contract = ["wasm-contracts"]
 contracts = ["polkavm-contracts"]
-experimental = ["hashing"]
-hashing = ["dep:sp-core"]
-chain = ["dep:pop-chains", "dep:git2", "dep:regex", "dep:sp-core", "dep:tracing-subscriber", "wallet-integration"]
+chain = ["dep:pop-chains", "dep:git2", "dep:regex", "dep:tracing-subscriber", "wallet-integration"]
 v6 = []
-polkavm-contracts = ["pop-contracts/v6", "dep:pop-contracts", "dep:sp-core", "wallet-integration"]
+polkavm-contracts = ["pop-contracts/v6", "dep:pop-contracts", "wallet-integration"]
 telemetry = ["dep:pop-telemetry"]
 v5 = []
-wasm-contracts = ["pop-contracts/v5", "dep:pop-contracts", "dep:sp-core", "wallet-integration", "v5"]
+wasm-contracts = ["pop-contracts/v5", "dep:pop-contracts", "wallet-integration", "v5"]
 wallet-integration = ["dep:axum", "dep:open", "dep:tower-http"]

--- a/crates/pop-cli/src/cli.rs
+++ b/crates/pop-cli/src/cli.rs
@@ -37,6 +37,8 @@ pub(crate) mod traits {
 		fn success(&mut self, message: impl Display) -> Result<()>;
 		/// Prints a warning message.
 		fn warning(&mut self, message: impl Display) -> Result<()>;
+		/// Prints a plaikn message.
+		fn plain(&mut self, message: impl Display) -> Result<()>;
 	}
 
 	/// A confirmation prompt.
@@ -165,6 +167,11 @@ impl traits::Cli for Cli {
 		cliclack::log::warning(message)?;
 		#[cfg(not(test))]
 		sleep(Duration::from_secs(1));
+		Ok(())
+	}
+
+	fn plain(&mut self, message: impl Display) -> Result<()> {
+		println!("{message}");
 		Ok(())
 	}
 }
@@ -577,6 +584,11 @@ pub(crate) mod tests {
 		fn warning(&mut self, message: impl Display) -> Result<()> {
 			let message = message.to_string();
 			self.warning_expectations.retain(|x| *x != message);
+			Ok(())
+		}
+
+		fn plain(&mut self, message: impl Display) -> Result<()> {
+			println!("{message}");
 			Ok(())
 		}
 	}

--- a/crates/pop-cli/src/cli.rs
+++ b/crates/pop-cli/src/cli.rs
@@ -37,7 +37,7 @@ pub(crate) mod traits {
 		fn success(&mut self, message: impl Display) -> Result<()>;
 		/// Prints a warning message.
 		fn warning(&mut self, message: impl Display) -> Result<()>;
-		/// Prints a plaikn message.
+		/// Prints a plain message.
 		fn plain(&mut self, message: impl Display) -> Result<()>;
 	}
 
@@ -310,6 +310,7 @@ pub(crate) mod tests {
 			Vec<(String, Option<bool>, bool, Option<Vec<(String, String)>>, usize, Option<bool>)>,
 		success_expectations: Vec<String>,
 		warning_expectations: Vec<String>,
+		plain_expectations: Vec<String>,
 	}
 
 	#[allow(dead_code)]
@@ -396,6 +397,11 @@ pub(crate) mod tests {
 			self
 		}
 
+		pub(crate) fn expect_plain(mut self, message: impl Display) -> Self {
+			self.plain_expectations.push(message.to_string());
+			self
+		}
+
 		pub(crate) fn verify(self) -> anyhow::Result<()> {
 			if !self.confirm_expectation.is_empty() {
 				panic!("`{:?}` confirm expectations not satisfied", self.confirm_expectation)
@@ -447,6 +453,12 @@ pub(crate) mod tests {
 				panic!(
 					"`{}` warning log expectations not satisfied",
 					self.warning_expectations.join(",")
+				)
+			}
+			if !self.plain_expectations.is_empty() {
+				panic!(
+					"`{}` plain log expectations not satisfied",
+					self.plain_expectations.join(",")
 				)
 			}
 			Ok(())
@@ -588,7 +600,8 @@ pub(crate) mod tests {
 		}
 
 		fn plain(&mut self, message: impl Display) -> Result<()> {
-			println!("{message}");
+			let message = message.to_string();
+			self.plain_expectations.retain(|x| *x != message);
 			Ok(())
 		}
 	}

--- a/crates/pop-cli/src/commands/hash.rs
+++ b/crates/pop-cli/src/commands/hash.rs
@@ -74,20 +74,9 @@ pub(crate) enum Command {
 impl Command {
 	/// Executes the command.
 	pub(crate) fn execute(&self, cli: &mut impl Cli) -> Result<()> {
-		let hash = self.hash()?;
-		let additional_info = format!("(Source: {}, Output: {} bytes)", self.data(), hash.len());
-		let output =
-			format!("{} {}", to_hex(&self.hash()?, false), console::style(additional_info).dim());
-		cli.success(&output)?;
-		console::Term::stderr().clear_last_lines(1)?;
+		let output = &to_hex(&self.hash()?, false)[2..];
+		cli.plain(output)?;
 		Ok(())
-	}
-
-	fn data(&self) -> &Data {
-		match self {
-			Blake2 { data, .. } | Keccak { data, .. } | Sha2 { data, .. } | TwoX { data, .. } =>
-				data,
-		}
 	}
 
 	fn hash(&self) -> Result<Vec<u8>> {
@@ -337,21 +326,6 @@ mod tests {
 				format!("{}", command.hash().unwrap_err().root_cause()),
 				format!("unsupported length: {length}")
 			);
-		}
-	}
-
-	#[test]
-	fn data_works() {
-		let data = "test".as_bytes();
-		for data in [File(data.to_vec()), Hex(data.to_vec()), String(data.to_vec())] {
-			for command in [
-				Blake2 { length: Default::default(), data: data.clone(), concat: false },
-				Keccak { length: Default::default(), data: data.clone() },
-				Sha2 { length: Default::default(), data: data.clone() },
-				TwoX { length: Default::default(), data: data.clone(), concat: false },
-			] {
-				assert_eq!(command.data(), &data);
-			}
 		}
 	}
 

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -16,8 +16,7 @@ pub(crate) mod build;
 #[cfg(any(feature = "chain", feature = "polkavm-contracts", feature = "wasm-contracts"))]
 pub(crate) mod call;
 pub(crate) mod clean;
-#[cfg(feature = "hashing")]
-mod hash;
+pub(crate) mod hash;
 #[cfg(any(feature = "chain", feature = "polkavm-contracts", feature = "wasm-contracts"))]
 pub(crate) mod install;
 #[cfg(any(feature = "chain", feature = "polkavm-contracts", feature = "wasm-contracts"))]
@@ -54,7 +53,6 @@ pub(crate) enum Command {
 	Test(test::TestArgs),
 	/// Hash data using a supported hash algorithm.
 	#[clap(alias = "h")]
-	#[cfg(feature = "hashing")]
 	Hash(hash::HashArgs),
 	/// Remove generated/cached artifacts.
 	#[clap(alias = "C")]
@@ -223,7 +221,6 @@ impl Command {
 					.await
 					.map(|(project, feature)| Test { project, feature })
 			},
-			#[cfg(feature = "hashing")]
 			Self::Hash(args) => {
 				env_logger::init();
 				args.command.execute(&mut Cli).map(|_| Null)
@@ -312,7 +309,6 @@ impl Display for Command {
 			Self::Clean(_) => write!(f, "clean"),
 			#[cfg(feature = "chain")]
 			Self::Bench(args) => write!(f, "bench {}", args.command),
-			#[cfg(feature = "hashing")]
 			Command::Hash(args) => write!(f, "hash {}", args.command),
 		}
 	}
@@ -426,7 +422,6 @@ mod tests {
 		}
 	}
 
-	#[cfg(feature = "hashing")]
 	#[test]
 	fn hash_command_display_works() {
 		use hash::{Command::*, Data, HashArgs};


### PR DESCRIPTION
This PR:

- Removes the `experimental` and `hashing` features.
- Uses plain output in the hashing command.
- Removes the leading `0x` from the output.

### Example

<img width="648" height="73" alt="Screenshot 2025-09-01 at 13 50 18" src="https://github.com/user-attachments/assets/d0c4e0e1-1164-439a-ad48-afbdaf8099f8" />
