### PR TITLE
fix: release binary build doesn't generate all binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: binaries
+          name: binaries-${{ strategy.job-index }}
           path: ${{ env.path }}/${{ env.package }}
 
       - name: Add binary to release


### PR DESCRIPTION
Closes https://github.com/r0gue-io/pop-cli/issues/600  
We found an issue in the CI when generating the binaries:
```
Failed to CreateArtifact: ... (409) Conflict: an artifact with this name already exists on the workflow run.
```
Basically was only able to publish one of the binaries due to a conflict with the naming: https://github.com/r0gue-io/pop-cli/releases/tag/v0.8.1

This is a known issue in the GitHub Action `actions/upload-artifact@v4` https://github.com/actions/upload-artifact/issues/480. The suggested workaround https://github.com/actions/upload-artifact/issues/480#issuecomment-2863501922 is to add an index to the artifact name using `${{ strategy.job-index }}`

I tested this fix in my fork, and the binaries were successfully generated:
- CI run: https://github.com/AlexD10S/pop-cli/actions/runs/17406965249 
- Release binaries https://github.com/AlexD10S/pop-cli/releases/tag/v0.9.0