### PR TITLE
chore(ci): mark coverage status project and patch as informational only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,10 @@ coverage:
       default:
         target: auto
         threshold: 0%
+        informational: true
+    patch:
+      default:
+        informational: true 
 comment:
   layout: " diff, flags, files"
   behavior: default


### PR DESCRIPTION
For the coverage CI mark the project and patch checks as informational instead of showing it red  in the CI.
An example on how it works in this PR: https://github.com/r0gue-io/pop-cli/pull/567 where I merged this change
<img width="830" height="77" alt="Captura de pantalla 2025-10-08 a las 13 56 55" src="https://github.com/user-attachments/assets/7ed7b4cd-459b-4f22-8a93-012e295ff4ea" />
