### PR TITLE
feat: always build contracts with pop up

### DIFF
--- a/crates/pop-cli/src/commands/up/mod.rs
+++ b/crates/pop-cli/src/commands/up/mod.rs
@@ -171,6 +171,7 @@ mod tests {
 				dry_run: true,
 				upload_only: true,
 				skip_confirm: false,
+				skip_build: true,
 			},
 			#[cfg(feature = "chain")]
 			rollup: rollup::UpCommand::default(),


### PR DESCRIPTION
Closes #623.

This PR adds a `skip-build` command to `pop up contract`.

- If `false`, it will always rebuild the contract, even if it was already built. This is the default behaviour.
- If `true`, it won't build the contract in advance, UNLESS it wasn't built already. If so, it'll be built, ignoring the `--skip-build` flag.