### PR TITLE
ci: publish on homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,4 +106,6 @@ jobs:
       - name: Update the formula
         run: |
           cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           ./update.sh "${VERSION}"


### PR DESCRIPTION
Closes #668.

This PR adds an extra step in the release workflow to update the version in pop-cli in the [homebrew repository](https://github.com/r0gue-io/homebrew-pop-cli).

The new `HOMEBREW_TAP_TOKEN` secret will have to be configured so that it has read and write permissions into that repository.

You can currently try out the functionality  this way:

```sh
brew install r0gue-io/pop-cli/pop
which pop
pop --version
```