### PR TITLE
feat: display ink-node url

### DIFF
--- a/crates/pop-cli/src/commands/up/contract.rs
+++ b/crates/pop-cli/src/commands/up/contract.rs
@@ -573,8 +573,9 @@ pub(crate) async fn start_ink_node(
 	Cli.info(format!(
 		"Local node started successfully:{}",
 		style(format!(
-			"\n{}\n{}",
+			"\n{}\n{}\n{}",
 			style(format!("portal: https://polkadot.js.org/apps/?rpc={}#/explorer", url)).dim(),
+			style(format!("url: {}", url)).dim(),
 			style(format!("logs: tail -f {}", log_ink_node.path().display())).dim(),
 		))
 		.dim()


### PR DESCRIPTION
Closes #799

This PR adds the ink-node url to the output.

<img width="777" height="296" alt="Screenshot 2025-11-26 at 11 16 23" src="https://github.com/user-attachments/assets/0992f2a3-48ab-44c2-8e35-66bf1853470f" />
