### PR TITLE
chore: remove cargo deny job from the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,21 +95,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  deny:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ runner.os }}
-
-      - name: Run cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check
-          arguments: '--no-default-features'
-
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ cargo nextest run
 > per <https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#getting-a-higher-rate-limit>, a
 > personal access token can be used via the `GITHUB_TOKEN` environment variable.
 
+## Security/advisory checks
+
+We use `cargo-deny` locally to check advisories and licenses.
+
+```bash
+cargo install cargo-deny
+cargo deny check
+
+# Advisories only
+cargo deny check advisories
+# Licenses only
+cargo deny check licenses
+```
+
 ## Acknowledgements
 
 Pop CLI would not be possible without these awesome crates!


### PR DESCRIPTION
Remove the `deny` job from CI: it’s producing frequent  failures due to new upstream advisories on transitive deps, even when none new dependency has been added.

I keep `deny.toml` in the repo for local checks and future re-enablement with a quick explanation on how to use it in the README.