### PR TITLE
fix: update cargo-deny config for new advisories and licenses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3281,13 +3281,14 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
  "console 0.15.11",
  "shell-words",
  "tempfile",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -4771,9 +4772,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.18.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
@@ -4786,9 +4787,9 @@ dependencies = [
 
 [[package]]
 name = "git2_credentials"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a297fe29addafaf3c774fdbb8f410e487b819555f067ed94c44c5c2ae15e3702"
+checksum = "8a5ef5b71f0b7c38b9fab78d33a071100a3a3d6f82d80bc8e53ba4b82b6487ed"
 dependencies = [
  "dialoguer",
  "dirs",
@@ -6432,9 +6433,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.16.2+1.7.2"
+version = "0.18.3+1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
 dependencies = [
  "cc",
  "libc",
@@ -10895,7 +10896,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ duct = { version = "0.13", default-features = false }
 env_logger = { version = "0.11.7", default-features = false }
 flate2 = "1.0.30"
 futures = { version = "0.3.30", default-features = false }
-git2 = { version = "0.18", default-features = true, features = ["vendored-openssl"] }
+git2 = { version = "0.20.4", default-features = true, features = ["vendored-openssl"] }
 glob = { version = "0.3.1", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["std"] }
 jsonrpsee = { version = "0.24", default-features = false, features = ["server", "macros"] }
@@ -85,7 +85,7 @@ serde_json = { version = "1.0", default-features = false, features = ["preserve_
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 zombienet-configuration = { version = "0.4.3", default-features = false }
 zombienet-sdk = { version = "0.4.3", default-features = false }
-git2_credentials = "0.13.0"
+git2_credentials = "0.15.0"
 cumulus-client-cli = { version = "0.26.0", default-features = false }
 
 # benchmarking

--- a/deny.toml
+++ b/deny.toml
@@ -4,18 +4,17 @@ all-features = false
 # This section is considered when running `cargo deny check advisories`
 [advisories]
 ignore = [
-    { id = "RUSTSEC-2024-0344", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/214" },
-    { id = "RUSTSEC-2024-0388", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/436" },
-    { id = "RUSTSEC-2024-0384", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/437" },
-    { id = "RUSTSEC-2020-0163", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/438" },
-    { id = "RUSTSEC-2024-0436", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/450" },
-    { id = "RUSTSEC-2025-0012", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/451" },
-    { id = "RUSTSEC-2024-0370", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
-    { id = "RUSTSEC-2022-0061", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
-    { id = "RUSTSEC-2020-0168", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
-    { id = "RUSTSEC-2024-0438", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
-    { id = "RUSTSEC-2023-0091", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
-    { id = "RUSTSEC-2024-0442", reason = "No upgrade available. Tracking the vulnerability: https://github.com/r0gue-io/pop-cli/issues/458" },
+    { id = "RUSTSEC-2024-0388", reason = "No upgrade available. Dependency of contract-extrinsics" },
+    { id = "RUSTSEC-2024-0384", reason = "No upgrade available. Dependency of zombienet-sdk" },
+    { id = "RUSTSEC-2020-0163", reason = "No upgrade available. Dependency of contract-extrinsics" },
+    { id = "RUSTSEC-2024-0436", reason = "No upgrade available. Dependency of contract-build" },
+    { id = "RUSTSEC-2025-0012", reason = "No upgrade available. Dependency of zombienet-sdk" },
+    { id = "RUSTSEC-2024-0370", reason = "No upgrade available. Dependency of polkadot-sdk" },
+    { id = "RUSTSEC-2022-0061", reason = "No upgrade available. Dependency of polkadot-sdk" },
+    { id = "RUSTSEC-2026-0006", reason = "No upgrade available. Dependency of polkadot-sdk" },
+    { id = "RUSTSEC-2025-0118", reason = "No upgrade available. Dependency of polkadot-sdk" },
+    { id = "RUSTSEC-2025-0134", reason = "No upgrade available. Dependency of zombienet-sdk" },
+    { id = "RUSTSEC-2026-0002", reason = "No upgrade available. Dependency of polkadot-sdk" },
 ]
 
 [licenses]
@@ -26,6 +25,7 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "CC0-1.0",
+    "CDLA-Permissive-2.0",
     "ISC",
     "GPL-3.0",
     "GPL-3.0 WITH Classpath-exception-2.0", # For Substrate crates
@@ -43,6 +43,10 @@ confidence-threshold = 0.93
 [[licenses.exceptions]]
 allow = ["OpenSSL"]
 name = "ring"
+
+[[licenses.exceptions]]
+allow = ["OpenSSL"]
+name = "aws-lc-sys"
 
 [[licenses.clarify]]
 crate = "webpki"


### PR DESCRIPTION
## Summary
- Fix `cargo deny check advisories `and `cargo deny check licenses ` that were currently failing
- Also bumps `git2` and `git2_credentials` to resolve the `RUSTSEC-2024-0344` advisory.
- Updates dependency configuration to ensure all current advisories and license checks pass successfully.

**Discussion**
In the ignored vulnerabilities section, replace references to individual GitHub issues with a generic explanatory message. This will allow us to close the remaining open vulnerability tracking issues:  https://github.com/r0gue-io/pop-cli/issues?q=is%3Aissue%20state%3Aopen%20Vulnerability%20dependency

Closes https://github.com/r0gue-io/pop-cli/issues/458 https://github.com/r0gue-io/pop-cli/issues/451 https://github.com/r0gue-io/pop-cli/issues/450 https://github.com/r0gue-io/pop-cli/issues/438 https://github.com/r0gue-io/pop-cli/issues/437 https://github.com/r0gue-io/pop-cli/issues/436 https://github.com/r0gue-io/pop-cli/issues/214