### PR TITLE
feat(fork): add fork to pop cli

### DIFF
--- a/crates/pop-cli/src/commands/fork/chain.rs
+++ b/crates/pop-cli/src/commands/fork/chain.rs
@@ -1,0 +1,13 @@
+use anyhow::Result;
+use clap::Args;
+
+/// Launch a local fork of live running chains.
+#[derive(Args)]
+#[cfg_attr(test, derive(Default))]
+pub(crate) struct ForkChainCommand {}
+
+impl ForkChainCommand {
+	pub(crate) fn execute(self) -> Result<()> {
+		Ok(())
+	}
+}

--- a/crates/pop-cli/src/commands/fork/contract.rs
+++ b/crates/pop-cli/src/commands/fork/contract.rs
@@ -1,0 +1,13 @@
+use anyhow::Result;
+use clap::Args;
+
+/// Launch a local fork of live-deployed contracts.
+#[derive(Args)]
+#[cfg_attr(test, derive(Default))]
+pub(crate) struct ForkContractCommand {}
+
+impl ForkContractCommand {
+	pub(crate) fn execute(self) -> Result<()> {
+		Ok(())
+	}
+}

--- a/crates/pop-cli/src/commands/fork/mod.rs
+++ b/crates/pop-cli/src/commands/fork/mod.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0
+
+use clap::{Args, Subcommand};
+use std::fmt::{Display, Formatter, Result};
+use url::Url;
+
+#[cfg(feature = "chain")]
+pub(crate) mod chain;
+#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts"))]
+pub(crate) mod contract;
+
+/// Arguments of the fork command.
+#[derive(Args)]
+#[command(args_conflicts_with_subcommands = true)]
+pub(crate) struct ForkArgs {
+	/// Entrypoint of the fork command.
+	#[command(subcommand)]
+	pub(crate) command: Command,
+	/// Websocket endpoint of a node.
+	#[arg(short, long, value_parser)]
+	pub(crate) endpoint: Url,
+}
+
+/// Launch a local fork of a live running chain or contract.
+#[derive(Subcommand)]
+pub(crate) enum Command {
+	/// Create a local fork of live running chains.
+	#[cfg(feature = "chain")]
+	Chain(chain::ForkChainCommand),
+	/// Create a local fork of live contracts.
+	#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts"))]
+	Contract(contract::ForkContractCommand),
+}
+
+impl Display for Command {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		match self {
+			#[cfg(feature = "chain")]
+			Command::Chain(_) => write!(f, "chain"),
+			#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts"))]
+			Command::Contract(_) => write!(f, "contract"),
+		}
+	}
+}

--- a/crates/pop-cli/src/commands/mod.rs
+++ b/crates/pop-cli/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod build;
 pub(crate) mod call;
 pub(crate) mod clean;
 pub(crate) mod convert;
+pub(crate) mod fork;
 pub(crate) mod hash;
 #[cfg(any(feature = "chain", feature = "polkavm-contracts", feature = "wasm-contracts"))]
 pub(crate) mod install;
@@ -61,6 +62,9 @@ pub(crate) enum Command {
 	/// Convert between different formats.
 	#[clap(alias = "cv")]
 	Convert(convert::ConvertArgs),
+	/// Create local forks of live chains or contracts.
+	#[clap(alias = "f")]
+	Fork(fork::ForkArgs),
 }
 
 /// Help message for the build command.
@@ -248,6 +252,15 @@ impl Command {
 				env_logger::init();
 				args.command.execute(&mut Cli).map(|_| Null)
 			},
+			Self::Fork(args) => {
+				env_logger::init();
+				match args.command {
+					#[cfg(feature = "chain")]
+					fork::Command::Chain(cmd) => cmd.execute().map(|_| Null),
+					#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts"))]
+					fork::Command::Contract(cmd) => cmd.execute().map(|_| Null),
+				}
+			},
 		}
 	}
 }
@@ -322,6 +335,7 @@ impl Display for Command {
 			Self::Bench(args) => write!(f, "bench {}", args.command),
 			Command::Hash(args) => write!(f, "hash {}", args.command),
 			Command::Convert(args) => write!(f, "convert {}", args.command),
+			Command::Fork(args) => write!(f, "fork {}", args.command),
 		}
 	}
 }
@@ -428,6 +442,21 @@ mod tests {
 					command: bench::Command::Pallet(Default::default()),
 				}),
 				"bench pallet",
+			),
+			// Fork.
+			(
+				Command::Fork(fork::ForkArgs {
+					command: fork::Command::Chain(Default::default()),
+					endpoint: "localhost:9944".parse().unwrap(),
+				}),
+				"fork chain",
+			),
+			(
+				Command::Fork(fork::ForkArgs {
+					command: fork::Command::Contract(Default::default()),
+					endpoint: "localhost:9944".parse().unwrap(),
+				}),
+				"fork contract",
 			),
 		];
 


### PR DESCRIPTION
Adds `fork` to pop cli.

Initially implemented in two different modules: `chain` and `contract` as it might be valuable in the future.
A priori forking a contract might not seem to provide extra value over forking a whole chain as if the chain is host to certain contracts these are brought with the chain' state.

But there might be space for optimizations such that we only pick certain state from certain contracts addresses explicitly provided by the user.

Although the initial path to implementation is forking live chains, I've gone ahead and include the command structure for now as it was not any extra effort.