### PR TITLE
feat: upgrade psvm to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9514,9 +9514,9 @@ dependencies = [
 
 [[package]]
 name = "psvm"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfdccfd6a3bde5850453b14562c7e9421ac6296067b351f62254224bbb2c25d"
+checksum = "ea243fe51803ab01a17366de6cd8e9eab4f216314b09075ec2212290ca7af53e"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ git2 = { version = "0.18", default-features = true, features = ["vendored-openss
 glob = { version = "0.3.1", default-features = false }
 log = { version = "0.4.20", default-features = false }
 mockito = { version = "1.4.0", default-features = false }
-psvm = { version = "0.3.0", default-features = false }
+psvm = { version = "0.3.1", default-features = false }
 rustilities = "3.0.1"
 tar = { version = "0.4.40", default-features = false }
 tempfile = { version = "3.10", default-features = false }


### PR DESCRIPTION
This PR upgrades `psvm` to 0.3.1, which includes https://github.com/paritytech/psvm/pull/36 to use the `GITHUB_TOKEN` environment variable for querying github API without requiring the `gh` binary present in the system.