### PR TITLE
chore(pop-fork): improve metadata handling

### DIFF
--- a/crates/pop-fork/src/error/local.rs
+++ b/crates/pop-fork/src/error/local.rs
@@ -2,7 +2,7 @@
 
 //! Local storage layer error types.
 
-use crate::error::{CacheError, RemoteStorageError};
+use crate::error::{CacheError, RemoteStorageError, RpcClientError};
 use thiserror::Error;
 
 /// Errors that can occur when accessing the local storage layer.
@@ -17,7 +17,13 @@ pub enum LocalStorageError {
 	/// Remote storage error
 	#[error(transparent)]
 	RemoteStorage(#[from] RemoteStorageError),
+	/// RPC client error when fetching metadata from remote
+	#[error("RPC error: {0}")]
+	Rpc(#[from] RpcClientError),
 	/// Lock acquire error
 	#[error("Local storage acquire error: {0}")]
 	Lock(String),
+	/// Metadata not found for the requested block
+	#[error("Metadata not found: {0}")]
+	MetadataNotFound(String),
 }

--- a/crates/pop-fork/src/inherent/parachain.rs
+++ b/crates/pop-fork/src/inherent/parachain.rs
@@ -96,7 +96,7 @@ impl InherentProvider for ParachainInherent {
 	) -> Result<Vec<Vec<u8>>, BlockBuilderError> {
 		// Check if ParachainSystem pallet exists in metadata.
 		// If not, this is a relay chain or standalone chain - gracefully skip.
-		let metadata = parent.metadata();
+		let metadata = parent.metadata().await?;
 
 		if metadata.pallet_by_name(strings::metadata::PALLET_NAME).is_none() {
 			// No ParachainSystem pallet - this is not a parachain runtime

--- a/crates/pop-fork/src/inherent/timestamp.rs
+++ b/crates/pop-fork/src/inherent/timestamp.rs
@@ -192,7 +192,7 @@ impl InherentProvider for TimestampInherent {
 		executor: &RuntimeExecutor,
 	) -> Result<Vec<Vec<u8>>, BlockBuilderError> {
 		// Look up pallet and call indices from metadata
-		let metadata = parent.metadata();
+		let metadata = parent.metadata().await?;
 
 		let pallet = metadata.pallet_by_name(strings::metadata::PALLET_NAME).ok_or_else(|| {
 			BlockBuilderError::InherentProvider {
@@ -225,7 +225,7 @@ impl InherentProvider for TimestampInherent {
 		let slot_duration = Self::get_slot_duration_from_runtime(
 			executor,
 			storage,
-			metadata,
+			&metadata,
 			self.slot_duration_ms,
 		)
 		.await;
@@ -406,7 +406,8 @@ mod tests {
 			let metadata = Metadata::decode(&mut metadata_bytes.as_slice()).ok()?;
 			let cache = StorageCache::in_memory().await.ok()?;
 			let remote = RemoteStorageLayer::new(rpc, cache);
-			let storage = LocalStorageLayer::new(remote, block_number, block_hash);
+			let storage =
+				LocalStorageLayer::new(remote, block_number, block_hash, metadata.clone());
 			let executor = RuntimeExecutor::new(runtime_code, None).ok()?;
 
 			Some(RemoteTestContext { executor, storage, metadata })

--- a/crates/pop-fork/src/strings/builder.rs
+++ b/crates/pop-fork/src/strings/builder.rs
@@ -21,4 +21,10 @@ pub mod runtime_api {
 	/// Called after all extrinsics have been applied.
 	/// Returns the final block header with computed roots.
 	pub const BLOCK_BUILDER_FINALIZE_BLOCK: &str = "BlockBuilder_finalize_block";
+
+	/// Runtime method to retrieve runtime metadata.
+	///
+	/// Called to fetch the metadata of a runtime, typically after a runtime upgrade.
+	/// Returns SCALE-encoded metadata bytes.
+	pub const METADATA_METADATA: &str = "Metadata_metadata";
 }


### PR DESCRIPTION
These changes remove `Metadata` from the `Block` struct and benefits from the already shared `LocalLayer` to maintain a record of what metadata is applicable to which blocks.

It also includes means to check if a code upgrade has happened.

As per the current implementation whether the metadata registry needs to reflect a change of metadata is handled on every block finalization. But maybe this could be improved later on if we see there are benefits from moving this logic somewhere else. 