### PR TITLE
feat: fetch polkadot-omni-node with pop up command

### DIFF
--- a/crates/pop-chains/src/lib.rs
+++ b/crates/pop-chains/src/lib.rs
@@ -20,6 +20,8 @@ mod generator;
 mod new_chain;
 /// Tools for creating new runtime pallets.
 mod new_pallet;
+/// Provides functionality for running runtime-only parachains.
+pub mod omni_node;
 /// A registry of parachains.
 pub mod registry;
 /// Relay chain interaction and management.

--- a/crates/pop-chains/src/omni_node.rs
+++ b/crates/pop-chains/src/omni_node.rs
@@ -1,0 +1,152 @@
+use pop_common::{
+	Error,
+	git::GitHub,
+	polkadot_sdk::sort_by_latest_semantic_version,
+	sourcing::{
+		ArchiveFileSpec, Binary,
+		GitHub::*,
+		Source,
+		filters::prefix,
+		traits::{
+			Source as SourceT,
+			enums::{Source as _, *},
+		},
+	},
+	target,
+};
+use std::path::PathBuf;
+use strum_macros::EnumProperty;
+
+/// CLI enum for managing Polkadot Omni Node binary sources and configuration.
+/// Provides repository information and binary specifications for fetching and managing the node.
+#[derive(Debug, EnumProperty, PartialEq)]
+pub enum PolkadotOmniNodeCli {
+	#[strum(props(
+		Repository = "https://github.com/r0gue-io/polkadot",
+		Binary = "polkadot-omni-node",
+		TagPattern = "polkadot-{version}",
+		Fallback = "stable2506-2"
+	))]
+	/// Polkadot Omni Node binary. Used to bootstrap parachains without node.
+	PolkadotOmniNode,
+}
+
+impl SourceT for PolkadotOmniNodeCli {
+	type Error = Error;
+	/// Creates a Source configuration for fetching the Polkadot Omni Node binary from GitHub.
+	fn source(&self) -> Result<Source, Error> {
+		// Source from GitHub release asset
+		let repo = GitHub::parse(self.repository())?;
+		let binary = self.binary();
+		Ok(Source::GitHub(ReleaseArchive {
+			owner: repo.org,
+			repository: repo.name,
+			tag: None,
+			tag_pattern: self.tag_pattern().map(|t| t.into()),
+			prerelease: false,
+			version_comparator: sort_by_latest_semantic_version,
+			fallback: self.fallback().into(),
+			archive: format!("{binary}-{}.tar.gz", target()?),
+			contents: vec![ArchiveFileSpec::new(binary.into(), Some(binary.into()), true)],
+			latest: None,
+		}))
+	}
+}
+
+/// Generate the source of the `polkadot-omni-node` binary on the remote repository.
+///
+/// # Arguments
+/// * `cache` - The path to the directory where the binary should be cached.
+/// * `version` - An optional version string. If `None`, the latest available version is used.
+pub async fn polkadot_omni_node_generator(
+	cache: PathBuf,
+	version: Option<&str>,
+) -> Result<Binary, Error> {
+	let cli = PolkadotOmniNodeCli::PolkadotOmniNode;
+	let name = cli.binary().to_string();
+	let source = cli
+		.source()?
+		.resolve(&name, version, cache.as_path(), |f| prefix(f, &name))
+		.await
+		.into();
+	let binary = Binary::Source { name, source, cache: cache.to_path_buf() };
+	Ok(binary)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use pop_common::sourcing::TagPattern;
+	use strum::EnumProperty;
+
+	#[test]
+	fn polkadot_omni_node_cli_properties_work() {
+		let cli = PolkadotOmniNodeCli::PolkadotOmniNode;
+
+		// Test enum properties
+		assert_eq!(cli.get_str("Repository"), Some("https://github.com/r0gue-io/polkadot"));
+		assert_eq!(cli.get_str("Binary"), Some("polkadot-omni-node"));
+		assert_eq!(cli.get_str("TagPattern"), Some("polkadot-{version}"));
+		assert_eq!(cli.get_str("Fallback"), Some("stable2506-2"));
+	}
+
+	#[test]
+	fn polkadot_omni_node_cli_source_works() -> anyhow::Result<()> {
+		let cli = PolkadotOmniNodeCli::PolkadotOmniNode;
+		let source = cli.source()?;
+
+		// Verify source is GitHub variant
+		match source {
+			Source::GitHub(ReleaseArchive {
+				owner,
+				repository,
+				tag,
+				tag_pattern,
+				prerelease,
+				fallback,
+				archive,
+				contents,
+				..
+			}) => {
+				assert_eq!(owner, "r0gue-io");
+				assert_eq!(repository, "polkadot");
+				assert_eq!(tag, None);
+				assert_eq!(tag_pattern, Some(TagPattern::new("polkadot-{version}")));
+				assert!(!prerelease);
+				assert_eq!(fallback, "stable2506-2");
+				assert!(archive.starts_with("polkadot-omni-node-"));
+				assert!(archive.ends_with(".tar.gz"));
+				assert_eq!(contents.len(), 1);
+				assert_eq!(contents[0].name, "polkadot-omni-node");
+				assert!(contents[0].required);
+			},
+			_ => panic!("Expected GitHub ReleaseArchive source variant"),
+		}
+
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn polkadot_omni_node_generator_works() -> anyhow::Result<()> {
+		let cache = tempfile::tempdir()?;
+		let binary = polkadot_omni_node_generator(cache.path().to_path_buf(), None).await?;
+
+		match binary {
+			Binary::Source { name, source, cache: cache_path } => {
+				assert_eq!(name, "polkadot-omni-node");
+				assert_eq!(cache_path, cache.path());
+				// Source should be a ResolvedRelease
+				match *source {
+					Source::GitHub(github) =>
+						if let ReleaseArchive { archive, .. } = github {
+							assert!(archive.contains("polkadot-omni-node"));
+						},
+					_ => panic!("Expected GitHub variant"),
+				}
+			},
+			_ => panic!("Expected Binary::Source variant"),
+		}
+
+		Ok(())
+	}
+}

--- a/crates/pop-chains/src/up/mod.rs
+++ b/crates/pop-chains/src/up/mod.rs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0
 
-use crate::{errors::Error, registry::traits::Rollup, up::chain_specs::Runtime};
+use crate::{
+	errors::Error, omni_node::PolkadotOmniNodeCli::PolkadotOmniNode, registry::traits::Rollup,
+	up::chain_specs::Runtime,
+};
 pub use chain_specs::Runtime as Relay;
 use glob::glob;
 use indexmap::IndexMap;
+use pop_common::sourcing::traits::{Source as _, enums::Source as _};
 pub use pop_common::{
 	Profile,
 	git::{GitHub, Repository},
@@ -209,6 +213,12 @@ impl Zombienet {
 				}
 				return Err(Error::MissingBinary(command));
 			}
+
+			if command.starts_with(PolkadotOmniNode.binary()) {
+				paras.insert(id, Chain::from_omni_node(id, cache)?);
+				continue 'outer;
+			}
+
 			return Err(Error::MissingBinary(command));
 		}
 		Ok(paras)
