### PR TITLE
fix: process user input for Strings and None values

### DIFF
--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -4,7 +4,7 @@ use crate::{
 	cli::{self, traits::*},
 	common::{
 		builds::get_project_path,
-		contracts::{has_contract_been_built, request_contract_function_args},
+		contracts::{has_contract_been_built, normalize_call_args, request_contract_function_args},
 		prompt::display_message,
 		urls,
 		wallet::{prompt_to_use_wallet, request_signature},
@@ -418,6 +418,7 @@ impl CallContractCommand {
 				return Err(anyhow!("Please specify the contract address."));
 			},
 		};
+		normalize_call_args(&mut self.args, &message_metadata);
 		let call_exec = match set_up_call(CallOpts {
 			path: project_path,
 			contract,

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -4,7 +4,7 @@ use crate::{
 	cli::{traits::Cli as _, Cli},
 	common::{
 		contracts::{
-			check_contracts_node_and_prompt, has_contract_been_built,
+			check_contracts_node_and_prompt, has_contract_been_built, normalize_call_args,
 			request_contract_function_args, terminate_node,
 		},
 		urls,
@@ -328,6 +328,7 @@ impl UpContractCommand {
 		if self.args.is_empty() && !function.args.is_empty() {
 			self.args = request_contract_function_args(&function, &mut Cli)?;
 		}
+		normalize_call_args(&mut self.args, &function);
 		// Otherwise instantiate.
 		let instantiate_exec = match set_up_deployment(self.clone().into()).await {
 			Ok(i) => i,

--- a/crates/pop-cli/src/common/contracts.rs
+++ b/crates/pop-cli/src/common/contracts.rs
@@ -122,7 +122,6 @@ pub fn request_contract_function_args(
 /// * `args` - The mutable list of argument values provided by the user.
 /// * `function` - The contract function containing argument definitions.
 pub(crate) fn normalize_call_args(args: &mut [String], function: &ContractFunction) {
-	println!("{:?}", function.args);
 	for (arg, param) in args.iter_mut().zip(&function.args) {
 		// If "None" return empty string
 		if param.type_name.starts_with("Option<") && arg == "None" {

--- a/crates/pop-cli/src/common/contracts.rs
+++ b/crates/pop-cli/src/common/contracts.rs
@@ -116,6 +116,35 @@ pub fn request_contract_function_args(
 	Ok(user_provided_args)
 }
 
+/// Normalizes contract arguments before execution.
+///
+/// # Arguments
+/// * `args` - The mutable list of argument values provided by the user.
+/// * `function` - The contract function containing argument definitions.
+pub(crate) fn normalize_call_args(args: &mut [String], function: &ContractFunction) {
+	println!("{:?}", function.args);
+	for (arg, param) in args.iter_mut().zip(&function.args) {
+		// If "None" return empty string
+		if param.type_name.starts_with("Option<") && arg == "None" {
+			*arg = "".to_string();
+		}
+		// For `str` params, ensure the value is wrapped in double quotes.
+		else if param.type_name == "str" {
+			*arg = ensure_double_quoted(arg);
+		}
+	}
+}
+
+/// Ensures a string is wrapped in double quotes.
+fn ensure_double_quoted(s: &str) -> String {
+	let trimmed = s.trim();
+	if trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2 {
+		trimmed.to_string()
+	} else {
+		format!("\"{}\"", trimmed)
+	}
+}
+
 #[cfg(feature = "polkavm-contracts")]
 pub(crate) async fn map_account(
 	extrinsic_opts: &ExtrinsicOpts<DefaultConfig, DefaultEnvironment, Keypair>,
@@ -142,7 +171,9 @@ mod tests {
 	use crate::cli::MockCli;
 	use duct::cmd;
 	use pop_common::{find_free_port, set_executable_permission};
-	use pop_contracts::{extract_function, is_chain_alive, run_contracts_node, FunctionType};
+	use pop_contracts::{
+		extract_function, is_chain_alive, run_contracts_node, FunctionType, Param,
+	};
 	use std::{
 		env,
 		fs::{self, File},
@@ -232,5 +263,30 @@ mod tests {
 		assert!(terminate_node(&mut cli, Some((process, log))).is_ok());
 		assert_eq!(is_chain_alive(Url::parse(&format!("ws://localhost:{}", port))?).await?, false);
 		cli.verify()
+	}
+
+	#[test]
+	fn normalize_call_args_works() {
+		let function = ContractFunction {
+			label: "test".to_string(),
+			payable: false,
+			args: vec![
+				Param { label: "test_string".to_string(), type_name: "str".to_string() },
+				Param { label: "test_none".to_string(), type_name: "Option<str>".to_string() },
+			],
+			docs: "test".to_string(),
+			default: false,
+			mutates: false,
+		};
+		let mut args = vec!["test".to_string(), "None".to_string()];
+		normalize_call_args(&mut args, &function);
+		assert_eq!(args, vec!["\"test\"", ""]);
+	}
+
+	#[test]
+	fn ensure_double_quoted_works() {
+		assert_eq!(ensure_double_quoted("hello"), "\"hello\"");
+		assert_eq!(ensure_double_quoted("  hello  "), "\"hello\"");
+		assert_eq!(ensure_double_quoted("\"hello\""), "\"hello\"");
 	}
 }

--- a/crates/pop-contracts/src/lib.rs
+++ b/crates/pop-contracts/src/lib.rs
@@ -34,7 +34,9 @@ pub use up::{
 	submit_signed_payload, upload_contract_signed, upload_smart_contract, ContractInfo, UpOpts,
 };
 pub use utils::{
-	metadata::{extract_function, get_message, get_messages, ContractFunction, FunctionType},
+	metadata::{
+		extract_function, get_message, get_messages, ContractFunction, FunctionType, Param,
+	},
 	parse_hex_bytes,
 };
 // External exports


### PR DESCRIPTION
This PR improves the handling of user-provided arguments for contract calls:

- Strings: User input is automatically normalized to ensure values are wrapped in double quotes (if not already).
Closes https://github.com/r0gue-io/pop-cli/issues/408

- None values: User input "None" is automatically normalized to an empty string ("").
Closes https://github.com/r0gue-io/pop-cli/issues/579