### PR TITLE
fix(install): Support more linux flavours based on already supported distros

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -2,14 +2,14 @@ name: pop install
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
     paths:
       - 'rust-toolchain.toml'
       - 'Cargo.lock'
       - '.github/workflows/install.yml'
       - 'crates/pop-cli/src/commands/install/**'
   pull_request:
-    branches: ["main"]
     paths:
       - 'rust-toolchain.toml'
       - 'Cargo.lock'

--- a/crates/pop-cli/src/commands/install/mod.rs
+++ b/crates/pop-cli/src/commands/install/mod.rs
@@ -325,7 +325,13 @@ async fn install_redhat(skip_confirm: bool, cli: &mut impl cli::traits::Cli) -> 
 		)?
 	}
 	cmd("yum", vec!["update", "-y"]).run()?;
-	cmd("yum", vec!["groupinstall", "-y", "Development Tools"]).run()?;
+	// NOTE: in many RedHad distributions we cannot run `yum groupinstall -y "Development Tools"`.
+	// We install here the most important packages from that group.
+	cmd(
+		"yum",
+		vec!["install", "-y", "gcc", "gcc-c++", "make", "cmake", "pkgconf", "pkgconf-pkg-config"],
+	)
+	.run()?;
 	cmd(
 		"yum",
 		vec![


### PR DESCRIPTION
We have been throwing not supported errors on install for linux distros that we might in fact do support, only because the distro has a name X but is based on one of our supported OSs.
Meaning that we could have been using our already supported installation path for the distro the system running pop is based on.

After these changes if the linux OS is not one of: `Arch`, `Debian`, `Redhat` or `Ubuntu`. We will look for one of the following files: `/etc/os-release` or `/usr/lib/os-release` and parse it.

The file includes information about the system. It will include between other fields:
- [`NAME`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html#NAME=)
- [`ID`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html#ID=)
- [`ID_LIKE`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html#ID_LIKE=)

And it is `ID_LIKE` that we will be using to implement the fix. If it contains information, it will give us OS identifiers that we could use to match against the initial list of OSs and run the proper installation.

> A space-separated list of operating system identifiers in the same syntax as the ID= setting. It should list identifiers of operating systems that are closely related to the local operating system in regards to packaging and programming interfaces, for example listing one or more OS identifiers the local OS is a derivative from. An OS should generally only list other OS identifiers it itself is a derivative of, and not any OSes that are derived from it, though symmetric relationships are possible. Build scripts and similar should check this variable if they need to identify the local operating system and the value of ID= is not recognized. Operating systems should be listed in order of how closely the local operating system relates to the listed ones, starting with the closest. This field is optional.

So in a scenario with a system like:

```
NAME="TUXEDO OS"
VERSION="24.04.3 LTS"
ID=tuxedo
ID_LIKE="ubuntu debian"
PRETTY_NAME="TUXEDO OS"
```

we would have normally returned an error prompting the OS is  not compatible. With this fix in place this will install all dependencies just fine.

source: https://www.freedesktop.org/software/systemd/man/latest/os-release.html