@@ -778,6 +788,19 @@ impl Chain {
 				chain_spec_generator: None,
 			})
 		}
+	}
+
+	fn from_omni_node(id: u32, cache: &Path) -> Result<Chain, Error> {
+		Ok(Chain {
+			id,
+			binary: Binary::Source {
+				name: PolkadotOmniNode.binary().to_string(),
+				source: Box::new(PolkadotOmniNode.source()?),
+				cache: cache.to_path_buf(),
+			},
+			chain: None,
+			chain_spec_generator: None,
+		})
 	}
 }
 

--- a/crates/pop-cli/src/common/bench.rs
+++ b/crates/pop-cli/src/common/bench.rs
@@ -8,7 +8,6 @@ use crate::{
 };
 use cliclack::ProgressBar;
 use pop_chains::omni_bencher_generator;
-use pop_common::sourcing::Binary;
 use std::{
 	self,
 	cmp::Ordering,

--- a/crates/pop-cli/src/common/binary.rs
+++ b/crates/pop-cli/src/common/binary.rs
@@ -116,9 +116,9 @@ macro_rules! impl_binary_generator {
 
 		impl BinaryGenerator for $generator_name {
 			async fn generate(
-				cache_path: PathBuf,
+				cache_path: std::path::PathBuf,
 				version: Option<&str>,
-			) -> Result<Binary, pop_common::Error> {
+			) -> Result<pop_common::sourcing::Binary, pop_common::Error> {
 				$generate_fn(cache_path, version).await
 			}
 		}

--- a/crates/pop-cli/src/common/contracts.rs
+++ b/crates/pop-cli/src/common/contracts.rs
@@ -6,7 +6,7 @@ use crate::{
 	impl_binary_generator,
 };
 use cliclack::ProgressBar;
-use pop_common::{manifest::from_path, sourcing::Binary};
+use pop_common::manifest::from_path;
 use pop_contracts::{ContractFunction, contracts_node_generator};
 use std::{
 	path::{Path, PathBuf},

--- a/crates/pop-cli/src/common/mod.rs
+++ b/crates/pop-cli/src/common/mod.rs
@@ -12,6 +12,7 @@ pub mod chain;
 pub mod contracts;
 #[cfg(any(feature = "chain", feature = "wasm-contracts", feature = "polkavm-contracts"))]
 pub mod helpers;
+/// Contains omni-node utilities.
 #[cfg(feature = "chain")]
 pub mod omni_node;
 /// Contains utilities for interacting with the CLI prompt.

--- a/crates/pop-cli/src/common/omni_node.rs
+++ b/crates/pop-cli/src/common/omni_node.rs
@@ -3,81 +3,11 @@ use crate::{
 	common::binary::{BinaryGenerator, check_and_prompt},
 	impl_binary_generator,
 };
-use pop_common::{
-	Error,
-	git::GitHub,
-	polkadot_sdk::sort_by_latest_semantic_version,
-	sourcing::{
-		ArchiveFileSpec, Binary,
-		GitHub::*,
-		Source,
-		filters::prefix,
-		traits::{
-			Source as SourceT,
-			enums::{Source as _, *},
-		},
-	},
-	target,
-};
+use pop_chains::omni_node::{PolkadotOmniNodeCli, polkadot_omni_node_generator};
+use pop_common::sourcing::traits::enums::Source;
 use std::path::{Path, PathBuf};
-use strum_macros::EnumProperty;
-
-/// CLI enum for managing Polkadot Omni Node binary sources and configuration.
-/// Provides repository information and binary specifications for fetching and managing the node.
-#[derive(Debug, EnumProperty, PartialEq)]
-pub(super) enum PolkadotOmniNodeCli {
-	#[strum(props(
-		Repository = "https://github.com/r0gue-io/polkadot",
-		Binary = "polkadot-omni-node",
-		TagPattern = "polkadot-{version}",
-		Fallback = "stable2506-2"
-	))]
-	PolkadotOmniNode,
-}
-
-impl SourceT for PolkadotOmniNodeCli {
-	type Error = Error;
-	/// Creates a Source configuration for fetching the Polkadot Omni Node binary from GitHub.
-	fn source(&self) -> Result<Source, Error> {
-		// Source from GitHub release asset
-		let repo = GitHub::parse(self.repository())?;
-		let binary = self.binary();
-		Ok(Source::GitHub(ReleaseArchive {
-			owner: repo.org,
-			repository: repo.name,
-			tag: None,
-			tag_pattern: self.tag_pattern().map(|t| t.into()),
-			prerelease: false,
-			version_comparator: sort_by_latest_semantic_version,
-			fallback: self.fallback().into(),
-			archive: format!("{binary}-{}.tar.gz", target()?),
-			contents: vec![ArchiveFileSpec::new(binary.into(), Some(binary.into()), true)],
-			latest: None,
-		}))
-	}
-}
 
 impl_binary_generator!(PolkadotOmniNodeGenerator, polkadot_omni_node_generator);
