### PR TITLE
chore: release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.0] - 2025-10-01
+
+### 🚀 Features
+
+- Allow to run a network by specifying its configuration (#594)
+- Autoremove the network's base directory upon tearing down (#591)
+- Add command to convert from/to Ethereum addresses (#592)
+- *(cli)* Autodetect target when invoking pop call without subcommand (#609)
+- *(cli)* Clearly highlight writing operations when calling smart contracts (#614)
+- *(cli)* Do not ask to run with sudo for every call (#620)
+- *(cli)* Follow logs of contracts node before termination (#622)
+- *(cli)* Keep making calls to contract after deployment (#629)
+
+### 🐛 Fixes
+
+- Skip redundant question when calling a contract (#593)
+- Release binary build doesn't generate all binaries (#605)
+- *(cli)* Use plain output in address conversion (#608)
+- Process user input for Strings and None values (#618)
+- All clippy warnings (#625)
+- *(ci)* Do not build docker image if exists (#638)
+
+### 🚜 Refactor
+
+- Clean up and speed up test suite with `nextest` (#582)
+- All commands to use the CLI module (#631)
+
+### 📚 Documentation
+
+- Remove build command from readme that doesn't build (#637)
+
+### 🧪 Testing
+
+- Move some tests to integration tests (#649)
+
+### ⚙ Miscellaneous Tasks
+
+- Remove sp-weights from the list of dependencies (#599)
+- Improve the hashing command (#603)
+- Include map account as one of the quick actions in pop call (#569)
+- Remove cargo deny from the CI (#627)
+- Deprecate pop_evm and parity substrate-contracts-node template (#628)
+- Several improvements (#648)
+- `pop build spec` improvements (#640)
+- Update packages to be installed (#644)
+
 ## [0.9.0] - 2025-08-01
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8838,7 +8838,7 @@ dependencies = [
 
 [[package]]
 name = "pop-chains"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -8880,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "pop-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8918,7 +8918,7 @@ dependencies = [
 
 [[package]]
 name = "pop-common"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8953,7 +8953,7 @@ dependencies = [
 
 [[package]]
 name = "pop-contracts"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "contract-build 5.0.3",
@@ -8985,7 +8985,7 @@ dependencies = [
 
 [[package]]
 name = "pop-telemetry"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "dirs",
  "env_logger 0.11.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ documentation = "https://learn.onpop.io/"
 license = "GPL-3.0"
 repository = "https://github.com/r0gue-io/pop-cli"
 rust-version = "1.81.0"
-version = "0.9.0"
+version = "0.10.0"
 
 [workspace.dependencies]
 anyhow = { version = "1.0", default-features = false }

--- a/crates/pop-chains/Cargo.toml
+++ b/crates/pop-chains/Cargo.toml
@@ -51,7 +51,7 @@ sc-cli.workspace = true
 sp-version.workspace = true
 
 # Pop
-pop-common = { path = "../pop-common", version = "0.9.0" }
+pop-common = { path = "../pop-common", version = "0.10.0" }
 
 [dev-dependencies]
 # Used in doc tests.

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -36,20 +36,20 @@ toml.workspace = true
 url.workspace = true
 
 # contracts
-pop-contracts = { path = "../pop-contracts", version = "0.9.0", default-features = false, optional = true }
+pop-contracts = { path = "../pop-contracts", version = "0.10.0", default-features = false, optional = true }
 sp-core = { workspace = true }
 
 # parachains
-pop-chains = { path = "../pop-chains", version = "0.9.0", optional = true }
+pop-chains = { path = "../pop-chains", version = "0.10.0", optional = true }
 git2 = { workspace = true, optional = true }
 regex.workspace = true
 tracing-subscriber = { workspace = true, optional = true }
 
 # telemetry
-pop-telemetry = { path = "../pop-telemetry", version = "0.9.0", optional = true }
+pop-telemetry = { path = "../pop-telemetry", version = "0.10.0", optional = true }
 
 # common
-pop-common = { path = "../pop-common", version = "0.9.0" }
+pop-common = { path = "../pop-common", version = "0.10.0" }
 
 # wallet-integration
 axum = { workspace = true, optional = true }

--- a/crates/pop-contracts/Cargo.toml
+++ b/crates/pop-contracts/Cargo.toml
@@ -40,7 +40,7 @@ contract-transcode_inkv6 = { workspace = true, optional = true }
 scale-info = { workspace = true }
 
 # pop
-pop-common = { path = "../pop-common", version = "0.9.0" }
+pop-common = { path = "../pop-common", version = "0.10.0" }
 
 [dev-dependencies]
 # Used in doc tests.


### PR DESCRIPTION
Ready new release of pop cli, version `0.10.0`.

- [x] Bump all crate versions to `0.10.0`.
- [x] Updated Changelog file with `git cliff --bump`.

After this PR:

- [x] Publish crates in _crates.io_
