### PR TITLE
fix: bug to deploy contract with salt

### DIFF
--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -508,8 +508,9 @@ impl UpContractCommand {
 			let weight_limit = if self.gas_limit.is_some() && self.proof_size.is_some() {
 				Weight::from_parts(self.gas_limit.unwrap(), self.proof_size.unwrap())
 			} else {
-				// Frontend will do dry run and update call data.
-				Weight::zero()
+				dry_run_gas_estimate_instantiate(&instantiate_exec)
+					.await
+					.unwrap_or_else(|_| Weight::zero())
 			};
 			let call_data = get_instantiate_payload(instantiate_exec, weight_limit).await?;
 			Ok((call_data, hash))


### PR DESCRIPTION
This PR fixes a bug when instantiating contracts with salt. Apparently a dry-run is required to estimate the weight consumed, as the frontend apparently does not do it properly.