-
-/// Generate the source of the `polkadot-omni-node` binary on the remote repository.
-///
-/// # Arguments
-/// * `cache` - The path to the directory where the binary should be cached.
-/// * `version` - An optional version string. If `None`, the latest available version is used.
-pub async fn polkadot_omni_node_generator(
-	cache: PathBuf,
-	version: Option<&str>,
-) -> Result<Binary, Error> {
-	let cli = PolkadotOmniNodeCli::PolkadotOmniNode;
-	let name = cli.binary().to_string();
-	let source = cli
-		.source()?
-		.resolve(&name, version, cache.as_path(), |f| prefix(f, &name))
-		.await
-		.into();
-	let binary = Binary::Source { name, source, cache: cache.to_path_buf() };
-	Ok(binary)
-}
 
 /// Sources and manages the polkadot-omni-node binary, handling download and installation if needed.
 ///
@@ -111,79 +41,6 @@ mod tests {
 	use super::*;
 	use crate::cli::MockCli;
 	use cliclack::spinner;
-	use pop_common::sourcing::TagPattern;
-	use strum::EnumProperty;
-
-	#[test]
-	fn polkadot_omni_node_cli_properties_work() {
-		let cli = PolkadotOmniNodeCli::PolkadotOmniNode;
-
-		// Test enum properties
-		assert_eq!(cli.get_str("Repository"), Some("https://github.com/r0gue-io/polkadot"));
-		assert_eq!(cli.get_str("Binary"), Some("polkadot-omni-node"));
-		assert_eq!(cli.get_str("TagPattern"), Some("polkadot-{version}"));
-		assert_eq!(cli.get_str("Fallback"), Some("stable2506-2"));
-	}
-
-	#[test]
-	fn polkadot_omni_node_cli_source_works() -> anyhow::Result<()> {
-		let cli = PolkadotOmniNodeCli::PolkadotOmniNode;
-		let source = cli.source()?;
-
-		// Verify source is GitHub variant
-		match source {
-			Source::GitHub(ReleaseArchive {
-				owner,
-				repository,
-				tag,
-				tag_pattern,
-				prerelease,
-				fallback,
-				archive,
-				contents,
-				..
-			}) => {
-				assert_eq!(owner, "r0gue-io");
-				assert_eq!(repository, "polkadot");
-				assert_eq!(tag, None);
-				assert_eq!(tag_pattern, Some(TagPattern::new("polkadot-{version}")));
-				assert!(!prerelease);
-				assert_eq!(fallback, "stable2506-2");
-				assert!(archive.starts_with("polkadot-omni-node-"));
-				assert!(archive.ends_with(".tar.gz"));
-				assert_eq!(contents.len(), 1);
-				assert_eq!(contents[0].name, "polkadot-omni-node");
-				assert!(contents[0].required);
-			},
-			_ => panic!("Expected GitHub ReleaseArchive source variant"),
-		}
-
-		Ok(())
-	}
-
-	#[tokio::test]
-	async fn polkadot_omni_node_generator_works() -> anyhow::Result<()> {
-		let cache = tempfile::tempdir()?;
-		let binary = polkadot_omni_node_generator(cache.path().to_path_buf(), None).await?;
-
-		match binary {
-			Binary::Source { name, source, cache: cache_path } => {
-				assert_eq!(name, "polkadot-omni-node");
-				assert_eq!(cache_path, cache.path());
-				// Source should be a ResolvedRelease
-				match *source {
-					Source::GitHub(github) =>
-						if let ReleaseArchive { archive, .. } = github {
-							assert!(archive.contains("polkadot-omni-node"));
-						},
-					_ => panic!("Expected GitHub variant"),
-				}
-			},
-			_ => panic!("Expected Binary::Source variant"),
-		}
-
-		Ok(())
-	}
 
 	#[tokio::test]
 	async fn source_polkadot_omni_node_binary_works() -> anyhow::Result<()> {

--- a/crates/pop-cli/src/common/try_runtime.rs
+++ b/crates/pop-cli/src/common/try_runtime.rs
@@ -23,7 +23,7 @@ use pop_chains::{
 	try_runtime::TryStateSelect,
 	try_runtime_generator, try_state_details, try_state_label,
 };
-use pop_common::{Profile, sourcing::Binary};
+use pop_common::Profile;
 use std::{
 	cmp::Ordering,
 	collections::HashSet,


### PR DESCRIPTION
Closes #655

This PR:

- Fetches the `polkadot-omni-node` binary when executing `pop up`.
- Uses the recently fetched binary as the equivalent of a parachain node to run the network.