### PR TITLE
feat(cli): follow logs of contracts node before termination

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ tracing-subscriber = { version = "0.3.19", default-features = false }
 
 # networking
 reqwest = { version = "0.12", default-features = false, features = ["default-tls", "json", "multipart", "stream"] }
-tokio = { version = "1.0", default-features = false, features = ["macros", "process", "rt-multi-thread"] }
+tokio = { version = "1.0", default-features = false, features = ["macros", "process", "rt-multi-thread", "signal"] }
 url = "2.5.4"
 
 # contracts

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -300,8 +300,8 @@ impl UpContractCommand {
 				return Ok(());
 			}
 
-			terminate_node(&mut Cli, process).await?;
 			Cli.outro(COMPLETE)?;
+			terminate_node(&mut Cli, process).await?;
 			return Ok(());
 		}
 
@@ -373,8 +373,8 @@ impl UpContractCommand {
 				contract_info.code_hash,
 			);
 
-			terminate_node(&mut Cli, process).await?;
 			Cli.outro(COMPLETE)?;
+			terminate_node(&mut Cli, process).await?;
 		}
 
 		Ok(())

--- a/crates/pop-cli/src/common/contracts.rs
+++ b/crates/pop-cli/src/common/contracts.rs
@@ -65,7 +65,7 @@ pub async fn terminate_node(
 			.spawn()?
 			.wait()?;
 	} else {
-		cli.warning("You can finish the process by pressing Ctrl+C.")?;
+		cli.warning("You can terminate the process by pressing Ctrl+C.")?;
 		Command::new("tail").args(["-F", &log.path().to_string_lossy()]).spawn()?;
 		tokio::signal::ctrl_c().await?;
 		cli.plain("\n")?;


### PR DESCRIPTION
Closes #555

This PR allows users to follow the logs instead of detaching the contracts node. This way users have access to the logs and can keep interacting with the node.

## Example

<img width="1846" height="860" alt="Screenshot 2025-09-08 at 22 33 03" src="https://github.com/user-attachments/assets/a84a6dc0-a9aa-412e-93ac-fb5191b7cb9f" />

