### PR TITLE
feat: upgrade to rust 1.90

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,5 @@
 # Basic
-edition = "2021"
+edition = "2024"
 hard_tabs = true
 max_width = 100
 use_small_heuristics = "Max"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9033,6 +9033,7 @@ dependencies = [
  "cargo_toml",
  "contract-build 5.0.3",
  "contract-extrinsics 5.0.3",
+ "derivative",
  "duct",
  "flate2",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 documentation = "https://learn.onpop.io/"
 license = "GPL-3.0"
 repository = "https://github.com/r0gue-io/pop-cli"
-rust-version = "1.86.0"
+rust-version = "1.90"
 version = "0.10.0"
 
 [workspace.dependencies]
@@ -25,6 +25,7 @@ anyhow = { version = "1.0", default-features = false }
 assert_cmd = { version = "2.0.14", default-features = false }
 bytes = { version = "1.10.1", default-features = false }
 cargo_toml = { version = "0.20.3", default-features = false }
+derivative = { version = "2.2.0", default-features = false }
 dirs = { version = "5.0", default-features = false }
 duct = { version = "0.13", default-features = false }
 env_logger = { version = "0.11.7", default-features = false }

--- a/crates/pop-chains/src/call/metadata/params.rs
+++ b/crates/pop-chains/src/call/metadata/params.rs
@@ -31,10 +31,10 @@ pub struct Param {
 /// * `field`: A parameter of a dispatchable function (as [Field]).
 pub fn field_to_param(metadata: &Metadata, field: &Field<PortableForm>) -> Result<Param, Error> {
 	let registry = metadata.types();
-	if let Some(name) = field.type_name.as_deref() {
-		if name.contains("RuntimeCall") {
-			return Err(Error::FunctionNotSupported);
-		}
+	if let Some(name) = field.type_name.as_deref() &&
+		name.contains("RuntimeCall")
+	{
+		return Err(Error::FunctionNotSupported);
 	}
 	let name = field.name.as_deref().unwrap_or("Unnamed"); //It can be unnamed field
 	type_to_param(name, registry, field.ty.id)

--- a/crates/pop-chains/src/up/mod.rs
+++ b/crates/pop-chains/src/up/mod.rs
@@ -184,11 +184,11 @@ impl Zombienet {
 			}
 
 			// Check if parachain binary source specified as an argument
-			if let Some(parachains) = parachains.as_ref() {
-				if let Some(repo) = parachains.iter().find(|r| command == r.package) {
-					paras.insert(id, Chain::from_repository(id, repo, chain, cache)?);
-					continue 'outer;
-				}
+			if let Some(parachains) = parachains.as_ref() &&
+				let Some(repo) = parachains.iter().find(|r| command == r.package)
+			{
+				paras.insert(id, Chain::from_repository(id, repo, chain, cache)?);
+				continue 'outer;
 			}
 
 			// Check if command references a local binary
@@ -237,12 +237,12 @@ impl Zombienet {
 				relay::from(default_command, version, runtime_version, chain, cache).await?;
 			// Validate any node config is supported
 			for node in relay_chain.nodes() {
-				if let Some(command) = node.command().map(|c| c.as_str()) {
-					if command.to_lowercase() != relay.binary.name() {
-						return Err(Error::UnsupportedCommand(format!(
-							"the relay chain command is unsupported: {command}",
-						)));
-					}
+				if let Some(command) = node.command().map(|c| c.as_str()) &&
+					command.to_lowercase() != relay.binary.name()
+				{
+					return Err(Error::UnsupportedCommand(format!(
+						"the relay chain command is unsupported: {command}",
+					)));
 				}
 			}
 			return Ok(relay);

--- a/crates/pop-chains/src/utils/helpers.rs
+++ b/crates/pop-chains/src/utils/helpers.rs
@@ -79,8 +79,7 @@ pub(crate) fn write_to_file(path: &Path, contents: &str) -> Result<(), Error> {
 			.map_err(Error::RustfmtError)?;
 
 		if !output.status.success() {
-			return Err(Error::RustfmtError(io::Error::new(
-				io::ErrorKind::Other,
+			return Err(Error::RustfmtError(io::Error::other(
 				"rustfmt exited with non-zero status code",
 			)));
 		}

--- a/crates/pop-cli/src/cli.rs
+++ b/crates/pop-cli/src/cli.rs
@@ -192,6 +192,7 @@ impl traits::Confirm for Confirm {
 }
 
 /// A input prompt using cliclack.
+#[allow(dead_code)]
 struct Input(cliclack::Input);
 impl traits::Input for Input {
 	/// Sets the default value for the input.
@@ -252,6 +253,7 @@ impl<T: Clone + Eq> traits::MultiSelect<T> for MultiSelect<T> {
 }
 
 /// A password prompt using cliclack.
+#[allow(dead_code)]
 struct Password(cliclack::Password);
 impl traits::Password for Password {
 	/// Starts the prompt interaction.
@@ -261,6 +263,7 @@ impl traits::Password for Password {
 }
 
 /// A select prompt using cliclack.
+#[allow(dead_code)]
 struct Select<T: Clone + Eq>(cliclack::Select<T>);
 
 impl<T: Clone + Eq> traits::Select<T> for Select<T> {
@@ -659,6 +662,7 @@ pub(crate) mod tests {
 	}
 
 	/// Mock multi-select prompt
+	#[allow(dead_code)]
 	pub(crate) struct MockMultiSelect<T> {
 		required_expectation: Option<bool>,
 		items_expectation: Option<Vec<(String, String)>>,
@@ -717,6 +721,7 @@ pub(crate) mod tests {
 	}
 
 	/// Mock password prompt
+	#[allow(dead_code)]
 	#[derive(Default)]
 	struct MockPassword {
 		prompt: String,
@@ -729,6 +734,7 @@ pub(crate) mod tests {
 	}
 
 	/// Mock select prompt
+	#[allow(dead_code)]
 	pub(crate) struct MockSelect<T> {
 		items_expectation: Option<Vec<(String, String)>>,
 		collect: bool,

--- a/crates/pop-cli/src/commands/bench/block.rs
+++ b/crates/pop-cli/src/commands/bench/block.rs
@@ -78,10 +78,10 @@ impl BenchmarkBlock {
 				!matches!(arg.as_str(), "--show-output" | "--nocapture" | "--ignored")
 			});
 		}
-		if !argument_exists(&arguments, "--profile") {
-			if let Some(ref profile) = self.profile {
-				arguments.push(format!("--profile={}", profile));
-			}
+		if !argument_exists(&arguments, "--profile") &&
+			let Some(ref profile) = self.profile
+		{
+			arguments.push(format!("--profile={}", profile));
 		}
 		args.extend(arguments);
 		args.join(" ")

--- a/crates/pop-cli/src/commands/bench/machine.rs
+++ b/crates/pop-cli/src/commands/bench/machine.rs
@@ -79,10 +79,10 @@ impl BenchmarkMachine {
 				!matches!(arg.as_str(), "--show-output" | "--nocapture" | "--ignored")
 			});
 		}
-		if !argument_exists(&arguments, "--profile") {
-			if let Some(ref profile) = self.profile {
-				arguments.push(format!("--profile={}", profile));
-			}
+		if !argument_exists(&arguments, "--profile") &&
+			let Some(ref profile) = self.profile
+		{
+			arguments.push(format!("--profile={}", profile));
 		}
 		args.extend(arguments);
 		args.join(" ")

--- a/crates/pop-cli/src/commands/bench/overhead.rs
+++ b/crates/pop-cli/src/commands/bench/overhead.rs
@@ -199,10 +199,8 @@ impl BenchmarkOverhead {
 			print_weight_path = print_weight_path && !argument.starts_with("--weight-path");
 		}
 
-		if print_runtime {
-			if let Some(ref runtime) = self.command.params.runtime {
-				arguments.push(format!("--runtime={}", runtime.display()));
-			}
+		if print_runtime && let Some(ref runtime) = self.command.params.runtime {
+			arguments.push(format!("--runtime={}", runtime.display()));
 		}
 		if print_genesis_builder {
 			arguments.push("--genesis-builder=runtime".to_string());
@@ -213,10 +211,8 @@ impl BenchmarkOverhead {
 				self.command.params.genesis_builder_preset
 			));
 		}
-		if print_weight_path {
-			if let Some(ref weight_path) = self.command.params.weight.weight_path {
-				arguments.push(format!("--weight-path={}", weight_path.display()));
-			}
+		if print_weight_path && let Some(ref weight_path) = self.command.params.weight.weight_path {
+			arguments.push(format!("--weight-path={}", weight_path.display()));
 		}
 		arguments
 	}

--- a/crates/pop-cli/src/commands/bench/pallet.rs
+++ b/crates/pop-cli/src/commands/bench/pallet.rs
@@ -309,10 +309,8 @@ impl BenchmarkPallet {
 			},
 			None => true,
 		};
-		if invalid_runtime {
-			if let Err(e) = self.update_runtime_path(cli) {
-				return display_message(&e.to_string(), false, cli);
-			}
+		if invalid_runtime && let Err(e) = self.update_runtime_path(cli) {
+			return display_message(&e.to_string(), false, cli);
 		}
 
 		if self.list {
@@ -348,11 +346,11 @@ impl BenchmarkPallet {
 		}
 
 		// No pallet provided, prompts user to select the pallet fetched from runtime.
-		if self.pallets.is_empty() {
-			if let Err(e) = self.update_pallets(cli, &mut registry).await {
-				return display_message(&e.to_string(), false, cli);
-			};
-		}
+		if self.pallets.is_empty() &&
+			let Err(e) = self.update_pallets(cli, &mut registry).await
+		{
+			return display_message(&e.to_string(), false, cli);
+		};
 		// No extrinsic provided, prompts user to select the extrinsics fetched from runtime.
 		if self.extrinsic.is_none() {
 			self.update_extrinsics(cli, &mut registry).await?;
@@ -594,15 +592,15 @@ impl BenchmarkPallet {
 		if let Some(ref template) = self.template {
 			args.push(format!("--template={}", template.display()));
 		}
-		if self.output_analysis != default_values.output_analysis {
-			if let Some(ref output_analysis) = self.output_analysis {
-				args.push(format!("--output-analysis={}", output_analysis));
-			}
+		if self.output_analysis != default_values.output_analysis &&
+			let Some(ref output_analysis) = self.output_analysis
+		{
+			args.push(format!("--output-analysis={}", output_analysis));
 		}
-		if self.output_pov_analysis != default_values.output_pov_analysis {
-			if let Some(ref output_pov_analysis) = self.output_pov_analysis {
-				args.push(format!("--output-pov-analysis={}", output_pov_analysis));
-			}
+		if self.output_pov_analysis != default_values.output_pov_analysis &&
+			let Some(ref output_pov_analysis) = self.output_pov_analysis
+		{
+			args.push(format!("--output-pov-analysis={}", output_pov_analysis));
 		}
 		if let Some(ref heap_pages) = self.heap_pages {
 			args.push(format!("--heap-pages={}", heap_pages));
@@ -619,14 +617,14 @@ impl BenchmarkPallet {
 		{
 			args.push("--allow-missing-host-functions".to_string());
 		}
-		if self.genesis_builder != default_values.genesis_builder {
-			if let Some(ref genesis_builder) = self.genesis_builder {
-				args.push(format!("--genesis-builder={}", genesis_builder));
-				if genesis_builder == &GenesisBuilderPolicy::Runtime &&
-					self.genesis_builder_preset != default_values.genesis_builder_preset
-				{
-					args.push(format!("--genesis-builder-preset={}", self.genesis_builder_preset));
-				}
+		if self.genesis_builder != default_values.genesis_builder &&
+			let Some(ref genesis_builder) = self.genesis_builder
+		{
+			args.push(format!("--genesis-builder={}", genesis_builder));
+			if genesis_builder == &GenesisBuilderPolicy::Runtime &&
+				self.genesis_builder_preset != default_values.genesis_builder_preset
+			{
+				args.push(format!("--genesis-builder-preset={}", self.genesis_builder_preset));
 			}
 		}
 		args

--- a/crates/pop-cli/src/commands/bench/storage.rs
+++ b/crates/pop-cli/src/commands/bench/storage.rs
@@ -120,10 +120,10 @@ impl BenchmarkStorage {
 				!matches!(arg.as_str(), "--show-output" | "--nocapture" | "--ignored")
 			});
 		}
-		if !argument_exists(&arguments, "--profile") {
-			if let Some(ref profile) = self.profile {
-				arguments.push(format!("--profile={}", profile));
-			}
+		if !argument_exists(&arguments, "--profile") &&
+			let Some(ref profile) = self.profile
+		{
+			arguments.push(format!("--profile={}", profile));
 		}
 		args.extend(arguments);
 		args

--- a/crates/pop-cli/src/commands/build/spec.rs
+++ b/crates/pop-cli/src/commands/build/spec.rs
@@ -763,10 +763,10 @@ fn prepare_output_path(output_path: impl AsRef<Path>) -> anyhow::Result<PathBuf>
 		output_path.push(DEFAULT_SPEC_NAME);
 	} else {
 		// Treat as file.
-		if let Some(parent_dir) = output_path.parent() {
-			if !parent_dir.exists() {
-				create_dir_all(parent_dir)?;
-			}
+		if let Some(parent_dir) = output_path.parent() &&
+			!parent_dir.exists()
+		{
+			create_dir_all(parent_dir)?;
 		}
 	}
 	Ok(output_path)

--- a/crates/pop-cli/src/commands/new/chain.rs
+++ b/crates/pop-cli/src/commands/new/chain.rs
@@ -191,12 +191,13 @@ async fn generate_parachain_from_template(
 	let spinner = cliclack::spinner();
 	spinner.start("Generating parachain...");
 	let tag = instantiate_template_dir(template, &destination_path, tag_version, config)?;
-	if let Err(err) = Git::git_init(&destination_path, "initialized parachain") {
-		if err.class() == git2::ErrorClass::Config && err.code() == git2::ErrorCode::NotFound {
-			cli.outro_cancel(
-				"git signature could not be found. Please configure your git config with your name and email",
-			)?;
-		}
+	if let Err(err) = Git::git_init(&destination_path, "initialized parachain") &&
+		err.class() == git2::ErrorClass::Config &&
+		err.code() == git2::ErrorCode::NotFound
+	{
+		cli.outro_cancel(
+			"git signature could not be found. Please configure your git config with your name and email",
+		)?;
 	}
 	spinner.clear();
 

--- a/crates/pop-cli/src/commands/test/create_snapshot.rs
+++ b/crates/pop-cli/src/commands/test/create_snapshot.rs
@@ -130,10 +130,11 @@ impl TestCreateSnapshotCommand {
 				!matches!(arg.as_str(), "--show-output" | "--nocapture" | "--ignored")
 			});
 		}
-		if let Some(arg) = user_provided_args.last() {
-			if !arg.starts_with("--") && arg.ends_with(".snap") {
-				provided_path = user_provided_args.pop();
-			}
+		if let Some(arg) = user_provided_args.last() &&
+			!arg.starts_with("--") &&
+			arg.ends_with(".snap")
+		{
+			provided_path = user_provided_args.pop();
 		}
 		let collected_args = collect_args(user_provided_args.into_iter());
 		let mut args = vec![];

--- a/crates/pop-cli/src/commands/up/network.rs
+++ b/crates/pop-cli/src/commands/up/network.rs
@@ -94,7 +94,7 @@ impl ConfigFileCommand {
 			None => match self.file.as_deref() {
 				None => {
 					cli.outro_cancel("🚫 A network configuration file must be specified. See `pop up network --help` for usage.".to_string())?;
-					return Ok(())
+					return Ok(());
 				},
 				Some(path) => path,
 			},
@@ -311,7 +311,7 @@ pub(crate) async fn spawn(
 	.await
 	{
 		Ok(n) => n,
-		Err(e) =>
+		Err(e) => {
 			return match e {
 				Error::Config(message) => {
 					cli.outro_cancel(format!("🚫 A configuration error occurred: `{message}`"))?;
@@ -322,7 +322,8 @@ pub(crate) async fn spawn(
 					Ok(())
 				},
 				_ => Err(e.into()),
-			},
+			};
+		},
 	};
 
 	// Source any missing/stale binaries

--- a/crates/pop-cli/src/commands/up/rollup.rs
+++ b/crates/pop-cli/src/commands/up/rollup.rs
@@ -212,19 +212,19 @@ impl UpCommand {
 		if let Some(addr) = &self.proxied_address {
 			return Ok(Some(format!("Id({addr})")));
 		}
-		if let Some(api) = api {
-			if api.provider == DeploymentProvider::PDP {
-				cli.info(format!(
-					"{}The provider {} requires registration via a pure proxy for security and best practices.",
-					format_step_prefix(1, 5, show_deployment_steps),
-					api.provider.name()
-				))?;
-				return Ok(Some(prompt_for_proxy_address(
-					self.skip_registration,
-					relay_chain_url,
-					cli,
-				)?));
-			}
+		if let Some(api) = api &&
+			api.provider == DeploymentProvider::PDP
+		{
+			cli.info(format!(
+				"{}The provider {} requires registration via a pure proxy for security and best practices.",
+				format_step_prefix(1, 5, show_deployment_steps),
+				api.provider.name()
+			))?;
+			return Ok(Some(prompt_for_proxy_address(
+				self.skip_registration,
+				relay_chain_url,
+				cli,
+			)?));
 		}
 		if cli
 			.confirm(

--- a/crates/pop-cli/src/common/binary.rs
+++ b/crates/pop-cli/src/common/binary.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
+#[cfg(any(feature = "chain", test))]
 use duct::cmd;
 #[cfg(any(feature = "chain", test))]
 use std::cmp::Ordering;
@@ -125,9 +126,11 @@ macro_rules! impl_binary_generator {
 }
 
 /// Represents a semantic version (major.minor.patch).
+#[cfg(any(feature = "chain", test))]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct SemanticVersion(pub u8, pub u8, pub u8);
 
+#[cfg(any(feature = "chain", test))]
 impl TryFrom<String> for SemanticVersion {
 	type Error = anyhow::Error;
 	fn try_from(binary: String) -> Result<Self, Self::Error> {

--- a/crates/pop-cli/src/common/builds.rs
+++ b/crates/pop-cli/src/common/builds.rs
@@ -211,7 +211,6 @@ name = "test-workspace"
 			r#"[package]
 name = "runtime"
 version = "0.1.0"
-edition = "2024"
 
 [dependencies]
 "#,

--- a/crates/pop-cli/src/common/mod.rs
+++ b/crates/pop-cli/src/common/mod.rs
@@ -91,6 +91,7 @@ pub enum Template {
 }
 
 /// Supported operating systems.
+#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts", feature = "chain"))]
 #[derive(Debug, PartialEq, Clone, VariantArray)]
 pub enum Os {
 	/// Linux.
@@ -173,6 +174,7 @@ impl Display for Template {
 	}
 }
 
+#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts", feature = "chain"))]
 impl Display for Os {
 	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
 		use Os::*;
@@ -284,6 +286,7 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(any(feature = "polkavm-contracts", feature = "wasm-contracts", feature = "chain"))]
 	fn os_display_works() {
 		for os in Os::VARIANTS {
 			let expected = match os {

--- a/crates/pop-cli/src/common/try_runtime.rs
+++ b/crates/pop-cli/src/common/try_runtime.rs
@@ -367,16 +367,15 @@ impl<'a> ArgumentConstructor<'a> {
 	) {
 		if !self.seen.contains(flag) &&
 			condition_args.iter().all(|a| !self.seen.contains(*a)) &&
-			external_condition
+			external_condition &&
+			let Some(v) = value
 		{
-			if let Some(v) = value {
-				if !v.is_empty() {
-					self.args.push(format_arg(flag, v));
-				} else {
-					self.args.push(flag.to_string());
-				}
-				self.mark_added(flag);
+			if !v.is_empty() {
+				self.args.push(format_arg(flag, v));
+			} else {
+				self.args.push(flag.to_string());
 			}
+			self.mark_added(flag);
 		}
 	}
 
@@ -512,14 +511,15 @@ pub(crate) fn collect_args<A: Iterator<Item = String>>(args: A) -> Vec<String> {
 	let mut format_args = Vec::new();
 	let mut args = args.peekable();
 	while let Some(arg) = args.next() {
-		if (arg.starts_with("--") || arg.starts_with("-")) && !arg.contains("=") {
-			if let Some(value) = args.peek() {
-				if !value.starts_with("--") && !value.starts_with("-") {
-					let next_value = args.next().unwrap();
-					format_args.push(format_arg(arg, next_value));
-					continue;
-				}
-			}
+		if (arg.starts_with("--") || arg.starts_with("-")) &&
+			!arg.contains("=") &&
+			let Some(value) = args.peek() &&
+			!value.starts_with("--") &&
+			!value.starts_with("-")
+		{
+			let next_value = args.next().unwrap();
+			format_args.push(format_arg(arg, next_value));
+			continue;
 		}
 		format_args.push(arg);
 	}

--- a/crates/pop-cli/src/style.rs
+++ b/crates/pop-cli/src/style.rs
@@ -50,7 +50,7 @@ pub(crate) fn format_url(url: &str) -> String {
 /// Formats the step label if steps should be shown.
 #[cfg(feature = "chain")]
 pub(crate) fn format_step_prefix(current: usize, total: usize, show: bool) -> String {
-	show.then(|| format!("[{}/{}]: ", current, total)).unwrap_or_default()
+	if show { format!("[{}/{}]: ", current, total) } else { Default::default() }
 }
 
 #[cfg(test)]

--- a/crates/pop-common/Cargo.toml
+++ b/crates/pop-common/Cargo.toml
@@ -37,6 +37,7 @@ tokio.workspace = true
 toml.workspace = true
 toml_edit.workspace = true
 url.workspace = true
+derivative.workspace = true
 
 [dev-dependencies]
 mockito.workspace = true

--- a/crates/pop-common/src/api.rs
+++ b/crates/pop-common/src/api.rs
@@ -50,7 +50,7 @@ impl ApiClient {
 		#[cfg(test)]
 		// Check if a request for url already cached
 		if let Some(response) = &self.cache.lock().await.get(url.as_str()) {
-			return Ok((*response).clone())
+			return Ok((*response).clone());
 		}
 
 		// Acquire a permit based on the concurrency control
@@ -59,12 +59,12 @@ impl ApiClient {
 		// Check if prior evidence of being rate limited
 		// Note: only applies if multiple attempts within the same process (e.g., tests)
 		let mut rate_limits = self.rate_limits.lock().await;
-		if let Some(0) = rate_limits.remaining {
-			if let Some(reset) = rate_limits.reset {
-				let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
-				if now < reset {
-					return Err(rate_limits.deref().into());
-				}
+		if let Some(0) = rate_limits.remaining &&
+			let Some(reset) = rate_limits.reset
+		{
+			let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
+			if now < reset {
+				return Err(rate_limits.deref().into());
 			}
 		}
 

--- a/crates/pop-common/src/lib.rs
+++ b/crates/pop-common/src/lib.rs
@@ -75,16 +75,18 @@ pub fn target() -> Result<&'static str, Error> {
 	}
 
 	match ARCH {
-		"aarch64" =>
+		"aarch64" => {
 			return match OS {
 				"macos" => Ok("aarch64-apple-darwin"),
 				_ => Ok("aarch64-unknown-linux-gnu"),
-			},
-		"x86_64" | "x86" =>
+			};
+		},
+		"x86_64" | "x86" => {
 			return match OS {
 				"macos" => Ok("x86_64-apple-darwin"),
 				_ => Ok("x86_64-unknown-linux-gnu"),
-			},
+			};
+		},
 		&_ => {},
 	}
 	Err(Error::UnsupportedPlatform { arch: ARCH, os: OS })
@@ -101,10 +103,10 @@ pub fn pop(dir: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Com
 /// Checks if preferred port is available, otherwise returns a random available port.
 pub fn find_free_port(preferred_port: Option<u16>) -> u16 {
 	// Try to bind to preferred port if provided.
-	if let Some(port) = preferred_port {
-		if TcpListener::bind(format!("127.0.0.1:{}", port)).is_ok() {
-			return port;
-		}
+	if let Some(port) = preferred_port &&
+		TcpListener::bind(format!("127.0.0.1:{}", port)).is_ok()
+	{
+		return port;
 	}
 
 	// Else, fallback to a random available port

--- a/crates/pop-common/src/manifest.rs
+++ b/crates/pop-common/src/manifest.rs
@@ -42,12 +42,11 @@ pub fn find_workspace_toml(target_dir: &Path) -> Option<PathBuf> {
 			return None;
 		}
 		let cargo_toml = parent.join("Cargo.toml");
-		if cargo_toml.exists() {
-			if let Ok(contents) = read_to_string(&cargo_toml) {
-				if contents.contains("[workspace]") {
-					return Some(cargo_toml);
-				}
-			}
+		if cargo_toml.exists() &&
+			let Ok(contents) = read_to_string(&cargo_toml) &&
+			contents.contains("[workspace]")
+		{
+			return Some(cargo_toml);
 		}
 		dir = parent;
 	}
@@ -120,10 +119,10 @@ pub fn get_workspace_project_names(project_path: &Path) -> Result<Vec<(String, P
 			let member_manifest_path = entry.join("Cargo.toml");
 			if member_manifest_path.is_file() {
 				// Parse the member's manifest to get its name
-				if let Ok(member_manifest) = from_path(&member_manifest_path) {
-					if let Some(package) = &member_manifest.package {
-						result.push((package.name.clone(), entry));
-					}
+				if let Ok(member_manifest) = from_path(&member_manifest_path) &&
+					let Some(package) = &member_manifest.package
+				{
+					result.push((package.name.clone(), entry));
 				}
 			}
 		}

--- a/crates/pop-common/src/polkadot_sdk.rs
+++ b/crates/pop-common/src/polkadot_sdk.rs
@@ -114,7 +114,7 @@ pub fn parse_version(value: &str) -> Option<Version> {
 ///
 /// # Arguments
 /// * `versions` - The versions to sort.
-pub fn sort_by_latest_semantic_version<T: AsRef<str>>(versions: &mut [T]) -> SortedSlice<T> {
+pub fn sort_by_latest_semantic_version<T: AsRef<str>>(versions: &mut [T]) -> SortedSlice<'_, T> {
 	SortedSlice::by_key(versions, |tag| {
 		parse_version(tag.as_ref())
 			.map(|version| Reverse(Some(version)))
@@ -127,7 +127,7 @@ pub fn sort_by_latest_semantic_version<T: AsRef<str>>(versions: &mut [T]) -> Sor
 ///
 /// # Arguments
 /// * `versions` - The versions to sort.
-pub fn sort_by_latest_stable_version<T: AsRef<str>>(versions: &mut [T]) -> SortedSlice<T> {
+pub fn sort_by_latest_stable_version<T: AsRef<str>>(versions: &mut [T]) -> SortedSlice<'_, T> {
 	SortedSlice::by_key(versions, |tag| {
 		parse_stable_version(tag.as_ref())
 			.map(|version| Reverse(Some(version)))
@@ -140,7 +140,7 @@ pub fn sort_by_latest_stable_version<T: AsRef<str>>(versions: &mut [T]) -> Sorte
 ///
 /// # Arguments
 /// * `versions` - The versions to sort.
-pub fn sort_by_latest_version<T: AsRef<str>>(versions: &mut [T]) -> SortedSlice<T> {
+pub fn sort_by_latest_version<T: AsRef<str>>(versions: &mut [T]) -> SortedSlice<'_, T> {
 	SortedSlice::by_key(versions, |tag| {
 		parse_version(tag.as_ref())
 			.map(|version| Reverse(Some(version)))

--- a/crates/pop-contracts/src/new.rs
+++ b/crates/pop-contracts/src/new.rs
@@ -203,7 +203,6 @@ mod tests {
 				name = "erc20"
 				version = "5.0.0"
 				authors = ["R0GUE"]
-				edition = "2021"
 				publish = false
 			"#
 		)?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.86"
+channel = "1.90"
 components = [
     "cargo",
     "clippy",


### PR DESCRIPTION
Closes #674.

This PR upgrades pop-cli to the latest stable rust release -> 1.90.

Most of the changes are related to formatting or clippy issues.