### PR TITLE
feat(cli): do not ask to run with sudo for every call

### DIFF
--- a/crates/pop-cli/src/commands/call/chain.rs
+++ b/crates/pop-cli/src/commands/call/chain.rs
@@ -200,8 +200,8 @@ impl CallChainCommand {
 
 			// If chain has sudo prompt the user to confirm if they want to execute the call via
 			// sudo.
-			if !self.skip_confirm {
-				self.configure_sudo(chain, cli)?;
+			if self.sudo {
+				self.check_sudo(chain, cli)?;
 			}
 
 			let (use_wallet, suri) = self.determine_signing_method(cli)?;
@@ -289,26 +289,20 @@ impl CallChainCommand {
 
 	// Checks if the chain has the Sudo pallet and prompts the user to confirm if they want to
 	// execute the call via `sudo`.
-	fn configure_sudo(&mut self, chain: &Chain, cli: &mut impl Cli) -> Result<()> {
+	fn check_sudo(&mut self, chain: &Chain, cli: &mut impl Cli) -> Result<()> {
 		match find_dispatchable_by_name(&chain.pallets, "Sudo", "sudo") {
-			Ok(_) =>
-				if !self.sudo {
-					self.sudo = cli
-						.confirm(
-							"Would you like to dispatch this function call with `Root` origin?",
-						)
-						.initial_value(false)
-						.interact()?;
-				},
+			Ok(_) => {
+				self.sudo = cli
+					.confirm(
+						"Are you sure you want to dispatch this function call with `Root` origin?",
+					)
+					.initial_value(false)
+					.interact()?;
+				Ok(())
+			},
 			Err(_) =>
-				if self.sudo {
-					cli.warning(
-						"NOTE: sudo is not supported by the chain. Ignoring `--sudo` flag.",
-					)?;
-					self.sudo = false;
-				},
+				Err(anyhow::anyhow!("The sudo pallet is not supported by the chain. Aborting...")),
 		}
-		Ok(())
 	}
 
 	// Resets specific fields to default values for a new call.
@@ -623,8 +617,11 @@ mod tests {
 	async fn guide_user_to_call_chain_works() -> Result<()> {
 		let node = TestNode::spawn().await?;
 		let node_url = node.ws_url();
-		let mut call_config =
-			CallChainCommand { pallet: Some("System".to_string()), ..Default::default() };
+		let mut call_config = CallChainCommand {
+			pallet: Some("System".to_string()),
+			sudo: true,
+			..Default::default()
+		};
 
 		let mut cli = MockCli::new()
 		.expect_input("Which chain would you like to interact with?", node_url.into())
@@ -649,11 +646,11 @@ mod tests {
 				.to_vec(),
 			),
 			5, // "remark" dispatchable function
-			None,
-		)
-		.expect_input("The value for `remark` might be too large to enter. You may enter the path to a file instead.", "0x11".into())
-		.expect_confirm("Would you like to dispatch this function call with `Root` origin?", true)
-		.expect_confirm(USE_WALLET_PROMPT, true);
+            None,
+        )
+            .expect_input("The value for `remark` might be too large to enter. You may enter the path to a file instead.", "0x11".into())
+            .expect_confirm("Are you sure you want to dispatch this function call with `Root` origin?", true)
+            .expect_confirm(USE_WALLET_PROMPT, true);
 
 		let chain = chain::configure(
 			"Which chain would you like to interact with?",

--- a/crates/pop-cli/src/commands/call/chain.rs
+++ b/crates/pop-cli/src/commands/call/chain.rs
@@ -292,12 +292,14 @@ impl CallChainCommand {
 	fn check_sudo(&mut self, chain: &Chain, cli: &mut impl Cli) -> Result<()> {
 		match find_dispatchable_by_name(&chain.pallets, "Sudo", "sudo") {
 			Ok(_) => {
-				self.sudo = cli
-					.confirm(
-						"Are you sure you want to dispatch this function call with `Root` origin?",
-					)
-					.initial_value(false)
-					.interact()?;
+				if !self.skip_confirm {
+					self.sudo = cli
+                        .confirm(
+                            "Are you sure you want to dispatch this function call with `Root` origin?",
+                        )
+                        .initial_value(true)
+                        .interact()?;
+				}
 				Ok(())
 			},
 			Err(_) =>


### PR DESCRIPTION
Closes #610

This PR avoids asking every time to the user wether the call should be run with sudo or not.

Instead, it simply asks the user to confirm its decision if the `--root` flag is specified.

Example:

<img width="834" height="341" alt="Screenshot 2025-09-05 at 17 22 53" src="https://github.com/user-attachments/assets/484d7728-c521-4f05-8178-a1ceadd37281" />

