### PR TITLE
fix: display full contract event

### DIFF
--- a/crates/pop-contracts/src/call.rs
+++ b/crates/pop-contracts/src/call.rs
@@ -151,8 +151,11 @@ pub async fn call_smart_contract(
 		.call(Some(gas_limit), storage_deposit_limit)
 		.await
 		.map_err(|error_variant| Error::CallContractError(format!("{:?}", error_variant)))?;
-	let display_events =
-		DisplayEvents::from_events::<DefaultConfig, DefaultEnvironment>(&events, None, &metadata)?;
+	let display_events = DisplayEvents::from_events::<DefaultConfig, DefaultEnvironment>(
+		&events,
+		Some(call_exec.transcoder()),
+		&metadata,
+	)?;
 
 	let output =
 		display_events.display_events::<DefaultEnvironment>(Verbosity::Default, &token_metadata)?;


### PR DESCRIPTION
Closes #763

This PR correctly displays the event emitted by a smart contract.


### Before

<img width="1642" height="920" alt="516336208-2f3aac16-7b19-485e-9e7a-dd87ca05b78b" src="https://github.com/user-attachments/assets/bef781e4-286c-497b-ba77-f6066d73a125" />


### After

<img width="1632" height="570" alt="Screenshot 2025-11-19 at 16 21 11" src="https://github.com/user-attachments/assets/62850a18-38b7-42ae-8535-2a67469659e8" />

