### PR TITLE
fix: actually use already passed contract message arguments

### DIFF
--- a/crates/pop-cli/src/commands/call/contract.rs
+++ b/crates/pop-cli/src/commands/call/contract.rs
@@ -6,7 +6,7 @@ use crate::{
 		builds::{ensure_project_path, get_project_path},
 		contracts::{
 			has_contract_been_built, map_account, normalize_call_args,
-			request_contract_function_args,
+			request_remaining_contract_function_args,
 		},
 		prompt::display_message,
 		rpc::prompt_to_select_chain_rpc,
@@ -247,7 +247,7 @@ impl CallContractCommand {
 
 	fn configure_message(&mut self, message: &ContractFunction, cli: &mut impl Cli) -> Result<()> {
 		// Resolve message arguments.
-		self.args = request_contract_function_args(message, cli)?;
+		self.args = request_remaining_contract_function_args(message, cli, &self.args)?;
 
 		// Resolve value.
 		if message.payable && self.value == DEFAULT_PAYABLE_VALUE {

--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -9,7 +9,7 @@ use crate::{
 	common::{
 		contracts::{
 			check_ink_node_and_prompt, has_contract_been_built, map_account, normalize_call_args,
-			request_contract_function_args, terminate_nodes,
+			request_remaining_contract_function_args, terminate_nodes,
 		},
 		rpc::prompt_to_select_chain_rpc,
 		urls,
@@ -344,7 +344,7 @@ impl UpContractCommand {
 		let function =
 			extract_function(self.path.clone(), &self.constructor, FunctionType::Constructor)?;
 		if self.args.is_empty() && !function.args.is_empty() {
-			self.args = request_contract_function_args(&function, &mut Cli)?;
+			self.args = request_remaining_contract_function_args(&function, &mut Cli, &self.args)?;
 		}
 		normalize_call_args(&mut self.args, &function);
 		// Otherwise instantiate.

--- a/crates/pop-cli/src/common/contracts.rs
+++ b/crates/pop-cli/src/common/contracts.rs
@@ -108,15 +108,17 @@ pub fn has_contract_been_built(path: &Path) -> bool {
 /// # Arguments
 /// * `function` - The contract function containing argument definitions.
 /// * `cli` - Command line interface implementation for user interaction.
+/// * `current_args` - A vector of strings containing the user-provided argument values.
 ///
 /// # Returns
 /// A vector of strings containing the user-provided argument values.
-pub fn request_contract_function_args(
+pub fn request_remaining_contract_function_args(
 	function: &ContractFunction,
 	cli: &mut impl Cli,
+	current_args: &[String],
 ) -> anyhow::Result<Vec<String>> {
-	let mut user_provided_args = Vec::new();
-	for arg in &function.args {
+	let mut user_provided_args = current_args.to_vec();
+	for arg in function.args.iter().skip(user_provided_args.len()) {
 		let mut input = cli
 			.input(format!("Enter the value for the parameter: {}", arg.label))
 			.placeholder(&format!("Type required: {}", arg.type_name));
@@ -225,7 +227,7 @@ mod tests {
 			"new",
 			FunctionType::Constructor,
 		)?;
-		assert_eq!(request_contract_function_args(&function, &mut cli)?, vec!["true"]);
+		assert_eq!(request_remaining_contract_function_args(&function, &mut cli, &[])?, vec!["true"]);
 		cli.verify()
 	}
 


### PR DESCRIPTION
This PR fixes an issue by which passed arguments when calling a contract were omitted.