### PR TITLE
ci: optimize ci integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           save-if: false
-          shared-key: shared-${{ github.head_ref || github.ref_name }}
+          shared-key: shared-docs-${{ github.head_ref || github.ref_name }}
 
       - name: Check no default features
         run: cargo doc --no-deps
@@ -183,7 +183,7 @@ jobs:
       - name: Run unit tests for polkavm-contracts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cargo nextest run --lib --bins --no-default-features --features "polkavm-contracts, v6" -p pop-cli -p pop-contracts
+        run: cargo nextest run --lib --bins --no-default-features --features "polkavm-contracts, v6" -p pop-cli -p pop-contracts --nocapture --status-level all
 
   documentation-tests:
     needs:
@@ -203,120 +203,3 @@ jobs:
 
       - name: Run doc tests
         run: cargo test --doc
-
-  contract-integration-tests:
-    needs: build
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          default: true
-          target: wasm32-unknown-unknown
-          components: rust-src, clippy
-
-      - name: Rust Cache Linux
-        if: matrix.os == 'ubuntu-latest'
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: false
-          shared-key: shared-${{ github.head_ref || github.ref_name }}
-
-      - name: Rust Cache MacOS
-        if: matrix.os == 'macos-latest'
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-all-crates: true
-          shared-key: shared-${{ github.head_ref || github.ref_name }}-macos
-
-      - name: Install packages (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
-          protoc --version
-
-      - name: Install packages (macOS)
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install protobuf
-          protoc --version
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
-
-      - name: Run integration tests
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cargo nextest run --no-default-features --features "contract,integration-tests" --test contract
-
-  chain-integration-tests:
-    needs: build
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          default: true
-          target: wasm32-unknown-unknown
-          components: rust-src
-
-      - name: Rust Cache Linux
-        if: matrix.os == 'ubuntu-latest'
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: false
-          shared-key: shared-${{ github.head_ref || github.ref_name }}
-
-      - name: Rust Cache MacOS
-        if: matrix.os == 'macos-latest'
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-all-crates: true
-          shared-key: shared-${{ github.head_ref || github.ref_name }}-macos
-
-      - name: Install packages (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
-          protoc --version
-
-      - name: Install packages (macOS)
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install protobuf
-          protoc --version
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
-        with:
-            tool: cargo-nextest
-
-      - name: Run integration tests
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cargo nextest run --no-default-features --features "chain,integration-tests" --test chain --test metadata

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,19 +37,6 @@ jobs:
           sudo apt update
           sudo apt install -y protobuf-compiler
 
-      - name: Free up space on runner
-        shell: bash
-        run: |
-          set -xeuo pipefail
-          sudo rm -rf /usr/local/lib/android &
-          sudo rm -rf /usr/share/dotnet &
-          sudo rm -rf /usr/share/swift &
-          if command -v docker &> /dev/null; then
-            sudo docker image prune -af &
-          fi
-          sudo apt-get clean &
-          wait
-
       - uses: actions/checkout@v4
 
       - name: Rust Cache

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,6 +37,19 @@ jobs:
           sudo apt update
           sudo apt install -y protobuf-compiler
 
+      - name: Free up space on runner
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          sudo rm -rf /usr/local/lib/android &
+          sudo rm -rf /usr/share/dotnet &
+          sudo rm -rf /usr/share/swift &
+          if command -v docker &> /dev/null; then
+            sudo docker image prune -af &
+          fi
+          sudo apt-get clean &
+          wait
+
       - uses: actions/checkout@v4
 
       - name: Rust Cache

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,146 @@
+name: integration tests
+
+permissions:
+  contents: read
+  packages: read
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+env:
+  CARGO_TERM_COLOR: always
+  GITHUB_ACTOR: pop-cli
+  CARGO_INCREMENTAL: 1
+  RUST_BACKTRACE: 1
+  # It is important to always use the same flags. Otherwise, the cache will not work.
+  RUSTFLAGS: "-Dwarnings"
+  RUSTDOCFLAGS: "-Dwarnings"
+
+concurrency:
+  # Cancel any in-progress jobs for the same pull request or branch
+  group: integration-tests-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract-integration-tests:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          default: true
+          target: wasm32-unknown-unknown
+          components: rust-src, clippy
+
+      - name: Rust Cache Linux
+        if: matrix.os == 'ubuntu-latest'
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: false
+          shared-key: shared-linux-contract${{ github.head_ref || github.ref_name }}
+
+      - name: Rust Cache MacOS
+        if: matrix.os == 'macos-latest'
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          shared-key: shared-macos-contract-${{ github.head_ref || github.ref_name }}-macos
+
+      - name: Install packages (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+          protoc --version
+
+      - name: Install packages (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install protobuf
+          protoc --version
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: Run integration tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo nextest run --no-default-features --features "contract,integration-tests" --test contract --nocapture --status-level all
+
+  chain-integration-tests:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          default: true
+          target: wasm32-unknown-unknown
+          components: rust-src
+
+      - name: Rust Cache Linux
+        if: matrix.os == 'ubuntu-latest'
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: false
+          shared-key: shared-linux-chain-${{ github.head_ref || github.ref_name }}
+
+      - name: Rust Cache MacOS
+        if: matrix.os == 'macos-latest'
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          shared-key: shared-macos-chain-${{ github.head_ref || github.ref_name }}-macos
+
+      - name: Install packages (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+          protoc --version
+
+      - name: Install packages (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install protobuf
+          protoc --version
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: Run integration tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cargo nextest run --no-default-features --features "chain,integration-tests" --test chain --test metadata --nocapture --status-level all


### PR DESCRIPTION
This PR:

- Moves integration tests to a separate workflow.
- ~~Does not optimize disk space in the coverage workflow, as it is no longer needed due to the smaller disk consumption.~~ Actually never mind. It is required to optimize 😓 (see the [failing job](https://github.com/r0gue-io/pop-cli/actions/runs/18286064534)).
- Display more output in tests.
- Updates cache names in case builds are performed with different rust flags or OS.