### PR TITLE
fix(call chain): support composite storage key queries

### DIFF
--- a/crates/pop-cli/src/commands/call/chain.rs
+++ b/crates/pop-cli/src/commands/call/chain.rs
@@ -57,7 +57,7 @@ async fn query_storage_with_tuple_fallback(
 	client: &OnlineClient<SubstrateConfig>,
 	keys: Vec<DynamicValue>,
 ) -> Result<(Vec<DynamicValue>, Option<Value<u32>>), pop_chains::Error> {
-	let mut keys_to_query = flatten_single_tuple_key(&keys).unwrap_or(keys);
+	let mut keys_to_query = keys;
 	let query_result = match storage.query(client, keys_to_query.clone()).await {
 		Err(e) if is_tuple_encoding_error(&e) => {
 			if let Some(flattened) = flatten_single_tuple_key(&keys_to_query) {
@@ -78,7 +78,7 @@ async fn query_all_storage_with_tuple_fallback(
 	client: &OnlineClient<SubstrateConfig>,
 	keys: Vec<DynamicValue>,
 ) -> Result<Vec<(Vec<DynamicValue>, Value<u32>)>, pop_chains::Error> {
-	let mut keys_to_query = flatten_single_tuple_key(&keys).unwrap_or(keys);
+	let mut keys_to_query = keys;
 	match storage.query_all(client, keys_to_query.clone()).await {
 		Err(e) if is_tuple_encoding_error(&e) => {
 			if let Some(flattened) = flatten_single_tuple_key(&keys_to_query) {


### PR DESCRIPTION
## Summary
- fix `pop call chain` storage querying for composite map keys (e.g. `Assets::Account`) by retrying with flattened key components when tuple encoding fails
- keep existing CLI argument normalization behavior, but make storage query execution robust for both:
  - `--args "4242" "0x..."`
  - `--args "(4242,0x...)"`
- add regression coverage for:
  - composite key query via `CallChainCommand::execute`
  - tuple-style composite key query via `CallChainCommand::execute`
  - `query_all` tuple composite path through the new fallback helper

## Root Cause
`CallChainCommand` normalizes composite storage keys into a single tuple argument. For double-map/NMap storage, Subxt expects one key value per hasher, so passing one tuple caused:

`Cannot encode Tuple into type with ID ...`

## Fix
- Added tuple-encoding fallback logic in `crates/pop-cli/src/commands/call/chain.rs`:
  - detect tuple key encoding failure
  - flatten a single tuple key into multiple key values
  - retry `storage.query` / `storage.query_all`
- No behavior change for non-composite or already-valid key encodings.

## Verification
### Targeted tests
- `LC_ALL=C LANG=C cargo test -p pop-cli composite_key -- --nocapture`

### Formatting
- `cargo +nightly fmt --all -- --check`

### Binary build
- `LC_ALL=C LANG=C cargo build -p pop-cli --bin pop`

### Manual E2E (local binary)
- start node:
  - `./target/debug/pop up ink-node --ink-node-port 9955 --eth-rpc-port 8555 --skip-confirm`
- create asset:
  - `./target/debug/pop call chain --url ws://127.0.0.1:9955 --pallet Assets --function create --args "4242" "Id(5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)" "1" --suri //Alice --skip-confirm`
- mint asset:
  - `./target/debug/pop call chain --url ws://127.0.0.1:9955 --pallet Assets --function mint --args "4242" "Id(5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)" "500" --suri //Alice --skip-confirm`
- verify supply:
  - `./target/debug/pop call chain --url ws://127.0.0.1:9955 --pallet Assets --function Asset --args "4242" --skip-confirm`
  - confirmed `supply: 500`
- verify composite key query with split args:
  - `./target/debug/pop call chain --url ws://127.0.0.1:9955 --pallet Assets --function Account --args "4242" "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d" --skip-confirm`
  - confirmed returned `balance: 500`
- verify composite key query with tuple arg:
  - `./target/debug/pop call chain --url ws://127.0.0.1:9955 --pallet Assets --function Account --args "(4242,0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d)" --skip-confirm`
  - confirmed returned `balance: 500`

Closes #962
