### PR TITLE
feat(cli): clearly highlight writing operations when calling smart contracts

### DIFF
--- a/crates/pop-cli/src/cli.rs
+++ b/crates/pop-cli/src/cli.rs
@@ -771,7 +771,7 @@ pub(crate) mod tests {
 			// Check expectations
 			if let Some(items) = self.items_expectation.as_mut() {
 				let item = (label.to_string(), hint.to_string());
-				assert!(items.contains(&item), "`{item:?}` item does not satisfy any expectations");
+				assert!(items.contains(&item), "`{item:?}` item does not satisfy any expectations.\nAvailable expectations:\n{items:#?}");
 				items.retain(|x| *x != item);
 			}
 			// Collect if specified

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -621,9 +621,9 @@ mod tests {
 		)?;
 
 		let items = vec![
-			("flip\n".into(), " A message that can be called on instantiated contracts.  This one flips the value of the stored `bool` from `true`  to `false` and vice versa.".into()),
+            ("📝 flip\n".into(), "[MUTATES] A message that can be called on instantiated contracts.  This one flips the value of the stored `bool` from `true`  to `false` and vice versa.".into()),
 			("get\n".into(), " Simply returns the current value of our `bool`.".into()),
-			("specific_flip\n".into(), " A message for testing, flips the value of the stored `bool` with `new_value`  and is payable".into())
+            ("📝 specific_flip\n".into(), "[MUTATES] A message for testing, flips the value of the stored `bool` with `new_value`  and is payable".into())
 		];
 		// The inputs are processed in reverse order.
 		let mut cli = MockCli::new()

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -700,9 +700,9 @@ mod tests {
 		)?;
 
 		let items = vec![
-			("flip\n".into(), " A message that can be called on instantiated contracts.  This one flips the value of the stored `bool` from `true`  to `false` and vice versa.".into()),
+            ("📝 flip\n".into(), "[MUTATES] A message that can be called on instantiated contracts.  This one flips the value of the stored `bool` from `true`  to `false` and vice versa.".into()),
 			("get\n".into(), " Simply returns the current value of our `bool`.".into()),
-			("specific_flip\n".into(), " A message for testing, flips the value of the stored `bool` with `new_value`  and is payable".into())
+            ("📝 specific_flip\n".into(), "[MUTATES] A message for testing, flips the value of the stored `bool` with `new_value`  and is payable".into())
 		];
 		// The inputs are processed in reverse order.
 		let mut cli = MockCli::new()

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -785,9 +785,9 @@ mod tests {
 		)?;
 
 		let items = vec![
-			("flip\n".into(), " A message that can be called on instantiated contracts.  This one flips the value of the stored `bool` from `true`  to `false` and vice versa.".into()),
+            ("📝 flip\n".into(), "[MUTATES] A message that can be called on instantiated contracts.  This one flips the value of the stored `bool` from `true`  to `false` and vice versa.".into()),
 			("get\n".into(), " Simply returns the current value of our `bool`.".into()),
-			("specific_flip\n".into(), " A message for testing, flips the value of the stored `bool` with `new_value`  and is payable".into())
+            ("📝 specific_flip\n".into(), "[MUTATES] A message for testing, flips the value of the stored `bool` with `new_value`  and is payable".into())
 		];
 		// The inputs are processed in reverse order.
 		let mut cli = MockCli::new()

--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -310,10 +310,12 @@ impl CallContractCommand {
 		let message = {
 			let mut prompt = cli.select("Select the message to call:");
 			for select_message in &messages {
+				let (icon, clarification) =
+					if select_message.mutates { ("📝 ", "[MUTATES]") } else { ("", "") };
 				prompt = prompt.item(
 					select_message,
-					format!("{}\n", &select_message.label),
-					&select_message.docs,
+					format!("{}{}\n", icon, &select_message.label),
+					format!("{}{}", clarification, &select_message.docs),
 				);
 			}
 			let message = prompt.interact()?;


### PR DESCRIPTION
Closes #611

This PR showcases those operations in smart contracts that imply sending an extrinsic from those that merely read from the storage.

## Screenshots

<img width="751" height="255" alt="fb46c62a-da17-4618-bebb-65d39bb82877" src="https://github.com/user-attachments/assets/6f6a4a72-db2b-4e61-9928-06c4bee5a815" />
<img width="751" height="255" alt="fb46c62a-da17-4618-bebb-65d39bb82877" src="https://github.com/user-attachments/assets/05abbe9c-513c-44e1-b68b-54d50b97b532" />
