### PR TITLE
feat: add configuration for cargo-binstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@
 
 ### Quick Install (Recommended)
 
-**Using cargo-binstall** (fastest - downloads pre-built binaries for Linux/macOS):
+**Using cargo-binstall** (cross-platform - downloads pre-built binaries when available):
 ```shell
 # Install cargo-binstall if you don't have it
 curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
 # Install pop-cli
-cargo binstall pop-cli
+cargo binstall pop-cli --locked
 ```
 
 ### macOS

--- a/crates/pop-cli/Cargo.toml
+++ b/crates/pop-cli/Cargo.toml
@@ -19,7 +19,6 @@ path = "src/main.rs"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/pop-{ target }.tar.gz"
-bin-dir = "{ bin }{ binary-ext }"
 pkg-fmt = "tgz"
 
 [dependencies]


### PR DESCRIPTION
This PR adds the relevant configuration to setup `cargo-binstall`.

You can test it out this way:

```shell
cargo binstall pop-cli --dry-run
```