### PR TITLE
Remove build command from readme that doesn't build

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,6 @@ On the [Pop Docs website](https://learn.onpop.io) you will find:
 
 ## Building Pop CLI locally
 
-Build the tool locally with all the features:
-
-```sh
-cargo build --all-features
-```
-
 Build the tool only for Parachain functionality:
 
 ```sh


### PR DESCRIPTION
There are several items with the same name that are build only under certain feature tags. Building with --all-features flag causes build to fail as all items will similar names come into scope.