### PR TITLE
fix: preserve template network.toml for stable2512+ omni-node templates

### DIFF
--- a/crates/pop-chains/src/new_chain.rs
+++ b/crates/pop-chains/src/new_chain.rs
@@ -14,7 +14,7 @@ use std::{fs, path::Path};
 use walkdir::WalkDir;
 
 // The latest version where we should overwrite the ./network.toml file on.
-const LATEST_NETWORK_TOML_OVERWRITE_VERSION: &str = "polkadot-stable2512";
+const LATEST_NETWORK_TOML_OVERWRITE_VERSION: &str = "polkadot-stable2506";
 
 /// Create a new chain.
 ///


### PR DESCRIPTION
## Summary

- Reverts `LATEST_NETWORK_TOML_OVERWRITE_VERSION` from `"polkadot-stable2512"` back to `"polkadot-stable2506"` so pop-cli stops overwriting the template's own `network.toml` for stable2512+ omni-node templates.
- Commit `fab75f993` accidentally bumped this constant during a bulk version update, causing `pop up ./network.toml` to fail by referencing the non-existent `parachain-template-node` binary instead of `polkadot-omni-node`.

Closes #985

## Test plan

- [x] `cargo nextest run --lib --bins -p pop-chains` — 225 tests pass